### PR TITLE
Add a method Entity.as_dict().

### DIFF
--- a/icat/entity.py
+++ b/icat/entity.py
@@ -312,6 +312,14 @@ class Entity(object):
             s.append(v)
         return s
 
+    def as_dict(self):
+        """Return a dict with the object's attributes.
+        """
+        d = {}
+        for a in self.InstAttr | self.MetaAttr:
+            d[a] = getattr(self, a)
+        return d
+
 
     def getAttrType(self, attr):
         """Get the type of an attribute.


### PR DESCRIPTION
It may occasionally be convenient to get a mapping with an entity object's attributes.  For instance, one may do nice things like string formatting:
```python
>>> inv
(investigation){
   createId = "simple/root"
   createTime = 2018-02-05 11:30:14+00:00
   id = 3
   modId = "simple/root"
   modTime = 2018-02-05 11:30:14+00:00
   endDate = 2012-08-06 01:10:08+00:00
   name = "12100409-ST"
   startDate = 2012-07-26 15:44:24+00:00
   title = "NiO SC OF1 JUH HHL"
   visitId = "1.1-P"
 }
>>> "%(name)s-%(visitId)s" % inv.as_dict()
'12100409-ST-1.1-P'
```
