### PR TITLE
Add support for the IDS Write API call

### DIFF
--- a/icat/ids.py
+++ b/icat/ids.py
@@ -320,7 +320,15 @@ class IDSClient(object):
         parameters = {"sessionId": self.sessionId}
         selection.fillParams(parameters)
         req = IDSRequest(self.url + "write", parameters, method="POST")
-        self.opener.open(req)
+        # FIXME: the write API method is not yet in IDS.  Update the
+        # minversion argument to _versionMethodError() as soon as this
+        # call has been added to IDS and it is foreseeable which
+        # release version will support it.  Before, it does not make
+        # sense to merge this branch into master anyway.
+        try:
+            self.opener.open(req)
+        except (HTTPError, IDSError) as e:
+            raise self._versionMethodError("write", '42.0', e)
 
     def reset(self, selection):
         """Reset data so that they can be queried again.

--- a/icat/ids.py
+++ b/icat/ids.py
@@ -314,6 +314,14 @@ class IDSClient(object):
         req = IDSRequest(self.url + "restore", parameters, method="POST")
         self.opener.open(req)
 
+    def write(self, selection):
+        """Write data.
+        """
+        parameters = {"sessionId": self.sessionId}
+        selection.fillParams(parameters)
+        req = IDSRequest(self.url + "write", parameters, method="POST")
+        self.opener.open(req)
+
     def reset(self, selection):
         """Reset data so that they can be queried again.
         """

--- a/tests/test_06_ids.py
+++ b/tests/test_06_ids.py
@@ -311,6 +311,29 @@ def test_putData_datafileCreateTime(tmpdirsec, client):
         assert df.datafileCreateTime == createTime
 
 @pytest.mark.parametrize(("case"), markeddatasets)
+def test_write(client, case):
+    """Call write() on a dataset.
+    """
+    # FIXME: the write API method is not yet in IDS.  Update the
+    # version to compare with as soon as this call has been added to
+    # IDS and it is foreseeable which release version will support it.
+    if client.ids.apiversion < '1.7.0':
+        pytest.skip("IDS %s is too old, need 1.7.0 or newer" 
+                    % client.ids.apiversion)
+    if not client.ids.isTwoLevel():
+        pytest.skip("This IDS does not use two levels of data storage")
+    selection = DataSelection([getDataset(client, case)])
+    status = client.ids.getStatus(selection)
+    print("Status of dataset %s is %s" % (case['dsname'], status))
+    if status != "ONLINE":
+        pytest.skip("Dataset %s is not ONLINE" % (case['dsname']))
+    print("Request write of dataset %s" % (case['dsname']))
+    client.ids.write(selection)
+    # Note that there is no effect whatsoever of the write request
+    # visible at the client side.  The only thing that we can test
+    # here is that IDS did accept the call without raising an error.
+
+@pytest.mark.parametrize(("case"), markeddatasets)
 def test_archive(client, case):
     """Call archive() on a dataset.
     """

--- a/tests/test_06_ids.py
+++ b/tests/test_06_ids.py
@@ -309,11 +309,8 @@ def test_putData_datafileCreateTime(tmpdirsec, client):
 def test_write(client, case):
     """Call write() on a dataset.
     """
-    # FIXME: the write API method is not yet in IDS.  Update the
-    # version to compare with as soon as this call has been added to
-    # IDS and it is foreseeable which release version will support it.
-    if client.ids.apiversion < '1.7.0':
-        pytest.skip("IDS %s is too old, need 1.7.0 or newer" 
+    if client.ids.apiversion < '1.9.0':
+        pytest.skip("IDS %s is too old, need 1.9.0 or newer" 
                     % client.ids.apiversion)
     if not client.ids.isTwoLevel():
         pytest.skip("This IDS does not use two levels of data storage")


### PR DESCRIPTION
The IDS Write API call is proposed in icatproject/ids.server#67.  This PR adds support for the call on the client side.  It should be merged as soon as the PR for the Write call is merged & released in ids.server.
