### PR TITLE
Add support for icat.server 4.10

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -3,6 +3,11 @@
 
 * Version 0.15.0 (not yet published)
 
+** New features
+
+ + Add support for ICAT 4.10.0 including schema changes in that
+   version.
+
 ** Bug fixes and minor changes
 
  + Issue #49: Module icat.eval is outdated

--- a/doc/icatdata-4.10.xsd
+++ b/doc/icatdata-4.10.xsd
@@ -1,0 +1,1046 @@
+<?xml version="1.0" encoding="utf-8"?>
+<xsd:schema xmlns:xsd="http://www.w3.org/2001/XMLSchema">
+
+<xsd:annotation>
+  <xsd:documentation>
+    Schema definition for an ICAT data file format.
+    Valid for ICAT 4.10.*.
+  </xsd:documentation>
+</xsd:annotation>
+
+<xsd:element name="icatdata" type="icatdata"/>
+
+<xsd:complexType name="icatdata">
+  <xsd:sequence>
+    <xsd:element name="head" type="head" minOccurs="0"/>
+    <xsd:element name="data" type="data" minOccurs="0" maxOccurs="unbounded"/>
+  </xsd:sequence>
+</xsd:complexType>
+
+<xsd:complexType name="head">
+  <xsd:sequence>
+    <xsd:element name="date" type="xsd:dateTime"/>
+    <xsd:element name="service" type="xsd:anyURI" minOccurs="0"/>
+    <xsd:element name="apiversion" type="xsd:string" minOccurs="0"/>
+    <xsd:element name="generator" type="xsd:string"/>
+  </xsd:sequence>
+</xsd:complexType>
+
+<xsd:complexType name="data">
+  <!-- The data element contains the entity objects.  
+
+       Order is important.  Objects referenced by others in a
+       many-to-one relation MUST come before the referencing object.
+  -->
+  <xsd:sequence>
+    <!-- entity object references -->
+    <xsd:element name="applicationRef" type="applicationRef" 
+		 minOccurs="0" maxOccurs="unbounded"/>
+    <xsd:element name="datafileRef" type="datafileRef" 
+		 minOccurs="0" maxOccurs="unbounded"/>
+    <xsd:element name="datafileFormatRef" type="datafileFormatRef" 
+		 minOccurs="0" maxOccurs="unbounded"/>
+    <xsd:element name="datasetRef" type="datasetRef" 
+		 minOccurs="0" maxOccurs="unbounded"/>
+    <xsd:element name="datasetTypeRef" type="datasetTypeRef" 
+		 minOccurs="0" maxOccurs="unbounded"/>
+    <xsd:element name="facilityRef" type="facilityRef" 
+		 minOccurs="0" maxOccurs="unbounded"/>
+    <xsd:element name="groupingRef" type="groupingRef" 
+		 minOccurs="0" maxOccurs="unbounded"/>
+    <xsd:element name="instrumentRef" type="instrumentRef" 
+		 minOccurs="0" maxOccurs="unbounded"/>
+    <xsd:element name="investigationRef" type="investigationRef" 
+		 minOccurs="0" maxOccurs="unbounded"/>
+    <xsd:element name="investigationTypeRef" type="investigationTypeRef" 
+		 minOccurs="0" maxOccurs="unbounded"/>
+    <xsd:element name="parameterTypeRef" type="parameterTypeRef" 
+		 minOccurs="0" maxOccurs="unbounded"/>
+    <xsd:element name="sampleRef" type="sampleRef" 
+		 minOccurs="0" maxOccurs="unbounded"/>
+    <xsd:element name="sampleTypeRef" type="sampleTypeRef" 
+		 minOccurs="0" maxOccurs="unbounded"/>
+    <xsd:element name="userRef" type="userRef" 
+		 minOccurs="0" maxOccurs="unbounded"/>
+    <!-- entity object definitions -->
+    <!-- authz -->
+    <xsd:element name="user" type="user" 
+		 minOccurs="0" maxOccurs="unbounded"/>
+    <xsd:element name="grouping" type="grouping" 
+		 minOccurs="0" maxOccurs="unbounded"/>
+    <xsd:element name="userGroup" type="userGroup" 
+		 minOccurs="0" maxOccurs="unbounded"/>
+    <xsd:element name="rule" type="rule" 
+		 minOccurs="0" maxOccurs="unbounded"/>
+    <xsd:element name="publicStep" type="publicStep" 
+		 minOccurs="0" maxOccurs="unbounded"/>
+    <!-- static -->
+    <xsd:element name="facility" type="facility" 
+		 minOccurs="0" maxOccurs="unbounded"/>
+    <xsd:element name="instrument" type="instrument" 
+		 minOccurs="0" maxOccurs="unbounded"/>
+    <xsd:element name="instrumentScientist" type="instrumentScientist" 
+		 minOccurs="0" maxOccurs="unbounded"/>
+    <xsd:element name="parameterType" type="parameterType" 
+		 minOccurs="0" maxOccurs="unbounded"/>
+    <xsd:element name="permissibleStringValue" type="permissibleStringValue" 
+		 minOccurs="0" maxOccurs="unbounded"/>
+    <xsd:element name="investigationType" type="investigationType" 
+		 minOccurs="0" maxOccurs="unbounded"/>
+    <xsd:element name="sampleType" type="sampleType" 
+		 minOccurs="0" maxOccurs="unbounded"/>
+    <xsd:element name="datasetType" type="datasetType" 
+		 minOccurs="0" maxOccurs="unbounded"/>
+    <xsd:element name="datafileFormat" type="datafileFormat" 
+		 minOccurs="0" maxOccurs="unbounded"/>
+    <xsd:element name="facilityCycle" type="facilityCycle" 
+		 minOccurs="0" maxOccurs="unbounded"/>
+    <xsd:element name="application" type="application" 
+		 minOccurs="0" maxOccurs="unbounded"/>
+    <!-- investigation -->
+    <xsd:element name="investigation" type="investigation" 
+		 minOccurs="0" maxOccurs="unbounded"/>
+    <xsd:element name="investigationParameter" type="investigationParameter" 
+		 minOccurs="0" maxOccurs="unbounded"/>
+    <xsd:element name="keyword" type="keyword" 
+		 minOccurs="0" maxOccurs="unbounded"/>
+    <xsd:element name="publication" type="publication" 
+		 minOccurs="0" maxOccurs="unbounded"/>
+    <xsd:element name="shift" type="shift" 
+		 minOccurs="0" maxOccurs="unbounded"/>
+    <xsd:element name="investigationGroup" type="investigationGroup" 
+		 minOccurs="0" maxOccurs="unbounded"/>
+    <xsd:element name="investigationInstrument" type="investigationInstrument" 
+		 minOccurs="0" maxOccurs="unbounded"/>
+    <xsd:element name="investigationUser" type="investigationUser" 
+		 minOccurs="0" maxOccurs="unbounded"/>
+    <xsd:element name="sample" type="sample" 
+		 minOccurs="0" maxOccurs="unbounded"/>
+    <xsd:element name="sampleParameter" type="sampleParameter" 
+		 minOccurs="0" maxOccurs="unbounded"/>
+    <xsd:element name="dataset" type="dataset" 
+		 minOccurs="0" maxOccurs="unbounded"/>
+    <xsd:element name="datasetParameter" type="datasetParameter" 
+		 minOccurs="0" maxOccurs="unbounded"/>
+    <xsd:element name="datafile" type="datafile" 
+		 minOccurs="0" maxOccurs="unbounded"/>
+    <xsd:element name="datafileParameter" type="datafileParameter" 
+		 minOccurs="0" maxOccurs="unbounded"/>
+    <!-- other -->
+    <xsd:element name="study" type="study" 
+		 minOccurs="0" maxOccurs="unbounded"/>
+    <xsd:element name="studyInvestigation" type="studyInvestigation" 
+		 minOccurs="0" maxOccurs="unbounded"/>
+    <xsd:element name="relatedDatafile" type="relatedDatafile" 
+		 minOccurs="0" maxOccurs="unbounded"/>
+    <xsd:element name="dataCollection" type="dataCollection" 
+		 minOccurs="0" maxOccurs="unbounded"/>
+    <xsd:element name="dataCollectionParameter" type="dataCollectionParameter" 
+		 minOccurs="0" maxOccurs="unbounded"/>
+    <xsd:element name="dataCollectionDataset" type="dataCollectionDataset" 
+		 minOccurs="0" maxOccurs="unbounded"/>
+    <xsd:element name="dataCollectionDatafile" type="dataCollectionDatafile" 
+		 minOccurs="0" maxOccurs="unbounded"/>
+    <xsd:element name="job" type="job" 
+		 minOccurs="0" maxOccurs="unbounded"/>
+  </xsd:sequence>
+</xsd:complexType>
+
+
+<xsd:complexType name="entityBase">
+  <xsd:attribute name="id" type="xsd:string"/>
+</xsd:complexType>
+
+
+<!-- Entity object reference types 
+
+     There are different flavours, depending on context and on the way
+     the target object is referenced.
+
+     Object references may either be direct children of the data
+     element or children of object definitions.  In the latter case,
+     they establish a relation between the parent and the target
+     object.  In the former case, the id attribute SHOULD be set and
+     this defines a new reference key that may be used later on to
+     reference the target object in other reference objects.
+
+     The target object may either be referenced by reference key or by
+     object attributes.  In the former case, the key is given in the
+     ref attribute and other attributes SHOULD NOT be present.  The
+     reference key may either have been defined earlier in the id
+     attribute of an other entity object or reference in the same data
+     element or it must the unique key as returned by the
+     getUniqueKey() method of the target object.  In the latter case,
+     the attribute values must uniquely define the target object.
+
+     Note that in the case of referencing the target object by
+     attribute values, this schema is somewhat too restricted: in
+     principle, any attribute of the target object or any related
+     object could be used.  But this would be an infinite number of
+     possible attributes.  This cannot be properly formulated in XML
+     Schema Definition language.  Thus, only a subset of possible
+     attributes is defined here.  On the other hand, only some
+     attributes are likely useful for referencing entity objects in
+     practice.  So this should be no real limitation.
+
+-->
+
+<xsd:complexType name="entityReference">
+  <xsd:complexContent>
+    <xsd:extension base="entityBase">
+      <xsd:attribute name="ref" type="xsd:string"/>
+    </xsd:extension>
+  </xsd:complexContent>
+</xsd:complexType>
+
+<xsd:complexType name="applicationRef">
+  <xsd:complexContent>
+    <xsd:extension base="entityReference">
+      <xsd:attribute name="facility.name" type="xsd:string"/>
+      <xsd:attribute name="name" type="xsd:string"/>
+      <xsd:attribute name="version" type="xsd:string"/>
+    </xsd:extension>
+  </xsd:complexContent>
+</xsd:complexType>
+
+<xsd:complexType name="datafileRef">
+  <xsd:complexContent>
+    <xsd:extension base="entityReference">
+      <xsd:attribute name="dataset.investigation.facility.name" 
+		     type="xsd:string"/>
+      <xsd:attribute name="dataset.investigation.name" type="xsd:string"/>
+      <xsd:attribute name="dataset.investigation.visitId" type="xsd:string"/>
+      <xsd:attribute name="dataset.name" type="xsd:string"/>
+      <xsd:attribute name="name" type="xsd:string"/>
+    </xsd:extension>
+  </xsd:complexContent>
+</xsd:complexType>
+
+<xsd:complexType name="datafileFormatRef">
+  <xsd:complexContent>
+    <xsd:extension base="entityReference">
+      <xsd:attribute name="facility.name" type="xsd:string"/>
+      <xsd:attribute name="name" type="xsd:string"/>
+      <xsd:attribute name="version" type="xsd:string"/>
+    </xsd:extension>
+  </xsd:complexContent>
+</xsd:complexType>
+
+<xsd:complexType name="datasetRef">
+  <xsd:complexContent>
+    <xsd:extension base="entityReference">
+      <xsd:attribute name="investigation.facility.name" type="xsd:string"/>
+      <xsd:attribute name="investigation.name" type="xsd:string"/>
+      <xsd:attribute name="investigation.visitId" type="xsd:string"/>
+      <xsd:attribute name="name" type="xsd:string"/>
+    </xsd:extension>
+  </xsd:complexContent>
+</xsd:complexType>
+
+<xsd:complexType name="datasetTypeRef">
+  <xsd:complexContent>
+    <xsd:extension base="entityReference">
+      <xsd:attribute name="facility.name" type="xsd:string"/>
+      <xsd:attribute name="name" type="xsd:string"/>
+    </xsd:extension>
+  </xsd:complexContent>
+</xsd:complexType>
+
+<xsd:complexType name="facilityRef">
+  <xsd:complexContent>
+    <xsd:extension base="entityReference">
+      <xsd:attribute name="name" type="xsd:string"/>
+    </xsd:extension>
+  </xsd:complexContent>
+</xsd:complexType>
+
+<xsd:complexType name="groupingRef">
+  <xsd:complexContent>
+    <xsd:extension base="entityReference">
+      <xsd:attribute name="name" type="xsd:string"/>
+    </xsd:extension>
+  </xsd:complexContent>
+</xsd:complexType>
+
+<xsd:complexType name="instrumentRef">
+  <xsd:complexContent>
+    <xsd:extension base="entityReference">
+      <xsd:attribute name="facility.name" type="xsd:string"/>
+      <xsd:attribute name="name" type="xsd:string"/>
+    </xsd:extension>
+  </xsd:complexContent>
+</xsd:complexType>
+
+<xsd:complexType name="investigationRef">
+  <xsd:complexContent>
+    <xsd:extension base="entityReference">
+      <xsd:attribute name="facility.name" type="xsd:string"/>
+      <xsd:attribute name="name" type="xsd:string"/>
+      <xsd:attribute name="visitId" type="xsd:string"/>
+    </xsd:extension>
+  </xsd:complexContent>
+</xsd:complexType>
+
+<xsd:complexType name="investigationTypeRef">
+  <xsd:complexContent>
+    <xsd:extension base="entityReference">
+      <xsd:attribute name="facility.name" type="xsd:string"/>
+      <xsd:attribute name="name" type="xsd:string"/>
+    </xsd:extension>
+  </xsd:complexContent>
+</xsd:complexType>
+
+<xsd:complexType name="parameterTypeRef">
+  <xsd:complexContent>
+    <xsd:extension base="entityReference">
+      <xsd:attribute name="facility.name" type="xsd:string"/>
+      <xsd:attribute name="name" type="xsd:string"/>
+      <xsd:attribute name="units" type="xsd:string"/>
+    </xsd:extension>
+  </xsd:complexContent>
+</xsd:complexType>
+
+<xsd:complexType name="sampleRef">
+  <xsd:complexContent>
+    <xsd:extension base="entityReference">
+      <xsd:attribute name="investigation.facility.name" type="xsd:string"/>
+      <xsd:attribute name="investigation.name" type="xsd:string"/>
+      <xsd:attribute name="investigation.visitId" type="xsd:string"/>
+      <xsd:attribute name="name" type="xsd:string"/>
+    </xsd:extension>
+  </xsd:complexContent>
+</xsd:complexType>
+
+<xsd:complexType name="sampleTypeRef">
+  <xsd:complexContent>
+    <xsd:extension base="entityReference">
+      <xsd:attribute name="facility.name" type="xsd:string"/>
+      <xsd:attribute name="name" type="xsd:string"/>
+      <xsd:attribute name="molecularFormula" type="xsd:string"/>
+    </xsd:extension>
+  </xsd:complexContent>
+</xsd:complexType>
+
+<xsd:complexType name="userRef">
+  <xsd:complexContent>
+    <xsd:extension base="entityReference">
+      <xsd:attribute name="name" type="xsd:string"/>
+    </xsd:extension>
+  </xsd:complexContent>
+</xsd:complexType>
+
+
+<!-- Entity object definition types
+
+     Note that this schema is somewhat too liberal.  Additional
+     constraints that depend on context (and thus are not easy to
+     formulate in XML Schema Definition language) must be respected:
+
+     Many-to-one relations are marked as optional here.  But they are
+     in fact not.  For objects that are direct children of the data
+     element, all many-to-one relations MUST be present, unless they
+     are truly optional in the ICAT schema.  For objects that are
+     children of other objects, e.g. that are included in a
+     one-to-many relation, the many-to-one relation to the parent is
+     implied and MUST NOT be present, but all other many-to-one
+     relations MUST be present.
+
+     The id attribute is optional according to this schema.  But any
+     object that is referenced by another object in a many-to-one
+     relation MUST have the id attribute set.  These referenced
+     objects MUST be direct children of the data element.  Objects
+     that are children of other objects SHOULD NOT have the id
+     attribute set.
+
+-->
+
+<xsd:complexType name="application">
+  <xsd:complexContent>
+    <xsd:extension base="entityBase">
+      <xsd:sequence>
+	<xsd:element name="name" type="xsd:string"/>
+	<xsd:element name="version" type="xsd:string"/>
+	<xsd:element name="facility" type="facilityRef" minOccurs="0"/>
+	<xsd:element name="jobs" type="job" 
+		     minOccurs="0" maxOccurs="unbounded"/>
+      </xsd:sequence>
+    </xsd:extension>
+  </xsd:complexContent>
+</xsd:complexType>
+
+<xsd:complexType name="dataCollection">
+  <xsd:complexContent>
+    <xsd:extension base="entityBase">
+      <xsd:sequence>
+	<xsd:element name="doi" type="xsd:string" minOccurs="0"/>
+	<xsd:element name="dataCollectionDatafiles" 
+		     type="dataCollectionDatafile" 
+		     minOccurs="0" maxOccurs="unbounded"/>
+	<xsd:element name="dataCollectionDatasets" type="dataCollectionDataset" 
+		     minOccurs="0" maxOccurs="unbounded"/>
+	<xsd:element name="jobsAsInput" type="job" 
+		     minOccurs="0" maxOccurs="unbounded"/>
+	<xsd:element name="jobsAsOutput" type="job" 
+		     minOccurs="0" maxOccurs="unbounded"/>
+	<xsd:element name="parameters" type="dataCollectionParameter" 
+		     minOccurs="0" maxOccurs="unbounded"/>
+      </xsd:sequence>
+    </xsd:extension>
+  </xsd:complexContent>
+</xsd:complexType>
+
+<xsd:complexType name="dataCollectionDatafile">
+  <xsd:complexContent>
+    <xsd:extension base="entityBase">
+      <xsd:sequence>
+	<xsd:element name="dataCollection" type="entityReference" 
+		     minOccurs="0"/>
+	<xsd:element name="datafile" type="datafileRef" minOccurs="0"/>
+      </xsd:sequence>
+    </xsd:extension>
+  </xsd:complexContent>
+</xsd:complexType>
+
+<xsd:complexType name="dataCollectionDataset">
+  <xsd:complexContent>
+    <xsd:extension base="entityBase">
+      <xsd:sequence>
+	<xsd:element name="dataCollection" type="entityReference" 
+		     minOccurs="0"/>
+	<xsd:element name="dataset" type="datasetRef" minOccurs="0"/>
+      </xsd:sequence>
+    </xsd:extension>
+  </xsd:complexContent>
+</xsd:complexType>
+
+<xsd:complexType name="dataCollectionParameter">
+  <xsd:complexContent>
+    <xsd:extension base="entityBase">
+      <xsd:sequence>
+	<xsd:element name="dateTimeValue" type="xsd:dateTime" minOccurs="0"/>
+	<xsd:element name="error" type="xsd:double" minOccurs="0"/>
+	<xsd:element name="numericValue" type="xsd:double" minOccurs="0"/>
+	<xsd:element name="rangeBottom" type="xsd:double" minOccurs="0"/>
+	<xsd:element name="rangeTop" type="xsd:double" minOccurs="0"/>
+	<xsd:element name="stringValue" type="xsd:string" minOccurs="0"/>
+	<xsd:element name="dataCollection" type="entityReference" 
+		     minOccurs="0"/>
+	<xsd:element name="type" type="parameterTypeRef" minOccurs="0"/>
+      </xsd:sequence>
+    </xsd:extension>
+  </xsd:complexContent>
+</xsd:complexType>
+
+<xsd:complexType name="datafile">
+  <xsd:complexContent>
+    <xsd:extension base="entityBase">
+      <xsd:sequence>
+	<xsd:element name="checksum" type="xsd:string" minOccurs="0"/>
+	<xsd:element name="datafileCreateTime" type="xsd:dateTime" 
+		     minOccurs="0"/>
+	<xsd:element name="datafileModTime" type="xsd:dateTime" minOccurs="0"/>
+	<xsd:element name="description" type="xsd:string" minOccurs="0"/>
+	<xsd:element name="doi" type="xsd:string" minOccurs="0"/>
+	<xsd:element name="fileSize" type="xsd:long" minOccurs="0"/>
+	<xsd:element name="location" type="xsd:string" minOccurs="0"/>
+	<xsd:element name="name" type="xsd:string"/>
+	<xsd:element name="datafileFormat" type="datafileFormatRef" 
+		     minOccurs="0"/>
+	<xsd:element name="dataset" type="datasetRef" minOccurs="0"/>
+	<xsd:element name="dataCollectionDatafiles" 
+		     type="dataCollectionDatafile" 
+		     minOccurs="0" maxOccurs="unbounded"/>
+	<xsd:element name="destDatafiles" type="relatedDatafile" 
+		     minOccurs="0" maxOccurs="unbounded"/>
+	<xsd:element name="parameters" type="datafileParameter" 
+		     minOccurs="0" maxOccurs="unbounded"/>
+	<xsd:element name="sourceDatafiles" type="relatedDatafile" 
+		     minOccurs="0" maxOccurs="unbounded"/>
+      </xsd:sequence>
+    </xsd:extension>
+  </xsd:complexContent>
+</xsd:complexType>
+
+<xsd:complexType name="datafileFormat">
+  <xsd:complexContent>
+    <xsd:extension base="entityBase">
+      <xsd:sequence>
+	<xsd:element name="description" type="xsd:string" minOccurs="0"/>
+	<xsd:element name="name" type="xsd:string"/>
+	<xsd:element name="type" type="xsd:string" minOccurs="0"/>
+	<xsd:element name="version" type="xsd:string"/>
+	<xsd:element name="facility" type="facilityRef" minOccurs="0"/>
+	<xsd:element name="datafiles" type="datafile" 
+		     minOccurs="0" maxOccurs="unbounded"/>
+      </xsd:sequence>
+    </xsd:extension>
+  </xsd:complexContent>
+</xsd:complexType>
+
+<xsd:complexType name="datafileParameter">
+  <xsd:complexContent>
+    <xsd:extension base="entityBase">
+      <xsd:sequence>
+	<xsd:element name="dateTimeValue" type="xsd:dateTime" minOccurs="0"/>
+	<xsd:element name="error" type="xsd:double" minOccurs="0"/>
+	<xsd:element name="numericValue" type="xsd:double" minOccurs="0"/>
+	<xsd:element name="rangeBottom" type="xsd:double" minOccurs="0"/>
+	<xsd:element name="rangeTop" type="xsd:double" minOccurs="0"/>
+	<xsd:element name="stringValue" type="xsd:string" minOccurs="0"/>
+	<xsd:element name="datafile" type="datafileRef" minOccurs="0"/>
+	<xsd:element name="type" type="parameterTypeRef" minOccurs="0"/>
+      </xsd:sequence>
+    </xsd:extension>
+  </xsd:complexContent>
+</xsd:complexType>
+
+<xsd:complexType name="dataset">
+  <xsd:complexContent>
+    <xsd:extension base="entityBase">
+      <xsd:sequence>
+	<xsd:element name="complete" type="xsd:boolean"/>
+	<xsd:element name="description" type="xsd:string" minOccurs="0"/>
+	<xsd:element name="doi" type="xsd:string" minOccurs="0"/>
+	<xsd:element name="endDate" type="xsd:dateTime" minOccurs="0"/>
+	<xsd:element name="location" type="xsd:string" minOccurs="0"/>
+	<xsd:element name="name" type="xsd:string"/>
+	<xsd:element name="startDate" type="xsd:dateTime" minOccurs="0"/>
+	<xsd:element name="investigation" type="investigationRef" 
+		     minOccurs="0"/>
+	<xsd:element name="sample" type="sampleRef" minOccurs="0"/>
+	<xsd:element name="type" type="datasetTypeRef" minOccurs="0"/>
+	<xsd:element name="dataCollectionDatasets" type="dataCollectionDataset" 
+		     minOccurs="0" maxOccurs="unbounded"/>
+	<xsd:element name="datafiles" type="datafile" 
+		     minOccurs="0" maxOccurs="unbounded"/>
+	<xsd:element name="parameters" type="datasetParameter" 
+		     minOccurs="0" maxOccurs="unbounded"/>
+      </xsd:sequence>
+    </xsd:extension>
+  </xsd:complexContent>
+</xsd:complexType>
+
+<xsd:complexType name="datasetParameter">
+  <xsd:complexContent>
+    <xsd:extension base="entityBase">
+      <xsd:sequence>
+	<xsd:element name="dateTimeValue" type="xsd:dateTime" minOccurs="0"/>
+	<xsd:element name="error" type="xsd:double" minOccurs="0"/>
+	<xsd:element name="numericValue" type="xsd:double" minOccurs="0"/>
+	<xsd:element name="rangeBottom" type="xsd:double" minOccurs="0"/>
+	<xsd:element name="rangeTop" type="xsd:double" minOccurs="0"/>
+	<xsd:element name="stringValue" type="xsd:string" minOccurs="0"/>
+	<xsd:element name="dataset" type="datasetRef" minOccurs="0"/>
+	<xsd:element name="type" type="parameterTypeRef" minOccurs="0"/>
+      </xsd:sequence>
+    </xsd:extension>
+  </xsd:complexContent>
+</xsd:complexType>
+
+<xsd:complexType name="datasetType">
+  <xsd:complexContent>
+    <xsd:extension base="entityBase">
+      <xsd:sequence>
+	<xsd:element name="description" type="xsd:string" minOccurs="0"/>
+	<xsd:element name="name" type="xsd:string"/>
+	<xsd:element name="facility" type="facilityRef" minOccurs="0"/>
+	<xsd:element name="datasets" type="dataset" 
+		     minOccurs="0" maxOccurs="unbounded"/>
+      </xsd:sequence>
+    </xsd:extension>
+  </xsd:complexContent>
+</xsd:complexType>
+
+<xsd:complexType name="facility">
+  <xsd:complexContent>
+    <xsd:extension base="entityBase">
+      <xsd:sequence>
+	<xsd:element name="daysUntilRelease" type="xsd:int" minOccurs="0"/>
+	<xsd:element name="description" type="xsd:string" minOccurs="0"/>
+	<xsd:element name="fullName" type="xsd:string" minOccurs="0"/>
+	<xsd:element name="name" type="xsd:string"/>
+	<xsd:element name="url" type="xsd:string" minOccurs="0"/>
+	<xsd:element name="applications" type="application" 
+		     minOccurs="0" maxOccurs="unbounded"/>
+	<xsd:element name="datafileFormats" type="datafileFormat" 
+		     minOccurs="0" maxOccurs="unbounded"/>
+	<xsd:element name="datasetTypes" type="datasetType" 
+		     minOccurs="0" maxOccurs="unbounded"/>
+	<xsd:element name="facilityCycles" type="facilityCycle" 
+		     minOccurs="0" maxOccurs="unbounded"/>
+	<xsd:element name="instruments" type="instrument" 
+		     minOccurs="0" maxOccurs="unbounded"/>
+	<xsd:element name="investigationTypes" type="investigationType" 
+		     minOccurs="0" maxOccurs="unbounded"/>
+	<xsd:element name="investigations" type="investigation" 
+		     minOccurs="0" maxOccurs="unbounded"/>
+	<xsd:element name="parameterTypes" type="parameterType" 
+		     minOccurs="0" maxOccurs="unbounded"/>
+	<xsd:element name="sampleTypes" type="sampleType" 
+		     minOccurs="0" maxOccurs="unbounded"/>
+      </xsd:sequence>
+    </xsd:extension>
+  </xsd:complexContent>
+</xsd:complexType>
+
+<xsd:complexType name="facilityCycle">
+  <xsd:complexContent>
+    <xsd:extension base="entityBase">
+      <xsd:sequence>
+	<xsd:element name="description" type="xsd:string" minOccurs="0"/>
+	<xsd:element name="endDate" type="xsd:dateTime" minOccurs="0"/>
+	<xsd:element name="name" type="xsd:string"/>
+	<xsd:element name="startDate" type="xsd:dateTime" minOccurs="0"/>
+	<xsd:element name="facility" type="facilityRef" minOccurs="0"/>
+      </xsd:sequence>
+    </xsd:extension>
+  </xsd:complexContent>
+</xsd:complexType>
+
+<xsd:complexType name="grouping">
+  <xsd:complexContent>
+    <xsd:extension base="entityBase">
+      <xsd:sequence>
+	<xsd:element name="name" type="xsd:string"/>
+	<xsd:element name="investigationGroups" type="investigationGroup" 
+		     minOccurs="0" maxOccurs="unbounded"/>
+	<xsd:element name="rules" type="rule" 
+		     minOccurs="0" maxOccurs="unbounded"/>
+	<xsd:element name="userGroups" type="userGroup" 
+		     minOccurs="0" maxOccurs="unbounded"/>
+      </xsd:sequence>
+    </xsd:extension>
+  </xsd:complexContent>
+</xsd:complexType>
+
+<xsd:complexType name="instrument">
+  <xsd:complexContent>
+    <xsd:extension base="entityBase">
+      <xsd:sequence>
+	<xsd:element name="description" type="xsd:string" minOccurs="0"/>
+	<xsd:element name="fullName" type="xsd:string" minOccurs="0"/>
+	<xsd:element name="name" type="xsd:string"/>
+	<xsd:element name="pid" type="xsd:string" minOccurs="0"/>
+	<xsd:element name="type" type="xsd:string" minOccurs="0"/>
+	<xsd:element name="url" type="xsd:string" minOccurs="0"/>
+	<xsd:element name="facility" type="facilityRef" minOccurs="0"/>
+	<xsd:element name="instrumentScientists" type="instrumentScientist" 
+		     minOccurs="0" maxOccurs="unbounded"/>
+	<xsd:element name="investigationInstruments" 
+		     type="investigationInstrument" 
+		     minOccurs="0" maxOccurs="unbounded"/>
+	<xsd:element name="shifts" type="shift" 
+		     minOccurs="0" maxOccurs="unbounded"/>
+      </xsd:sequence>
+    </xsd:extension>
+  </xsd:complexContent>
+</xsd:complexType>
+
+<xsd:complexType name="instrumentScientist">
+  <xsd:complexContent>
+    <xsd:extension base="entityBase">
+      <xsd:sequence>
+	<xsd:element name="instrument" type="instrumentRef" minOccurs="0"/>
+	<xsd:element name="user" type="userRef" minOccurs="0"/>
+      </xsd:sequence>
+    </xsd:extension>
+  </xsd:complexContent>
+</xsd:complexType>
+
+<xsd:complexType name="investigation">
+  <xsd:complexContent>
+    <xsd:extension base="entityBase">
+      <xsd:sequence>
+	<xsd:element name="doi" type="xsd:string" minOccurs="0"/>
+	<xsd:element name="endDate" type="xsd:dateTime" minOccurs="0"/>
+	<xsd:element name="name" type="xsd:string"/>
+	<xsd:element name="releaseDate" type="xsd:dateTime" minOccurs="0"/>
+	<xsd:element name="startDate" type="xsd:dateTime" minOccurs="0"/>
+	<xsd:element name="summary" type="xsd:string" minOccurs="0"/>
+	<xsd:element name="title" type="xsd:string"/>
+	<xsd:element name="visitId" type="xsd:string"/>
+	<xsd:element name="facility" type="facilityRef" minOccurs="0"/>
+	<xsd:element name="type" type="investigationTypeRef" minOccurs="0"/>
+	<xsd:element name="datasets" type="dataset" 
+		     minOccurs="0" maxOccurs="unbounded"/>
+	<xsd:element name="investigationGroups" type="investigationGroup" 
+		     minOccurs="0" maxOccurs="unbounded"/>
+	<xsd:element name="investigationInstruments" 
+		     type="investigationInstrument" 
+		     minOccurs="0" maxOccurs="unbounded"/>
+	<xsd:element name="investigationUsers" type="investigationUser" 
+		     minOccurs="0" maxOccurs="unbounded"/>
+	<xsd:element name="keywords" type="keyword" 
+		     minOccurs="0" maxOccurs="unbounded"/>
+	<xsd:element name="parameters" type="investigationParameter"
+		     minOccurs="0" maxOccurs="unbounded"/>
+	<xsd:element name="publications" type="publication" 
+		     minOccurs="0" maxOccurs="unbounded"/>
+	<xsd:element name="samples" type="sample" 
+		     minOccurs="0" maxOccurs="unbounded"/>
+	<xsd:element name="shifts" type="shift" 
+		     minOccurs="0" maxOccurs="unbounded"/>
+	<xsd:element name="studyInvestigations" type="studyInvestigation" 
+		     minOccurs="0" maxOccurs="unbounded"/>
+      </xsd:sequence>
+    </xsd:extension>
+  </xsd:complexContent>
+</xsd:complexType>
+
+<xsd:complexType name="investigationGroup">
+  <xsd:complexContent>
+    <xsd:extension base="entityBase">
+      <xsd:sequence>
+	<xsd:element name="role" type="xsd:string" minOccurs="0"/>
+	<xsd:element name="grouping" type="groupingRef" minOccurs="0"/>
+	<xsd:element name="investigation" type="investigationRef" 
+		     minOccurs="0"/>
+      </xsd:sequence>
+    </xsd:extension>
+  </xsd:complexContent>
+</xsd:complexType>
+
+<xsd:complexType name="investigationInstrument">
+  <xsd:complexContent>
+    <xsd:extension base="entityBase">
+      <xsd:sequence>
+	<xsd:element name="instrument" type="instrumentRef" minOccurs="0"/>
+	<xsd:element name="investigation" type="investigationRef" 
+		     minOccurs="0"/>
+      </xsd:sequence>
+    </xsd:extension>
+  </xsd:complexContent>
+</xsd:complexType>
+
+<xsd:complexType name="investigationParameter">
+  <xsd:complexContent>
+    <xsd:extension base="entityBase">
+      <xsd:sequence>
+	<xsd:element name="dateTimeValue" type="xsd:dateTime" minOccurs="0"/>
+	<xsd:element name="error" type="xsd:double" minOccurs="0"/>
+	<xsd:element name="numericValue" type="xsd:double" minOccurs="0"/>
+	<xsd:element name="rangeBottom" type="xsd:double" minOccurs="0"/>
+	<xsd:element name="rangeTop" type="xsd:double" minOccurs="0"/>
+	<xsd:element name="stringValue" type="xsd:string" minOccurs="0"/>
+	<xsd:element name="type" type="parameterTypeRef" minOccurs="0"/>
+	<xsd:element name="investigation" type="investigationRef" 
+		     minOccurs="0"/>
+      </xsd:sequence>
+    </xsd:extension>
+  </xsd:complexContent>
+</xsd:complexType>
+
+<xsd:complexType name="investigationType">
+  <xsd:complexContent>
+    <xsd:extension base="entityBase">
+      <xsd:sequence>
+	<xsd:element name="description" type="xsd:string" minOccurs="0"/>
+	<xsd:element name="name" type="xsd:string"/>
+	<xsd:element name="facility" type="facilityRef" minOccurs="0"/>
+	<xsd:element name="investigations" type="investigation" 
+		     minOccurs="0" maxOccurs="unbounded"/>
+      </xsd:sequence>
+    </xsd:extension>
+  </xsd:complexContent>
+</xsd:complexType>
+
+<xsd:complexType name="investigationUser">
+  <xsd:complexContent>
+    <xsd:extension base="entityBase">
+      <xsd:sequence>
+	<xsd:element name="role" type="xsd:string" minOccurs="0"/>
+	<xsd:element name="investigation" type="investigationRef" 
+		     minOccurs="0"/>
+	<xsd:element name="user" type="userRef" minOccurs="0"/>
+      </xsd:sequence>
+    </xsd:extension>
+  </xsd:complexContent>
+</xsd:complexType>
+
+<xsd:complexType name="job">
+  <xsd:complexContent>
+    <xsd:extension base="entityBase">
+      <xsd:sequence>
+	<xsd:element name="arguments" type="xsd:string" minOccurs="0"/>
+	<xsd:element name="application" type="applicationRef" minOccurs="0"/>
+	<xsd:element name="inputDataCollection" type="entityReference" 
+		     minOccurs="0"/>
+	<xsd:element name="outputDataCollection" type="entityReference" 
+		     minOccurs="0"/>
+      </xsd:sequence>
+    </xsd:extension>
+  </xsd:complexContent>
+</xsd:complexType>
+
+<xsd:complexType name="keyword">
+  <xsd:complexContent>
+    <xsd:extension base="entityBase">
+      <xsd:sequence>
+	<xsd:element name="name" type="xsd:string"/>
+	<xsd:element name="investigation" type="investigationRef" 
+		     minOccurs="0"/>
+      </xsd:sequence>
+    </xsd:extension>
+  </xsd:complexContent>
+</xsd:complexType>
+
+<xsd:complexType name="parameterType">
+  <xsd:complexContent>
+    <xsd:extension base="entityBase">
+      <xsd:sequence>
+	<xsd:element name="applicableToDataCollection" type="xsd:boolean" 
+		     minOccurs="0"/>
+	<xsd:element name="applicableToDatafile" type="xsd:boolean" 
+		     minOccurs="0"/>
+	<xsd:element name="applicableToDataset" type="xsd:boolean" 
+		     minOccurs="0"/>
+	<xsd:element name="applicableToInvestigation" type="xsd:boolean" 
+		     minOccurs="0"/>
+	<xsd:element name="applicableToSample" type="xsd:boolean" 
+		     minOccurs="0"/>
+	<xsd:element name="description" type="xsd:string" minOccurs="0"/>
+	<xsd:element name="enforced" type="xsd:boolean" minOccurs="0"/>
+	<xsd:element name="maximumNumericValue" type="xsd:double" 
+		     minOccurs="0"/>
+	<xsd:element name="minimumNumericValue" type="xsd:double" 
+		     minOccurs="0"/>
+	<xsd:element name="name" type="xsd:string"/>
+	<xsd:element name="pid" type="xsd:string" minOccurs="0"/>
+	<xsd:element name="units" type="xsd:string"/>
+	<xsd:element name="unitsFullName" type="xsd:string" minOccurs="0"/>
+	<xsd:element name="valueType" type="parameterValueType"/>
+	<xsd:element name="verified" type="xsd:boolean" minOccurs="0"/>
+	<xsd:element name="facility" type="facilityRef" minOccurs="0"/>
+	<xsd:element name="dataCollectionParameters" 
+		     type="dataCollectionParameter" 
+		     minOccurs="0" maxOccurs="unbounded"/>
+	<xsd:element name="datafileParameters" type="datafileParameter" 
+		     minOccurs="0" maxOccurs="unbounded"/>
+	<xsd:element name="datasetParameters" type="datasetParameter" 
+		     minOccurs="0" maxOccurs="unbounded"/>
+	<xsd:element name="investigationParameters" 
+		     type="investigationParameter" 
+		     minOccurs="0" maxOccurs="unbounded"/>
+	<xsd:element name="permissibleStringValues" 
+		     type="permissibleStringValue" 
+		     minOccurs="0" maxOccurs="unbounded"/>
+	<xsd:element name="sampleParameters" type="sampleParameter" 
+		     minOccurs="0" maxOccurs="unbounded"/>
+      </xsd:sequence>
+    </xsd:extension>
+  </xsd:complexContent>
+</xsd:complexType>
+
+<xsd:complexType name="permissibleStringValue">
+  <xsd:complexContent>
+    <xsd:extension base="entityBase">
+      <xsd:sequence>
+	<xsd:element name="value" type="xsd:string"/>
+	<xsd:element name="type" type="parameterType" minOccurs="0"/>
+      </xsd:sequence>
+    </xsd:extension>
+  </xsd:complexContent>
+</xsd:complexType>
+
+<xsd:complexType name="publicStep">
+  <xsd:complexContent>
+    <xsd:extension base="entityBase">
+      <xsd:sequence>
+	<xsd:element name="field" type="xsd:string"/>
+	<xsd:element name="origin" type="xsd:string"/>
+      </xsd:sequence>
+    </xsd:extension>
+  </xsd:complexContent>
+</xsd:complexType>
+
+<xsd:complexType name="publication">
+  <xsd:complexContent>
+    <xsd:extension base="entityBase">
+      <xsd:sequence>
+	<xsd:element name="doi" type="xsd:string" minOccurs="0"/>
+	<xsd:element name="fullReference" type="xsd:string"/>
+	<xsd:element name="repository" type="xsd:string" minOccurs="0"/>
+	<xsd:element name="repositoryId" type="xsd:string" minOccurs="0"/>
+	<xsd:element name="url" type="xsd:string" minOccurs="0"/>
+	<xsd:element name="investigation" type="investigationRef" 
+		     minOccurs="0"/>
+      </xsd:sequence>
+    </xsd:extension>
+  </xsd:complexContent>
+</xsd:complexType>
+
+<xsd:complexType name="relatedDatafile">
+  <xsd:complexContent>
+    <xsd:extension base="entityBase">
+      <xsd:sequence>
+	<xsd:element name="relation" type="xsd:string"/>
+	<xsd:element name="destDatafile" type="datafileRef" minOccurs="0"/>
+	<xsd:element name="sourceDatafile" type="datafileRef" minOccurs="0"/>
+      </xsd:sequence>
+    </xsd:extension>
+  </xsd:complexContent>
+</xsd:complexType>
+
+<xsd:complexType name="rule">
+  <xsd:complexContent>
+    <xsd:extension base="entityBase">
+      <xsd:sequence>
+	<xsd:element name="crudFlags" type="xsd:string"/>
+	<xsd:element name="what" type="xsd:string"/>
+	<xsd:element name="grouping" type="groupingRef" minOccurs="0"/>
+      </xsd:sequence>
+    </xsd:extension>
+  </xsd:complexContent>
+</xsd:complexType>
+
+<xsd:complexType name="sample">
+  <xsd:complexContent>
+    <xsd:extension base="entityBase">
+      <xsd:sequence>
+	<xsd:element name="name" type="xsd:string"/>
+	<xsd:element name="pid" type="xsd:string" minOccurs="0"/>
+	<xsd:element name="investigation" type="investigationRef" 
+		     minOccurs="0"/>
+	<xsd:element name="type" type="sampleTypeRef" minOccurs="0"/>
+	<xsd:element name="datasets" type="dataset" 
+		     minOccurs="0" maxOccurs="unbounded"/>
+	<xsd:element name="parameters" type="sampleParameter" 
+		     minOccurs="0" maxOccurs="unbounded"/>
+      </xsd:sequence>
+    </xsd:extension>
+  </xsd:complexContent>
+</xsd:complexType>
+
+<xsd:complexType name="sampleParameter">
+  <xsd:complexContent>
+    <xsd:extension base="entityBase">
+      <xsd:sequence>
+	<xsd:element name="dateTimeValue" type="xsd:dateTime" minOccurs="0"/>
+	<xsd:element name="error" type="xsd:double" minOccurs="0"/>
+	<xsd:element name="numericValue" type="xsd:double" minOccurs="0"/>
+	<xsd:element name="rangeBottom" type="xsd:double" minOccurs="0"/>
+	<xsd:element name="rangeTop" type="xsd:double" minOccurs="0"/>
+	<xsd:element name="stringValue" type="xsd:string" minOccurs="0"/>
+	<xsd:element name="sample" type="sampleRef" minOccurs="0"/>
+	<xsd:element name="type" type="parameterTypeRef" minOccurs="0"/>
+      </xsd:sequence>
+    </xsd:extension>
+  </xsd:complexContent>
+</xsd:complexType>
+
+<xsd:complexType name="sampleType">
+  <xsd:complexContent>
+    <xsd:extension base="entityBase">
+      <xsd:sequence>
+	<xsd:element name="molecularFormula" type="xsd:string"/>
+	<xsd:element name="name" type="xsd:string"/>
+	<xsd:element name="safetyInformation" type="xsd:string" minOccurs="0"/>
+	<xsd:element name="facility" type="facilityRef" minOccurs="0"/>
+	<xsd:element name="samples" type="sample" 
+		     minOccurs="0" maxOccurs="unbounded"/>
+      </xsd:sequence>
+    </xsd:extension>
+  </xsd:complexContent>
+</xsd:complexType>
+
+<xsd:complexType name="shift">
+  <xsd:complexContent>
+    <xsd:extension base="entityBase">
+      <xsd:sequence>
+	<xsd:element name="comment" type="xsd:string" minOccurs="0"/>
+	<xsd:element name="endDate" type="xsd:dateTime"/>
+	<xsd:element name="startDate" type="xsd:dateTime"/>
+	<xsd:element name="instrument" type="instrumentRef" 
+		     minOccurs="0"/>
+	<xsd:element name="investigation" type="investigationRef" 
+		     minOccurs="0"/>
+      </xsd:sequence>
+    </xsd:extension>
+  </xsd:complexContent>
+</xsd:complexType>
+
+<xsd:complexType name="study">
+  <xsd:complexContent>
+    <xsd:extension base="entityBase">
+      <xsd:sequence>
+	<xsd:element name="description" type="xsd:string" minOccurs="0"/>
+	<xsd:element name="name" type="xsd:string"/>
+	<xsd:element name="pid" type="xsd:string" minOccurs="0"/>
+	<xsd:element name="startDate" type="xsd:dateTime" minOccurs="0"/>
+	<xsd:element name="status" type="studyStatus" minOccurs="0"/>
+	<xsd:element name="user" type="userRef" minOccurs="0"/>
+	<xsd:element name="studyInvestigations" type="studyInvestigation" 
+		     minOccurs="0" maxOccurs="unbounded"/>
+      </xsd:sequence>
+    </xsd:extension>
+  </xsd:complexContent>
+</xsd:complexType>
+
+<xsd:complexType name="studyInvestigation">
+  <xsd:complexContent>
+    <xsd:extension base="entityBase">
+      <xsd:sequence>
+	<xsd:element name="investigation" type="investigationRef" 
+		     minOccurs="0"/>
+	<xsd:element name="study" type="entityReference" minOccurs="0"/>
+      </xsd:sequence>
+    </xsd:extension>
+  </xsd:complexContent>
+</xsd:complexType>
+
+<xsd:complexType name="user">
+  <xsd:complexContent>
+    <xsd:extension base="entityBase">
+      <xsd:sequence>
+	<xsd:element name="affiliation" type="xsd:string" minOccurs="0"/>
+	<xsd:element name="email" type="xsd:string" minOccurs="0"/>
+	<xsd:element name="familyName" type="xsd:string" minOccurs="0"/>
+	<xsd:element name="fullName" type="xsd:string" minOccurs="0"/>
+	<xsd:element name="givenName" type="xsd:string" minOccurs="0"/>
+	<xsd:element name="name" type="xsd:string"/>
+	<xsd:element name="orcidId" type="xsd:string" minOccurs="0"/>
+	<xsd:element name="instrumentScientists" type="instrumentScientist" 
+		     minOccurs="0" maxOccurs="unbounded"/>
+	<xsd:element name="investigationUsers" type="investigationUser" 
+		     minOccurs="0" maxOccurs="unbounded"/>
+	<xsd:element name="studies" type="study" 
+		     minOccurs="0" maxOccurs="unbounded"/>
+	<xsd:element name="userGroups" type="userGroup" 
+		     minOccurs="0" maxOccurs="unbounded"/>
+      </xsd:sequence>
+    </xsd:extension>
+  </xsd:complexContent>
+</xsd:complexType>
+
+<xsd:complexType name="userGroup">
+  <xsd:complexContent>
+    <xsd:extension base="entityBase">
+      <xsd:sequence>
+	<xsd:element name="grouping" type="groupingRef" minOccurs="0"/>
+	<xsd:element name="user" type="userRef" minOccurs="0"/>
+      </xsd:sequence>
+    </xsd:extension>
+  </xsd:complexContent>
+</xsd:complexType>
+
+
+<!-- simple types -->
+
+<xsd:simpleType name="parameterValueType">
+  <xsd:restriction base="xsd:string">
+    <xsd:enumeration value="DATE_AND_TIME"/>
+    <xsd:enumeration value="NUMERIC"/>
+    <xsd:enumeration value="STRING"/>
+  </xsd:restriction>
+</xsd:simpleType>
+
+<xsd:simpleType name="studyStatus">
+  <xsd:restriction base="xsd:string">
+    <xsd:enumeration value="NEW"/>
+    <xsd:enumeration value="IN_PROGRESS"/>
+    <xsd:enumeration value="COMPLETE"/>
+    <xsd:enumeration value="CANCELLED"/>
+  </xsd:restriction>
+</xsd:simpleType>
+
+</xsd:schema>

--- a/doc/icatdata-4.10.xsd
+++ b/doc/icatdata-4.10.xsd
@@ -964,6 +964,7 @@
     <xsd:extension base="entityBase">
       <xsd:sequence>
 	<xsd:element name="description" type="xsd:string" minOccurs="0"/>
+	<xsd:element name="endDate" type="xsd:dateTime"/>
 	<xsd:element name="name" type="xsd:string"/>
 	<xsd:element name="pid" type="xsd:string" minOccurs="0"/>
 	<xsd:element name="startDate" type="xsd:dateTime" minOccurs="0"/>

--- a/icat/client.py
+++ b/icat/client.py
@@ -131,6 +131,15 @@ del TypeMap47['log']
 TypeMap47.update( dataCollection = icat.entities.DataCollection47,
                   user = icat.entities.User47 )
 
+TypeMap410 = TypeMap47.copy()
+"""Map instance types defined in the WSDL to Python classes (ICAT 4.10.0)."""
+TypeMap410.update( instrument = icat.entities.Instrument410,
+                   parameterType = icat.entities.ParameterType410,
+                   sample = icat.entities.Sample410,
+                   shift = icat.entities.Shift410,
+                   study = icat.entities.Study410,
+                   user = icat.entities.User410 )
+
 
 class Client(suds.client.Client):
  
@@ -231,9 +240,11 @@ class Client(suds.client.Client):
             self.typemap = TypeMap44.copy()
         elif self.apiversion < '4.9.9':
             self.typemap = TypeMap47.copy()
+        elif self.apiversion < '4.10.9':
+            self.typemap = TypeMap410.copy()
         else:
             warn(ClientVersionWarning(self.apiversion, "too new"))
-            self.typemap = TypeMap47.copy()
+            self.typemap = TypeMap410.copy()
 
         self.ids = None
         self.sessionId = None

--- a/icat/entities.py
+++ b/icat/entities.py
@@ -281,6 +281,14 @@ class Instrument43(Instrument):
     InstMRel = frozenset(['instrumentScientists', 'investigationInstruments'])
 
 
+class Instrument410(Instrument43):
+    """Used by a user within an investigation."""
+    InstAttr = frozenset(['id', 'pid', 'name', 'fullName', 'description', 
+                          'type', 'url'])
+    InstMRel = frozenset(['instrumentScientists', 'investigationInstruments', 
+                          'shifts'])
+
+
 class InstrumentScientist(Entity):
     """Relationship between an ICAT user as an instrument scientist
     and the instrument."""
@@ -483,6 +491,16 @@ class ParameterType43(ParameterType):
                           'permissibleStringValues'])
 
 
+class ParameterType410(ParameterType43):
+    """A parameter type with unique name and units."""
+    InstAttr = frozenset(['id', 'pid', 'name', 'description', 'valueType', 
+                          'units', 'unitsFullName', 'minimumNumericValue', 
+                          'maximumNumericValue', 'enforced', 'verified', 
+                          'applicableToDatafile', 'applicableToDataset', 
+                          'applicableToSample', 'applicableToInvestigation', 
+                          'applicableToDataCollection'])
+
+
 class PermissibleStringValue(Entity):
     """Permissible value for string parameter types."""
     BeanName = 'PermissibleStringValue'
@@ -547,6 +565,11 @@ class Sample43(Sample):
     Constraint = ('investigation', 'name')
 
 
+class Sample410(Sample43):
+    """A sample to be used in an investigation."""
+    InstAttr = frozenset(['id', 'pid', 'name'])
+
+
 class SampleParameter(Parameter):
     """A parameter associated with a sample."""
     BeanName = 'SampleParameter'
@@ -577,6 +600,11 @@ class Shift(Entity):
     InstRel = frozenset(['investigation'])
 
 
+class Shift410(Shift):
+    """A period of time related to an investigation."""
+    InstRel = frozenset(['investigation', 'instrument'])
+
+
 class Study(Entity):
     """A study which may be related to an investigation."""
     BeanName = 'Study'
@@ -584,6 +612,12 @@ class Study(Entity):
     InstRel = frozenset(['user'])
     InstMRel = frozenset(['studyInvestigations'])
     SortAttrs = ['name']
+
+
+class Study410(Study):
+    """A study which may be related to an investigation."""
+    InstAttr = frozenset(['id', 'pid', 'name', 'description', 'status', 
+                          'startDate'])
 
 
 class StudyInvestigation(Entity):
@@ -605,6 +639,12 @@ class User(Entity):
 class User47(User):
     """A user of the facility."""
     InstAttr = frozenset(['id', 'name', 'fullName', 'orcidId', 'email'])
+
+
+class User410(User47):
+    """A user of the facility."""
+    InstAttr = frozenset(['id', 'name', 'givenName', 'familyName', 'fullName', 
+                          'affiliation', 'orcidId', 'email'])
 
 
 class UserGroup(Entity):

--- a/icat/entities.py
+++ b/icat/entities.py
@@ -617,7 +617,7 @@ class Study(Entity):
 class Study410(Study):
     """A study which may be related to an investigation."""
     InstAttr = frozenset(['id', 'pid', 'name', 'description', 'status', 
-                          'startDate'])
+                          'startDate', 'endDate'])
 
 
 class StudyInvestigation(Entity):


### PR DESCRIPTION
The upcoming version 4.10.0 of `icat.server` will feature some schema additions. Obviously, we want to support this on the client side.

As of writing this PR supports the last snapshot release `icat.server-4.10.0-20190212.104517-1`. Obviously, we will wait for the official release before merge.