### PR TITLE
Fix bad coding style dealing with function parameters

### DIFF
--- a/icat/client.py
+++ b/icat/client.py
@@ -792,7 +792,7 @@ class Client(suds.client.Client):
         u.create()
         return u
 
-    def createGroup(self, name, users=[]):
+    def createGroup(self, name, users=()):
         """Create a group and add users to it.
 
         :param name: the name of the group.

--- a/icat/config.py
+++ b/icat/config.py
@@ -382,7 +382,7 @@ class Config(object):
             self.client = None
 
 
-    def add_variable(self, name, arg_opts=(), arg_kws=dict(), 
+    def add_variable(self, name, arg_opts=(), arg_kws=None,
                      envvar=None, optional=False, default=None, type=None, 
                      subst=False):
 
@@ -450,6 +450,10 @@ class Config(object):
             raise ValueError("Config variable name '%s' is reserved." % name)
         if name in self.confvariable:
             raise ValueError("Config variable '%s' is already defined." % name)
+        if arg_kws is None:
+            arg_kws = dict()
+        else:
+            arg_kws = dict(arg_kws)
         if type == flag:
             # flag is a variant of boolean that defines two command
             # line arguments, a positive and a negative one.

--- a/icat/icatcheck.py
+++ b/icat/icatcheck.py
@@ -303,7 +303,7 @@ class ICATChecker(object):
         return tree
 
 
-    def pythonsrc(self, genealogyrules=[(r'','entityBaseBean')], baseclassname='Entity'):
+    def pythonsrc(self, genealogyrules=None, baseclassname='Entity'):
         """Generate Python source code matching the ICAT schema.
 
         Generate source code for a set of classes that match the
@@ -339,6 +339,8 @@ class ICATChecker(object):
             `genealogyrules` is not consistent.
         """
 
+        if genealogyrules is None:
+            genealogyrules = [(r'','entityBaseBean')]
         tree = self._genealogy(genealogyrules)
         base = [t for t in tree if tree[t]['base'] is None][0]
         self.schema[base].classname = baseclassname

--- a/icat/ids.py
+++ b/icat/ids.py
@@ -43,8 +43,9 @@ __all__ = ['DataSelection', 'IDSClient']
 
 class IDSRequest(Request):
 
-    def __init__(self, url, parameters={}, data=None, headers={}, method=None):
+    def __init__(self, url, parameters=None, data=None, method=None):
 
+        headers = {}
         if parameters:
             parameters = urlencode(parameters)
             if method == "POST":

--- a/tests/test_07_entity_sort.py
+++ b/tests/test_07_entity_sort.py
@@ -239,7 +239,7 @@ def test_sortattrs_dependencies(client):
     This test verifies that there are no further circular dependencies
     for sort attributes in the entity object classes.
     """
-    def checkSortDependency(cls, recursionList=[]):
+    def checkSortDependency(cls, recursionList=()):
         """Helper function."""
         if cls.BeanName in recursionList:
             raise RuntimeError("Circular sorting dependency detected: %s" 


### PR DESCRIPTION
Fixes:

- Do not use mutable objects as default parameter value.
- Avoid modifying mutable parameters unless this is the intended behavior.

Both is very bad coding style and may have unexpected side effects.