### PR TITLE
Add documentation for the command line scripts

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -57,7 +57,7 @@ Bug fixes and minor changes
 
 + `#19`_: Review documentation and add tutorial.
 
-+ `#62`_: Minor fixes in the error handling in ``setup.py``.
++ `#62`_: Minor fixes in the error handling in `setup.py`.
 
 Misc
 ----
@@ -103,7 +103,7 @@ Bug fixes and minor changes
 Bug fixes and minor changes
 ---------------------------
 
-+ Issue `#56`_: ``icatdump.py`` fails to include
++ Issue `#56`_: :ref:`icatdump` fails to include
   :attr:`Shift.instrument`.
 
 + Issue `#57`_: :meth:`icat.client.Client.searchChunked` still
@@ -188,7 +188,7 @@ New features
   ids.server 1.9.0.
 
 + `#46`_, `#47`_: Add a :meth:`ìcat.client.Client.autoRefresh` method.
-  The scripts ``icatdump.py`` and ``icatingest.py`` call this method
+  The scripts :ref:`icatdump` and :ref:`icatingest` call this method
   periodically to prevent the session from expiring.
 
 + `#48`_: Add support for an ordering direction qualifier in class
@@ -260,7 +260,7 @@ New features
   login.  The configuration variables for these keys are then adapted
   accordingly.  Note incompatible changes below.
 
-+ Review ``wipeicat.py``.  This was an example script, but is now
++ Review :ref:`wipeicat`.  This was an example script, but is now
   promoted to be a regular utility script that gets installed.
 
 + `#32`_: Add support for using aggregate functions in class
@@ -420,7 +420,7 @@ New features
 Bug fixes and minor changes
 ---------------------------
 
-+ Sort objects in ``icatdump.py`` before writing them to the dump file.
++ Sort objects in :ref:`icatdump` before writing them to the dump file.
   This keeps the order independent from the collation used in the ICAT
   database backend.
 
@@ -429,9 +429,9 @@ Bug fixes and minor changes
   lib.  Keep our own implementation in module :mod:`icat.chunkedhttp`
   only for compatibility with older Python versions.
 
-+ Improved the example script ``wipeicat.py``.
++ Improved the example script :ref:`wipeicat`.
 
-+ Add an example script ``dumprules.py``.
++ Add an example script `dumprules.py`.
 
 + Add missing schema definition for the ICAT XML data file format for
   ICAT 4.7.
@@ -471,16 +471,17 @@ Bug fixes and minor changes
 + `#24`_, `#25`_: test failures caused by different timezone settings
   of the test server.
 
-+ Use a separate module `distutils_pytest`_ for ``setup.py test``.
++ Use a separate module `distutils_pytest`_ to run the tests from
+  `setup.py`.
 
 + :mod:`icat.icatcheck`: move checking of exceptions into a separate
   method :meth:`icat.icatcheck.ICATChecker.checkExceptions`.  Do not
   report exceptions defined in the client, but not found in the
   schema.
 
-+ Many fixes in the example script ``wipeicat.py``.
++ Many fixes in the example script :ref:`wipeicat`.
 
-+ Fix a missing import in the ``icatexport.py`` example script.
++ Fix a missing import in the `icatexport.py` example script.
 
 + Somewhat clearer error messages for some special cases of
   :exc:`icat.exception.SearchAssertionError`.
@@ -535,7 +536,7 @@ Bug fixes and minor changes
 + `#13`_: :meth:`icat.client.Client.searchChunked` raises exception if
   the query contains a percent character.
 
-+ `#15`_: ``icatdump.py`` raises
++ `#15`_: :ref:`icatdump` raises
   :exc:`icat.exception.DataConsistencyError` for
   `DataCollectionParameter`.
 
@@ -574,24 +575,25 @@ Bug fixes and minor changes
 New features
 ------------
 
-+ `#4`_: Extend ``icatrestore.py`` to become a generic ingestion tool.
++ `#4`_: Extend :ref:`icatrestore <icatingest>` to become a generic
+  ingestion tool.
 
-  Rename ``icatrestore.py`` to ``icatingest.py``.
+  Rename :ref:`icatrestore <icatingest>` to :ref:`icatingest`.
 
   Allow referencing of objects by attribute rather then by unique key
-  in the input file for ``icatingest.py`` (only in the XML backend).
+  in the input file for :ref:`icatingest` (only in the XML backend).
 
   Allow adding references to already existing objects in the input
-  file for ``icatingest.py`` (only in the XML backend).
+  file for :ref:`icatingest` (only in the XML backend).
 
   Change the name of the root element in the input file for
-  ``icatingest.py`` (and the output of ``icatdump.py``) from
+  :ref:`icatingest` (and the output of :ref:`icatdump`) from
   `icatdump` to `icatdata` (only in the XML backend).
 
 + Implement upload of Datafiles to IDS rather then only creating the
-  ICAT object from ``icatingest.py``.
+  ICAT object from :ref:`icatingest`.
 
-+ Implement handling of duplicates in ``icatingest.py``.  The same
++ Implement handling of duplicates in :ref:`icatingest`.  The same
   options (`THROW`, `IGNORE`, `CHECK`, and `OVERWRITE`) as in the
   import call in the ICAT restful interface are supported.
 
@@ -622,8 +624,8 @@ Bug fixes and minor changes
 + `#10`_: client.putData: IDSInternalError is raised if
   datafile.datafileCreateTime is set.
 
-+ Ignore import errors from the backend modules in ``icatingest.py`` and
-  ``icatdump.py``.  This means one can use the scripts also if the
++ Ignore import errors from the backend modules in :ref:`icatingest` and
+  :ref:`icatdump`.  This means one can use the scripts also if the
   prerequisites for some backends are not fulfilled, only the
   concerned backends are not available then.
 
@@ -648,7 +650,7 @@ Bug fixes and minor changes
   :class:`icat.entity.Entity`.  Accept any iterable of entities as
   value.
 
-+ `#9`_: ``icatingest.py`` with `duplicate=CHECK` may fail when
++ `#9`_: :ref:`icatingest` with `duplicate=CHECK` may fail when
   attributes are not strings.  Note that this bug was only present in
   an alpha version, but not in any earlier release version.
 
@@ -694,8 +696,8 @@ New features
   path on Windows, add ``/etc/icat`` and ``~/.config/icat`` to the
   path if not on Windows.
 
-+ Add ``icatexport.py`` and ``icatimport.py`` example scripts that use
-  the corresponding calls to the ICAT RESTful interface to dump and
++ Add `icatexport.py` and `icatimport.py` example scripts that use the
+  corresponding calls to the ICAT RESTful interface to dump and
   restore the ICAT content.
 
 + The constructor of :exc:`icat.exception.ICATError` and the
@@ -771,7 +773,7 @@ New features
   expression strings where appropriate.
 
   Numerous examples on how to use this new class can be found in
-  ``querytest.py`` in the examples.
+  `querytest.py` in the examples.
 
 + Add a class method :meth:`icat.entity.Entity.getNaturalOrder` that
   returns a list of attributes suitable to be used in an ORDER BY
@@ -817,17 +819,17 @@ New features
   `http_proxy`, `https_proxy`, and `no_proxy` are set in the
   environment.  [Suggested by Alistair Mills]
 
-+ Rework the dump file backend API for ``icatdump.py`` and
-  ``icatrestore.py``.  As a result, writing custom dump or restore
-  scripts is much cleaner and easier now.
++ Rework the dump file backend API for :ref:`icatdump` and
+  :ref:`icatrestore <icatingest>`.  As a result, writing custom dump
+  or restore scripts is much cleaner and easier now.
 
   This may cause compatibility issues for users who either wrote their
   own dump file backend or for users who wrote custom dump or restore
   scripts, using the XML or YAML backends.  In the first case, compare
   the old XML and YAML backends with the new versions and you'll
   easily see what needs to get adapted.  In the latter case, have a
-  look into the new versions of ``icatdump.py`` and ``icatrestore.py``
-  to see how to use the new backend API.
+  look into the new versions of :ref:`icatdump` and :ref:`icatrestore
+  <icatingest>` to see how to use the new backend API.
 
 + Add method :meth:`icat.client.Client.searchChunked`.
 
@@ -899,10 +901,10 @@ Minor changes and fixes
   the Python command line.  When imported as a regular module, it will
   essentially do nothing.  This avoids errors to occur when imported.
 
-+ ``setup.py`` raises an error with Python 2.6 if python2_6.patch has
++ `setup.py` raises an error with Python 2.6 if python2_6.patch has
   not been applied.
 
-+ Add missing ``MANIFEST.in`` in the source distribution.
++ Add missing `MANIFEST.in` in the source distribution.
 
 + Remove the work around the Suds datetime value bug (setting the
   environment variable TZ to ``UTC``) from :mod:`icat`.  Instead,
@@ -965,7 +967,7 @@ Minor changes and fixes
 
 + Integrate an IDS client in the ICAT client.
 
-+ Improved ``icatdump.py`` and ``icatrestore.py``:
++ Improved :ref:`icatdump` and :ref:`icatrestore <icatingest>`:
 
   - Changed the logical structure of the dump file format which
     significantly simplified the scripts.  Note that old dump files
@@ -1041,11 +1043,12 @@ Minor changes and fixes
   :meth:`icat.client.Client.cleanup`.
 
 + Installation: python-icat requires Python 2.6 or newer.  Raise an
-  error if ``setup.py`` is run by a too old Python version.
+  error if `setup.py` is run by a too old Python version.
 
 + Move some internal routines in a separate module :mod:`icat.helper`.
 
-+ Greatly improved example scripts ``icatdump.py`` and ``icatrestore.py``.
++ Greatly improved example scripts :ref:`icatdump` and
+  :ref:`icatrestore <icatingest>`.
 
 
 0.3.0 (2014-01-10)
@@ -1091,7 +1094,7 @@ Minor changes and fixes
 + Work around a bug in the way SUDS deals with datetime values: set
   the local time zone to ``UTC``.
 
-+ Add example scripts ``icatdump.py`` and ``icatrestore.py``.
++ Add example scripts :ref:`icatdump` and :ref:`icatrestore <icatingest>`.
 
 
 0.2.0 (2013-11-18)

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -55,7 +55,7 @@ Incompatible changes and deprecations
 Bug fixes and minor changes
 ---------------------------
 
-+ `#19`_: Review documentation and add tutorial.
++ `#19`_, `#69`_: Review documentation and add tutorial.
 
 + `#62`_: Minor fixes in the error handling in `setup.py`.
 
@@ -71,6 +71,7 @@ Misc
 .. _#63: https://github.com/icatproject/python-icat/issues/63
 .. _#64: https://github.com/icatproject/python-icat/pull/64
 .. _#65: https://github.com/icatproject/python-icat/pull/65
+.. _#69: https://github.com/icatproject/python-icat/pull/69
 
 
 0.16.0 (2019-09-26)

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -10,6 +10,7 @@ include doc/examples/icatdump.xml
 include doc/examples/icatdump.yaml
 include doc/examples/ingest-*.xml
 include doc/icatdata*.xsd
+include doc/man/*
 include doc/tutorial/*.py
 include tests/conftest.py
 include tests/data/summary*

--- a/Makefile
+++ b/Makefile
@@ -9,11 +9,14 @@ build:
 test:
 	$(PYTHON) setup.py test
 
-sdist:
+sdist: doc-man
 	$(PYTHON) setup.py sdist
 
 doc-html: build
 	$(MAKE) -C doc html PYTHONPATH=$(BUILDLIB)
+
+doc-man: build
+	$(MAKE) -C doc man PYTHONPATH=$(BUILDLIB)
 
 
 clean:

--- a/doc/src/conf.py
+++ b/doc/src/conf.py
@@ -140,8 +140,15 @@ latex_documents = [
 # One entry per manual page. List of tuples
 # (source start file, name, description, authors, manual section).
 man_pages = [
-    (master_doc, project, '%s Documentation' % project,
-     [author], 1)
+    ('icatdump', 'icatdump',
+     'Dump the content of the ICAT to a file',
+     [author], 1),
+    ('icatingest', 'icatingest',
+     'Restore the content of the ICAT from a dump file',
+     [author], 1),
+    ('wipeicat', 'wipeicat',
+     'Delete all content from an ICAT',
+     [author], 1),
 ]
 
 

--- a/doc/src/config.rst
+++ b/doc/src/config.rst
@@ -81,6 +81,8 @@ added.  The main class that client programs interact with is
     :show-inheritance:
 
 
+.. _standard-config-vars:
+
 Predefined configuration variables
 ----------------------------------
 

--- a/doc/src/dumpfile.rst
+++ b/doc/src/dumpfile.rst
@@ -25,6 +25,8 @@ that must implement the abstract methods.
 .. autofunction:: icat.dumpfile.open_dumpfile
 
 
+.. _ICAT-data-files:
+
 ICAT data files
 ---------------
 

--- a/doc/src/icatdump.rst
+++ b/doc/src/icatdump.rst
@@ -1,0 +1,198 @@
+.. _icatdump:
+
+icatdump
+========
+
+
+Synopsis
+~~~~~~~~
+
+**icatdump** [*standard options*] [-o FILE] [-f FORMAT]
+
+
+Description
+~~~~~~~~~~~
+
+.. program:: icatdump
+
+This script queries the content from an ICAT server and serializes
+into a flat file.  The format of that file depends on the backend that
+can be selected with the :option:`--format` option.
+
+
+Options
+~~~~~~~
+
+.. program:: icatdump
+
+The configuration options may be set in the command line or in a
+configuration file (besides :option:`--configfile` and
+:option:`--configsection`).  Some options may also be set in the
+environment.
+
+
+Specific Options
+................
+
+The following options are specific to icatdump:
+
+.. program:: icatdump
+
+.. option:: -o FILE, --outputfile FILE
+
+    Set the output file name.  If the value `-` is used, the output
+    will be written to standard output.  This is also the default.
+
+.. option:: -f FORMAT, --format FORMAT
+
+    Select the backend to use and thus the output file format.  XML
+    and YAML backends are available.
+
+
+Standard Options
+................
+
+The following options needed to connect the ICAT service are common
+for most python-icat scripts:
+
+.. program:: icatdump
+
+.. option:: -h, --help
+
+    Display a help message and exit.
+
+.. option:: -c CONFIGFILE, --configfile CONFIGFILE
+
+    Name of a configuration file.
+
+.. option:: -s SECTION, --configsection SECTION
+
+    Name of a section in the configuration file.  If set, the values
+    in this configuration section will be applied to define other
+    options.
+
+.. option:: -w URL, --url URL
+
+    URL of the ICAT server.  This should point to the web service
+    descriptions.  If the URL has no path component, a default path
+    will be added.
+
+.. option:: --no-check-certificate
+
+    Do not verify the ICAT server's TLS certificate.  This is only
+    relevant if the URL set with :option:`--url` uses HTTPS.  It is
+    mostly only useful for connecting a test server that does not have
+    a trusted certificate.
+
+.. option:: --http-proxy HTTP_PROXY
+
+    Proxy to use for http requests.
+
+.. option:: --https-proxy HTTPS_PROXY
+
+    Proxy to use for https requests.
+
+.. option:: --no-proxy NO_PROXY
+
+    Comma separated list of exclusions for proxy use.
+
+.. option:: -a AUTH, --auth AUTH
+
+    Name of the authentication plugin to use for login to the ICAT
+    server.
+
+.. option:: -u USERNAME, --user USERNAME
+
+    The ICAT user name.
+
+.. option:: -p PASSWORD, --pass PASSWORD
+
+    The user's password.  Will prompt for the password if not set.
+
+.. option:: -P, --prompt-pass
+
+    Prompt for the password.  This is mostly useful to override a
+    password set in the configuration file.
+
+
+Known Issues and Limitations
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+* IDS is not supported: the script only dumps the meta data stored in
+  the ICAT, not the content of the files stored in the IDS.
+
+* The script will only writes objects that the user connecting ICAT
+  has read permissions for.  The script may need to connect as the
+  ICAT root user in order to get the full content.
+
+* The following items are deliberately not included in the output:
+
+  + Log objects (ICAT server versions older then 4.7.0),
+  + The attributes :attr:`~icat.entity.Entity.id`,
+    :attr:`~icat.entity.Entity.createId`,
+    :attr:`~icat.entity.Entity.createTime`,
+    :attr:`~icat.entity.Entity.modId`, and
+    :attr:`~icat.entity.Entity.modTime` of any object.
+
+* It is assumed that for each Dataset `ds` in the ICAT where
+  `ds.sample` is not NULL, the condition `ds.investigation =
+  ds.sample.investigation` holds.  If this is not satisfied, this
+  script will fail with a :exc:`~icat.exception.DataConsistencyError`.
+
+* The partition of the data into chunks is static.  It should rather
+  be dynamic, e.g. chunks should be splitted if the number of objects
+  in them grows too large.
+
+* The content in the ICAT server must not be modified while this
+  script is retrieving it.  Otherwise the script may fail or the
+  dumpfile be inconsistent.
+
+* The script fails if the data contains any `Study` if the ICAT server
+  version is older then 4.6.0.  This is a `bug in icat.server`__.
+
+.. __: https://github.com/icatproject/icat.server/issues/155
+
+
+Environment Variables
+~~~~~~~~~~~~~~~~~~~~~
+
+.. describe:: ICAT_CFG
+
+    Name of a configuration file, see :option:`--configfile`.
+
+.. describe:: ICAT_CFG_SECTION
+
+    Name of a section in the configuration file, see
+    :option:`--configsection`.
+
+.. describe:: ICAT_SERVICE
+
+    URL of the ICAT server, see :option:`--url`.
+
+.. describe:: http_proxy
+
+    Proxy to use for http requests, see :option:`--http-proxy`.
+
+.. describe:: https_proxy
+
+    Proxy to use for https requests, see :option:`--https-proxy`.
+
+.. describe:: no_proxy
+
+    Exclusions for proxy use, see :option:`--no-proxy`.
+
+.. describe:: ICAT_AUTH
+
+    Name of the authentication plugin, see :option:`--auth`.
+
+.. describe:: ICAT_USER
+
+    ICAT user name, see :option:`--user`.
+
+
+See also
+~~~~~~~~
+
+* Section :ref:`ICAT-data-files` on the structure of the dump files.
+* Section :ref:`standard-config-vars` on the standard options.
+* The :ref:`icatingest` script.

--- a/doc/src/icatdump.rst
+++ b/doc/src/icatdump.rst
@@ -26,9 +26,7 @@ Options
 .. program:: icatdump
 
 The configuration options may be set in the command line or in a
-configuration file (besides :option:`--configfile` and
-:option:`--configsection`).  Some options may also be set in the
-environment.
+configuration file.  Some options may also be set in the environment.
 
 
 Specific Options
@@ -193,6 +191,12 @@ Environment Variables
 See also
 ~~~~~~~~
 
-* Section :ref:`ICAT-data-files` on the structure of the dump files.
-* Section :ref:`standard-config-vars` on the standard options.
-* The :ref:`icatingest` script.
+.. only:: not man
+
+    * Section :ref:`ICAT-data-files` on the structure of the dump files.
+    * Section :ref:`standard-config-vars` on the standard options.
+    * The :ref:`icatingest` script.
+
+.. only:: man
+
+    :manpage:`icatingest(1)`

--- a/doc/src/icatingest.rst
+++ b/doc/src/icatingest.rst
@@ -26,9 +26,7 @@ Options
 .. program:: icatingest
 
 The configuration options may be set in the command line or in a
-configuration file (besides :option:`--configfile` and
-:option:`--configsection`).  Some options may also be set in the
-environment.
+configuration file.  Some options may also be set in the environment.
 
 
 Specific Options
@@ -224,6 +222,12 @@ Environment Variables
 See also
 ~~~~~~~~
 
-* Section :ref:`ICAT-data-files` on the structure of the dump files.
-* Section :ref:`standard-config-vars` on the standard options.
-* The :ref:`icatdump` script.
+.. only:: not man
+
+    * Section :ref:`ICAT-data-files` on the structure of the dump files.
+    * Section :ref:`standard-config-vars` on the standard options.
+    * The :ref:`icatdump` script.
+
+.. only:: man
+
+    :manpage:`icatdump(1)`

--- a/doc/src/icatingest.rst
+++ b/doc/src/icatingest.rst
@@ -1,0 +1,229 @@
+.. _icatingest:
+
+icatingest
+==========
+
+
+Synopsis
+~~~~~~~~
+
+**icatingest** [*standard options*] [-i FILE] [-f FORMAT] [--upload-datafiles] [--datafile-dir DATADIR] [--duplicate OPTION]
+
+
+Description
+~~~~~~~~~~~
+
+.. program:: icatingest
+
+This script reads an ICAT data file and creates all objects found in
+an ICAT server.  The format of that file depends on the backend that
+can be selected with the :option:`--format` option.
+
+
+Options
+~~~~~~~
+
+.. program:: icatingest
+
+The configuration options may be set in the command line or in a
+configuration file (besides :option:`--configfile` and
+:option:`--configsection`).  Some options may also be set in the
+environment.
+
+
+Specific Options
+................
+
+The following options are specific to icatingest:
+
+.. program:: icatingest
+
+.. option:: -i FILE, --inputfile FILE
+
+    Set the input file name.  If the value `-` is used, the input will
+    be read from standard input.  This is also the default.
+
+.. option:: -f FORMAT, --format FORMAT
+
+    Select the backend to use and thus the input file format.  XML
+    and YAML backends are available.
+
+.. option:: --upload-datafiles
+
+    If that flag is set, Datafile objects will not be created in the
+    ICAT server directly, but a corresponding file will be uploaded to
+    IDS instead.
+
+.. option:: --datafile-dir DATADIR
+
+    Directory to search for the files to be uploaded to IDS.  This is
+    only relevant if :option:`--upload-datafiles` is set.  The default
+    is the current working directory.
+
+.. option:: --duplicate OPTION
+
+    Set the behavior in the case that any object read from the input
+    already exists in the ICAT server.  Valid options are:
+
+    **THROW**
+        Throw an error.  This is the default.
+
+    **IGNORE**
+        Skip the object read from the input.
+
+    **CHECK**
+        Compare all attributes from the input object with the already
+	existing object in ICAT.  Throw an error of any attribute
+	differs.
+
+    **OVERWRITE**
+        Overwrite the existing object in ICAT, e.g. update it with all
+	attributes set to the values found in the input object.
+
+    If :option:`--upload-datafiles` is set, this option will be
+    ignored for Datafile objects which will then always raise an error
+    if they already exist.
+
+
+Standard Options
+................
+
+The following options needed to connect the ICAT service are common
+for most python-icat scripts:
+
+.. program:: icatingest
+
+.. option:: -h, --help
+
+    Display a help message and exit.
+
+.. option:: -c CONFIGFILE, --configfile CONFIGFILE
+
+    Name of a configuration file.
+
+.. option:: -s SECTION, --configsection SECTION
+
+    Name of a section in the configuration file.  If set, the values
+    in this configuration section will be applied to define other
+    options.
+
+.. option:: -w URL, --url URL
+
+    URL of the ICAT server.  This should point to the web service
+    descriptions.  If the URL has no path component, a default path
+    will be added.
+
+.. option:: --idsurl URL
+
+    URL of the IDS server.  This is only relevant if
+    :option:`--upload-datafiles` is set.  If the URL has no path
+    component, a default path will be added.
+
+.. option:: --no-check-certificate
+
+    Do not verify the ICAT server's TLS certificate.  This is only
+    relevant if the URL set with :option:`--url` or :option:`--idsurl`
+    uses HTTPS.  It is mostly only useful for connecting a test server
+    that does not have a trusted certificate.
+
+.. option:: --http-proxy HTTP_PROXY
+
+    Proxy to use for http requests.
+
+.. option:: --https-proxy HTTPS_PROXY
+
+    Proxy to use for https requests.
+
+.. option:: --no-proxy NO_PROXY
+
+    Comma separated list of exclusions for proxy use.
+
+.. option:: -a AUTH, --auth AUTH
+
+    Name of the authentication plugin to use for login to the ICAT
+    server.
+
+.. option:: -u USERNAME, --user USERNAME
+
+    The ICAT user name.
+
+.. option:: -p PASSWORD, --pass PASSWORD
+
+    The user's password.  Will prompt for the password if not set.
+
+.. option:: -P, --prompt-pass
+
+    Prompt for the password.  This is mostly useful to override a
+    password set in the configuration file.
+
+
+Known Issues and Limitations
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+* The user running this script need to have create permission for all
+  objects in the dump file.  In the generic case of restoring the
+  entire content on an empty ICAT server, the script must be run by
+  the ICAT root user.
+
+* A dump and restore of an ICAT will not preserve the attributes
+  :attr:`~icat.entity.Entity.id`,
+  :attr:`~icat.entity.Entity.createId`,
+  :attr:`~icat.entity.Entity.createTime`,
+  :attr:`~icat.entity.Entity.modId`, and
+  :attr:`~icat.entity.Entity.modTime` of any object.  As a
+  consequence, access rules that are based on the values of these
+  attributes will not work after a restore.
+
+* Dealing with duplicates, see :option:`--duplicate`, is only
+  supported for single objects.  If the object contains embedded
+  related objects in one to many relationships that are to be created
+  at once, the only allowed option to deal with duplicates is THROW.
+
+
+Environment Variables
+~~~~~~~~~~~~~~~~~~~~~
+
+.. describe:: ICAT_CFG
+
+    Name of a configuration file, see :option:`--configfile`.
+
+.. describe:: ICAT_CFG_SECTION
+
+    Name of a section in the configuration file, see
+    :option:`--configsection`.
+
+.. describe:: ICAT_SERVICE
+
+    URL of the ICAT server, see :option:`--url`.
+
+.. describe:: ICAT_DATA_SERVICE
+
+    URL of the IDS server, see :option:`--idsurl`.
+
+.. describe:: http_proxy
+
+    Proxy to use for http requests, see :option:`--http-proxy`.
+
+.. describe:: https_proxy
+
+    Proxy to use for https requests, see :option:`--https-proxy`.
+
+.. describe:: no_proxy
+
+    Exclusions for proxy use, see :option:`--no-proxy`.
+
+.. describe:: ICAT_AUTH
+
+    Name of the authentication plugin, see :option:`--auth`.
+
+.. describe:: ICAT_USER
+
+    ICAT user name, see :option:`--user`.
+
+
+See also
+~~~~~~~~
+
+* Section :ref:`ICAT-data-files` on the structure of the dump files.
+* Section :ref:`standard-config-vars` on the standard options.
+* The :ref:`icatdump` script.

--- a/doc/src/index.rst
+++ b/doc/src/index.rst
@@ -34,6 +34,7 @@ Parts of the documentation
 
    tutorial
    moduleref
+   scripts
    changelog
 
 

--- a/doc/src/scripts.rst
+++ b/doc/src/scripts.rst
@@ -1,0 +1,12 @@
+Command line scripts
+====================
+
+This section provides a reference for the command line scripts that
+are alongside with python-icat.
+
+.. toctree::
+   :maxdepth: 1
+
+   icatdump
+   icatingest
+   wipeicat

--- a/doc/src/wipeicat.rst
+++ b/doc/src/wipeicat.rst
@@ -7,7 +7,7 @@ wipeicat
 Synopsis
 ~~~~~~~~
 
-**wipeicat** [*standard options*]
+**wipeicat** [*options*]
 
 
 Description
@@ -24,15 +24,13 @@ server.  If deleting the Datafiles succeeded, the remaing content is
 deleted from ICAT in palatable chunks.
 
 
-Standard Options
-~~~~~~~~~~~~~~~~
+Options
+~~~~~~~
 
 .. program:: wipeicat
 
 The configuration options may be set in the command line or in a
-configuration file (besides :option:`--configfile` and
-:option:`--configsection`).  Some options may also be set in the
-environment.
+configuration file.  Some options may also be set in the environment.
 
 These options are needed to connect the ICAT service and are common
 for most python-icat scripts.

--- a/doc/src/wipeicat.rst
+++ b/doc/src/wipeicat.rst
@@ -1,0 +1,157 @@
+.. _wipeicat:
+
+wipeicat
+========
+
+
+Synopsis
+~~~~~~~~
+
+**wipeicat** [*standard options*]
+
+
+Description
+~~~~~~~~~~~
+
+.. program:: wipeicat
+
+Delete all content from an ICAT server.
+
+In order to avoid leaving orphan content in the IDS server behind, the
+script first tries to delete all Datafiles having the
+:attr:`~icat.entities.Datafile.location` attribute set from the IDS
+server.  If deleting the Datafiles succeeded, the remaing content is
+deleted from ICAT in palatable chunks.
+
+
+Standard Options
+~~~~~~~~~~~~~~~~
+
+.. program:: wipeicat
+
+The configuration options may be set in the command line or in a
+configuration file (besides :option:`--configfile` and
+:option:`--configsection`).  Some options may also be set in the
+environment.
+
+These options are needed to connect the ICAT service and are common
+for most python-icat scripts.
+
+.. program:: wipeicat
+
+.. option:: -h, --help
+
+    Display a help message and exit.
+
+.. option:: -c CONFIGFILE, --configfile CONFIGFILE
+
+    Name of a configuration file.
+
+.. option:: -s SECTION, --configsection SECTION
+
+    Name of a section in the configuration file.  If set, the values
+    in this configuration section will be applied to define other
+    options.
+
+.. option:: -w URL, --url URL
+
+    URL of the ICAT server.  This should point to the web service
+    descriptions.  If the URL has no path component, a default path
+    will be added.
+
+.. option:: --no-check-certificate
+
+    Do not verify the ICAT server's TLS certificate.  This is only
+    relevant if the URL set with :option:`--url` uses HTTPS.  It is
+    mostly only useful for connecting a test server that does not have
+    a trusted certificate.
+
+.. option:: --http-proxy HTTP_PROXY
+
+    Proxy to use for http requests.
+
+.. option:: --https-proxy HTTPS_PROXY
+
+    Proxy to use for https requests.
+
+.. option:: --no-proxy NO_PROXY
+
+    Comma separated list of exclusions for proxy use.
+
+.. option:: -a AUTH, --auth AUTH
+
+    Name of the authentication plugin to use for login to the ICAT
+    server.
+
+.. option:: -u USERNAME, --user USERNAME
+
+    The ICAT user name.
+
+.. option:: -p PASSWORD, --pass PASSWORD
+
+    The user's password.  Will prompt for the password if not set.
+
+.. option:: -P, --prompt-pass
+
+    Prompt for the password.  This is mostly useful to override a
+    password set in the configuration file.
+
+
+Known Issues with old IDS Versions
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+The recommended version of the IDS server is 1.6.0 or newer.  The
+script does not take any particular measure to work around issues in
+servers older than that.  In particular, the script mail fail or leave
+rubbish behind in the following situations:
+
+* The IDS server is older then 1.6.0 and there is any Dataset with
+  many Datafiles, see `IDS Issue #42`_.
+
+* The IDS server is older then 1.3.0 and restoring of any Dataset
+  takes a significant amount of time, see `IDS Issue #14`_.
+
+The script does however take care not trying to delete any Datafile
+having a NULL :attr:`~icat.entities.Datafile.location` attribute in
+order to work around `IDS Issue #63`_ in IDS server older then 1.9.0.
+
+.. _IDS Issue #14: https://github.com/icatproject/ids.server/issues/14
+.. _IDS Issue #42: https://github.com/icatproject/ids.server/issues/42
+.. _IDS Issue #63: https://github.com/icatproject/ids.server/issues/63
+
+
+Environment Variables
+~~~~~~~~~~~~~~~~~~~~~
+
+.. describe:: ICAT_CFG
+
+    Name of a configuration file, see :option:`--configfile`.
+
+.. describe:: ICAT_CFG_SECTION
+
+    Name of a section in the configuration file, see
+    :option:`--configsection`.
+
+.. describe:: ICAT_SERVICE
+
+    URL of the ICAT server, see :option:`--url`.
+
+.. describe:: http_proxy
+
+    Proxy to use for http requests, see :option:`--http-proxy`.
+
+.. describe:: https_proxy
+
+    Proxy to use for https requests, see :option:`--https-proxy`.
+
+.. describe:: no_proxy
+
+    Exclusions for proxy use, see :option:`--no-proxy`.
+
+.. describe:: ICAT_AUTH
+
+    Name of the authentication plugin, see :option:`--auth`.
+
+.. describe:: ICAT_USER
+
+    ICAT user name, see :option:`--user`.

--- a/icatdump.py
+++ b/icatdump.py
@@ -1,31 +1,6 @@
 #! /usr/bin/python
 #
 # Dump the content of the ICAT to a file or to stdout.
-#
-# The following items are deliberately not included in the output:
-#  + Log objects,
-#  + the attributes id, createId, createTime, modId, and modTime.
-#
-# Known issues and limitations:
-#  + This script requires ICAT 4.3.0 or newer.
-#  + IDS is not supported: the script only dumps the meta data stored
-#    in the ICAT, not the content of the files stored in the IDS.
-#  + It is assumed that for each Dataset ds in the ICAT where
-#    ds.sample is not NULL, the condition
-#    ds.investigation == ds.sample.investigation holds.  If this
-#    is not met, this script will fail with a DataConsistencyError.
-#  + The partition of the data into chunks is static.  It should
-#    rather be dynamic, e.g. chunks should be splitted if the number
-#    of objects in them grows too large.
-#  + The data in the ICAT server must not be modified while this
-#    script is retrieving it.  Otherwise the script may fail or the
-#    dumpfile be inconsistent.  There is not too much that can be done
-#    about this.  A database dump is a snapshot after all.  The
-#    picture will be blurred if the subject is moving while we take
-#    it.
-#  + icatdump fails for Study if ICAT is older then 4.6.0.  This is a
-#    bug in icat.server, see Issue icatproject/icat.server#155.
-#
 
 import logging
 import icat

--- a/icatdump.py
+++ b/icatdump.py
@@ -14,7 +14,7 @@
 #    ds.sample is not NULL, the condition
 #    ds.investigation == ds.sample.investigation holds.  If this
 #    is not met, this script will fail with a DataConsistencyError.
-#  + The partition of the data into chunks ist static.  It should
+#  + The partition of the data into chunks is static.  It should
 #    rather be dynamic, e.g. chunks should be splitted if the number
 #    of objects in them grows too large.
 #  + The data in the ICAT server must not be modified while this

--- a/icatdump.py
+++ b/icatdump.py
@@ -50,7 +50,7 @@ formats = icat.dumpfile.Backends.keys()
 if len(formats) == 0:
     raise RuntimeError("No datafile backends available.")
 
-config = icat.config.Config()
+config = icat.config.Config(ids=False)
 config.add_variable('file', ("-o", "--outputfile"), 
                     dict(help="output file name or '-' for stdout"),
                     default='-')

--- a/icatingest.py
+++ b/icatingest.py
@@ -2,26 +2,6 @@
 #
 # Restore the content of the ICAT from a dump file as created by
 # icatdump.py.
-#
-# Known issues and limitations:
-#  + The user running this script need to have create permission for
-#    all objects in the dump file.  Appropriate rules must either
-#    already been set up at the ICAT server or must be contained in
-#    the dump file.  In the latter case, the rules and corresponding
-#    user and group objects must be in the first chunk (see below) of
-#    the file.  In the generic case of restoring the entire content on
-#    an empty ICAT server, the script must be run by the ICAT root
-#    user.
-#  + This script requires ICAT 4.3.0 or newer.
-#  + A dump and restore of an ICAT will not preserve the attributes
-#    id, createId, createTime, modId, and modTime of any objects.
-#    This is by design and cannot be fixed.  As a consequence, access
-#    rules that are based on object ids will not work after a restore.
-#  + Dealing with duplicates (option --duplicate) is only supported
-#    for single objects.  If the object contains related objects in
-#    one to many relationships that are to be created at once, the
-#    only allowed option to deal with duplicates is THROW.
-#
 
 import os.path
 import logging

--- a/python-icat.spec
+++ b/python-icat.spec
@@ -72,6 +72,18 @@ $long_description
 This package contains example scripts.
 
 
+%package man
+Summary:	Python interface to ICAT and IDS
+Group:		Documentation/Other
+Requires:	%{name} = %{version}
+Requires:	man
+
+%description man
+$long_description
+
+This package contains the manual pages for the command line scripts.
+
+
 %if 0%{?python2_enable}
 %package -n python%{python2_pkgversion}-icat
 Summary:	Python interface to ICAT and IDS
@@ -81,6 +93,7 @@ Requires:	python-argparse
 Requires:	%{name} = %{version}
 Requires:	python%{python2_pkgversion}-suds
 %if 0%{?suse_version}
+Recommends:	%{name}-man
 Recommends:	python%{python2_pkgversion}-PyYAML
 Recommends:	python%{python2_pkgversion}-lxml
 %endif
@@ -100,6 +113,7 @@ Summary:	Python interface to ICAT and IDS
 Requires:	%{name} = %{version}
 Requires:	python%{python3_pkgversion}-suds
 %if 0%{?suse_version}
+Recommends:	%{name}-man
 Recommends:	python%{python3_pkgversion}-PyYAML
 Recommends:	python%{python3_pkgversion}-lxml
 %endif
@@ -161,6 +175,9 @@ do
     mv %{buildroot}%{_bindir}/$$f %{buildroot}%{_bindir}/$$f-%{python2_version}
 done
 %endif
+
+%__install -d -m 755 %{buildroot}%{_mandir}/man1
+%__cp -p doc/man/*.1 %{buildroot}%{_mandir}/man1
 
 %__install -d -m 755 %{buildroot}%{_docdir}/%{name}
 %__cp -pr README.rst CHANGES.rst doc/* %{buildroot}%{_docdir}/%{name}
@@ -241,6 +258,10 @@ rm -rf %{buildroot}
 %dir %{_docdir}/%{name}
 %doc %{_docdir}/%{name}/examples
 %doc %{_docdir}/%{name}/tutorial
+
+%files man
+%defattr(-,root,root)
+%{_mandir}/man1/*
 
 %if 0%{?python2_enable}
 %files -n python%{python2_pkgversion}-icat

--- a/wipeicat.py
+++ b/wipeicat.py
@@ -4,19 +4,6 @@
 #
 # This is surprisingly involved to do it reliably.  See the comments
 # below for the issues that need to be taken into account.
-#
-# This script uses the JPQL syntax for searching in the ICAT.  It thus
-# requires icat.server version 4.3.0 or greater.
-#
-# The recommended version of ids.server is 1.6.0 or greater.  The
-# script does not take any particular measure to work around issues
-# in ids.server older than that.  In particular, the script mail fail
-# or leave rubbish behind in the following situations:
-# - ids.server is older then 1.6.0 and there is any dataset with many
-#   datafiles, Issue icatproject/ids.server#42.
-# - ids.server is older then 1.3.0 and restoring of any dataset takes a
-#   significant amount of time, Issue icatproject/ids.server#14.
-#
 
 import time
 import logging


### PR DESCRIPTION
Add documentation for the command line scripts `icatdump`, `icatingest`, and `wipeicat`.  This also includes man pages.