### PR TITLE
Add pathlib support

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -8,11 +8,26 @@ Changelog
 New features
 ------------
 
++ `#66`_, `#75`_: Add pathlib support: methods that take a file name
+  argument also accept a :class:`pathlib.Path` object. Internal
+  representation of filesystem paths are changed to use
+  :class:`pathlib.Path` where appropriate.  The predefined
+  configuarion variable `configFile` now supports tilde expansion.
+  Note incompatible changes below.
+
 + `#74`_: :class:`icat.ids.DataSelection` also accepts
   `DataCollection` as argument.
 
 Incompatible changes and deprecations
 -------------------------------------
+
++ As a consequence of switching to pathlib for filesystem paths some
+  return values and variables are now :class:`pathlib.Path` objects
+  rather then :class:`str`.  This affects:
+
+  - the return value of :func:`icat.config.cfgpath`,
+  - the predefined configuarion variable `configFile`,
+  - the module variable :data:`icat.config.cfgdirs`.
 
 + Drop support for Python 2 and Python 3.3.
 
@@ -39,7 +54,9 @@ Bug fixes and minor changes
 
 + Some (more) example scripts now require ICAT 4.4.0 or newer.
 
+.. _#66: https://github.com/icatproject/python-icat/issues/66
 .. _#74: https://github.com/icatproject/python-icat/issues/74
+.. _#75: https://github.com/icatproject/python-icat/pull/75
 
 
 0.17.0 (2020-04-30)

--- a/doc/examples/addfile.py
+++ b/doc/examples/addfile.py
@@ -22,7 +22,7 @@
 #
 
 import logging
-import os.path
+from pathlib import Path
 import icat
 import icat.config
 
@@ -37,8 +37,9 @@ config.add_variable('dataset', ("dataset",),
 config.add_variable('datafileformat', ("datafileformat",), 
                     dict(help="name and optionally version "
                          "(separated by a colon) of the datafile format"))
-config.add_variable('files', ("files",), 
-                    dict(help="name of the files to upload", nargs="+"))
+config.add_variable('files', ("files",),
+                    dict(help="name of the files to upload", nargs="+"),
+                    type=lambda l: [Path(f) for f in l])
 client, conf = config.getconfig()
 client.login(conf.auth, conf.credentials)
 
@@ -87,7 +88,7 @@ datafileformat = getdatafileformat(conf.datafileformat)
 # ------------------------------------------------------------
 
 for fname in conf.files:
-    datafile = client.new("datafile", name=os.path.basename(fname), 
+    datafile = client.new("datafile", name=fname.name,
                           dataset=dataset, datafileFormat=datafileformat)
     client.putData(fname, datafile)
 

--- a/doc/src/config.rst
+++ b/doc/src/config.rst
@@ -93,8 +93,9 @@ set of configuration variables that an ICAT client typically needs:
     Paths of the configuration files to read.  The default is a list
     of standard paths that depends on the operating system.  If a
     value is provided, it must be a single path.  The value that is
-    set in this variable after configuration is a list of the file
-    paths that have successfully been read.
+    set in this variable after configuration is a list of
+    :class:`~pathlib.Path` objects of the files that have successfully
+    been read.
 
   `configSection`
     Name of the section in the configuration file to apply.  If

--- a/icat/config.py
+++ b/icat/config.py
@@ -306,14 +306,14 @@ class ConfigSourceFile(ConfigSource):
 
     def read(self, filename):
         if filename:
-            readfile = self.confparser.read(filename)
+            readfile = self.confparser.read(str(filename))
             if not readfile:
                 raise ConfigError("Could not read config file '%s'." % filename)
         elif filename is None:
             readfile = self.confparser.read(self.defaultFiles)
         else:
-            readfile = filename
-        return readfile
+            readfile = []
+        return [Path(p) for p in readfile]
 
     def setsection(self, section):
         if section and not self.confparser.has_section(section):
@@ -700,7 +700,7 @@ class Config(BaseConfig):
         """
         var = self.add_variable('configFile', ("-c", "--configfile"), 
                                 dict(help="config file"),
-                                envvar='ICAT_CFG', optional=True)
+                                envvar='ICAT_CFG', optional=True, type=Path)
         var.postprocess = _post_configFile
         var = self.add_variable('configSection', ("-s", "--configsection"), 
                                 dict(help="section in the config file", 

--- a/icat/config.py
+++ b/icat/config.py
@@ -14,6 +14,14 @@ from icat.exception import ConfigError, VersionMethodError
 
 __all__ = ['boolean', 'flag', 'Configuration', 'Config']
 
+# Evil hack: Path.expanduser() has been added in Python 3.5.
+# Monkeypatch the class for older Python versions.
+if not hasattr(Path, "expanduser"):
+    import os.path
+    def _expanduser(p):
+        return Path(os.path.expanduser(str(p)))
+    Path.expanduser = _expanduser
+
 
 if sys.platform.startswith("win"):
     cfgdirs = [ Path(os.environ['ProgramData'], "ICAT"),

--- a/icat/config.py
+++ b/icat/config.py
@@ -700,7 +700,8 @@ class Config(BaseConfig):
         """
         var = self.add_variable('configFile', ("-c", "--configfile"), 
                                 dict(help="config file"),
-                                envvar='ICAT_CFG', optional=True, type=Path)
+                                envvar='ICAT_CFG', optional=True,
+                                type=lambda f: Path(f).expanduser())
         var.postprocess = _post_configFile
         var = self.add_variable('configSection', ("-s", "--configsection"), 
                                 dict(help="section in the config file", 

--- a/icat/dumpfile.py
+++ b/icat/dumpfile.py
@@ -68,7 +68,12 @@ class DumpFileReader():
     :param infile: the data source to read the objects from.  It
         depends on the backend which kind of data source they accept.
         Most backends will at least accept a file object opened for
-        reading or a :class:`str` with a file name.
+        reading or a :class:`~pathlib.Path` or a :class:`str` with a
+        file name.
+
+    .. versionchanged:: 1.0.0
+        The `infile` parameter also accepts a :class:`~pathlib.Path`
+        object.
     """
 
     mode = "r"
@@ -81,17 +86,19 @@ class DumpFileReader():
     def __init__(self, client, infile):
         self.client = client
         self._closefile = False
-        if isinstance(infile, str):
+        if hasattr(infile, 'open') or isinstance(infile, str):
             self.infile = self._file_open(infile)
             self._closefile = True
         else:
             self.infile = infile
 
-    def _file_open(self, filename):
-        if filename == "-":
+    def _file_open(self, infile):
+        if hasattr(infile, 'open'):
+            return infile.open(mode=self.mode)
+        elif infile == "-":
             return sys.stdin
         else:
-            return open(filename, self.mode)
+            return open(infile, self.mode)
 
     def __enter__(self):
         return self
@@ -157,7 +164,11 @@ class DumpFileWriter():
     :param outfile: the data file to write the objects to.  It depends
         on the backend what they accept here.  Most backends will at
         least accept a file object opened for writing or a
-        :class:`str` with a file name.
+        :class:`~pathlib.Path` or a :class:`str` with a file name.
+
+    .. versionchanged:: 1.0.0
+        The `outfile` parameter also accepts a :class:`~pathlib.Path`
+        object.
     """
 
     mode = "w"
@@ -170,18 +181,20 @@ class DumpFileWriter():
     def __init__(self, client, outfile):
         self.client = client
         self._closefile = False
-        if isinstance(outfile, str):
+        if hasattr(outfile, 'open') or isinstance(outfile, str):
             self.outfile = self._file_open(outfile)
             self._closefile = True
         else:
             self.outfile = outfile
         self.idcounter = {}
 
-    def _file_open(self, filename):
-        if filename == "-":
+    def _file_open(self, outfile):
+        if hasattr(outfile, 'open'):
+            return outfile.open(mode=self.mode)
+        elif outfile == "-":
             return sys.stdout
         else:
-            return open(filename, self.mode)
+            return open(outfile, self.mode)
 
     def __enter__(self):
         self.head()

--- a/icat/dumpfile_xml.py
+++ b/icat/dumpfile_xml.py
@@ -49,14 +49,14 @@ class XMLDumpFileReader(icat.dumpfile.DumpFileReader):
         else:
             self.getdata = self.getdata_file
 
-    def _file_open(self, filename):
-        if filename == "-":
+    def _file_open(self, infile):
+        if infile == "-":
             # lxml requires binary mode
             f = os.fdopen(os.dup(sys.stdin.fileno()), self.mode)
             sys.stdin.close()
             return f
         else:
-            return open(filename, self.mode)
+            return super()._file_open(infile)
 
     def _searchByReference(self, element, objtype, objindex):
         """Search for a referenced object.
@@ -154,14 +154,14 @@ class XMLDumpFileWriter(icat.dumpfile.DumpFileWriter):
         super().__init__(client, outfile)
         self.data = etree.Element("data")
 
-    def _file_open(self, filename):
-        if filename == "-":
+    def _file_open(self, outfile):
+        if outfile == "-":
             # lxml requires binary mode
             f = os.fdopen(os.dup(sys.stdout.fileno()), self.mode)
             sys.stdout.close()
             return f
         else:
-            return open(filename, self.mode)
+            return super()._file_open(outfile)
 
     def _entity2elem(self, obj, tag, keyindex):
         """Convert an entity object to an etree.Element."""

--- a/icatdump.py
+++ b/icatdump.py
@@ -3,6 +3,7 @@
 # Dump the content of the ICAT to a file or to stdout.
 
 import logging
+from pathlib import Path
 import icat
 import icat.config
 from icat.dump_queries import *
@@ -24,10 +25,16 @@ formats = icat.dumpfile.Backends.keys()
 if len(formats) == 0:
     raise RuntimeError("No datafile backends available.")
 
+def getPath(f):
+    if f == '-':
+        return f
+    else:
+        return Path(f).expanduser()
+
 config = icat.config.Config(ids=False)
 config.add_variable('file', ("-o", "--outputfile"), 
                     dict(help="output file name or '-' for stdout"),
-                    default='-')
+                    type=getPath, default='-')
 config.add_variable('format', ("-f", "--format"), 
                     dict(help="output file format", choices=formats),
                     default='YAML')

--- a/icatingest.py
+++ b/icatingest.py
@@ -4,7 +4,7 @@
 # icatdump.py.
 
 import logging
-import os.path
+from pathlib import Path
 import icat
 import icat.config
 from icat.dumpfile import open_dumpfile
@@ -38,7 +38,7 @@ config.add_variable('uploadDatafiles', ("--upload-datafiles",),
                     type=icat.config.flag, default=False)
 config.add_variable('dataDir', ("--datafile-dir",), 
                     dict(help="datafile directory"),
-                    default='.')
+                    type=Path, default='.')
 config.add_variable('duplicate', ("--duplicate",), 
                     dict(help="behavior in case of duplicate objects",
                          choices=["THROW", "IGNORE", "CHECK", "OVERWRITE"]), 
@@ -49,7 +49,7 @@ if conf.uploadDatafiles:
     if conf.idsurl is None:
         raise icat.ConfigError("Config option 'idsurl' not given, "
                                "but required for uploadDatafiles.")
-    conf.dataDir = os.path.abspath(conf.dataDir)
+    conf.dataDir = conf.dataDir.resolve()
 
 if client.apiversion < '4.3.0':
     raise RuntimeError("Sorry, ICAT version %s is too old, need 4.3.0 or newer."
@@ -86,7 +86,7 @@ def check_duplicate(obj):
 with open_dumpfile(client, conf.file, conf.format, 'r') as dumpfile:
     for obj in dumpfile.getobjs():
         if conf.uploadDatafiles and obj.BeanName == "Datafile":
-            fname = os.path.join(conf.dataDir, obj.name)
+            fname = conf.dataDir / obj.name
             client.putData(fname, obj)
         else:
             try:

--- a/icatingest.py
+++ b/icatingest.py
@@ -26,10 +26,16 @@ formats = icat.dumpfile.Backends.keys()
 if len(formats) == 0:
     raise RuntimeError("No datafile backends available.")
 
+def getPath(f):
+    if f == '-':
+        return f
+    else:
+        return Path(f).expanduser()
+
 config = icat.config.Config(ids="optional")
 config.add_variable('file', ("-i", "--inputfile"), 
                     dict(help="input file name or '-' for stdin"),
-                    default='-')
+                    type=getPath, default='-')
 config.add_variable('format', ("-f", "--format"), 
                     dict(help="input file format", choices=formats),
                     default='YAML')
@@ -38,7 +44,7 @@ config.add_variable('uploadDatafiles', ("--upload-datafiles",),
                     type=icat.config.flag, default=False)
 config.add_variable('dataDir', ("--datafile-dir",), 
                     dict(help="datafile directory"),
-                    type=Path, default='.')
+                    type=lambda f: Path(f).expanduser(), default='.')
 config.add_variable('duplicate', ("--duplicate",), 
                     dict(help="behavior in case of duplicate objects",
                          choices=["THROW", "IGNORE", "CHECK", "OVERWRITE"]), 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -89,7 +89,7 @@ def getConfig(confSection="root", **confArgs):
     try:
         confArgs['args'] = ["-c", str(confFile), "-s", confSection]
         client, conf = icat.config.Config(**confArgs).getconfig()
-        conf.cmdargs = ["-c", conf.configFile[0], "-s", conf.configSection]
+        conf.cmdargs = ["-c", str(conf.configFile[0]), "-s", conf.configSection]
         return (client, conf)
     except icat.ConfigError as err:
         _skip(str(err))

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -6,7 +6,7 @@ from distutils.version import StrictVersion as Version
 import locale
 import logging
 import os
-import os.path
+from pathlib import Path
 from random import getrandbits
 import re
 import shutil
@@ -38,7 +38,7 @@ logging.basicConfig(level=logging.INFO)
 logging.getLogger('suds.client').setLevel(logging.CRITICAL)
 logging.getLogger('suds').setLevel(logging.ERROR)
 
-testdir = os.path.dirname(__file__)
+testdir = Path(__file__).resolve().parent
 
 
 def _skip(reason):
@@ -57,10 +57,10 @@ class DummyDatafile():
         if date is not None:
             date = (date, date)
         self.name = name
-        self.fname = os.path.join(directory, name)
+        self.fname = directory / name
         chunksize = 8192
         crc32 = 0
-        with open(self.fname, 'wb') as f:
+        with self.fname.open('wb') as f:
             while size > 0:
                 if chunksize > size:
                     chunksize = size
@@ -69,9 +69,9 @@ class DummyDatafile():
                 crc32 = zlib.crc32(chunk, crc32)
                 f.write(chunk)
         if date:
-            os.utime(self.fname, date)
+            os.utime(str(self.fname), date)
         self.crc32 = "%x" % (crc32 & 0xffffffff)
-        self.stat = os.stat(self.fname)
+        self.stat = self.fname.stat()
         self.size = self.stat.st_size
         if UtcTimezone:
             mtime = int(self.stat.st_mtime)
@@ -83,11 +83,11 @@ class DummyDatafile():
 def getConfig(confSection="root", **confArgs):
     """Get the configuration, skip on ConfigError.
     """
-    confFile = os.path.join(testdir, "data", "icat.cfg")
-    if not os.path.isfile(confFile):
+    confFile = testdir / "data" / "icat.cfg"
+    if not confFile.is_file():
         _skip("no test ICAT server configured")
     try:
-        confArgs['args'] = ["-c", confFile, "-s", confSection]
+        confArgs['args'] = ["-c", str(confFile), "-s", confSection]
         client, conf = icat.config.Config(**confArgs).getconfig()
         conf.cmdargs = ["-c", conf.configFile[0], "-s", conf.configSection]
         return (client, conf)
@@ -122,8 +122,8 @@ class tmpClient:
 
 
 def gettestdata(fname):
-    fname = os.path.join(testdir, "data", fname)
-    assert os.path.isfile(fname)
+    fname = testdir / "data" / fname
+    assert fname.is_file()
     return fname
 
 
@@ -157,8 +157,8 @@ def get_reference_dumpfile(ext = "yaml"):
 
 
 def callscript(scriptname, args, stdin=None, stdout=None, stderr=None):
-    script = os.path.join(testdir, "scripts", scriptname)
-    cmd = [sys.executable, script] + args
+    script = testdir / "scripts" / scriptname
+    cmd = [sys.executable, str(script)] + args
     print("\n>", *cmd)
     subprocess.check_call(cmd, stdin=stdin, stdout=stdout, stderr=stderr)
 
@@ -177,7 +177,7 @@ def filter_file(infile, outfile, pattern, repl):
     call.  Such as the header of a dump file that contains date and
     ICAT version.
     """
-    with open(infile, 'rt') as inf, open(outfile, 'wt') as outf:
+    with infile.open('rt') as inf, outfile.open('wt') as outf:
         while True:
             l = inf.readline()
             if not l:
@@ -195,7 +195,7 @@ def filter_file(infile, outfile, pattern, repl):
 @pytest.fixture(scope="session")
 def tmpdirsec(request):
     tmpdir = tempfile.mkdtemp(prefix="python-icat-test-")
-    yield tmpdir
+    yield Path(tmpdir)
     shutil.rmtree(tmpdir)
 
 
@@ -209,7 +209,7 @@ def standardCmdArgs():
 def setupicat(standardCmdArgs):
     testcontent = get_reference_dumpfile()
     callscript("wipeicat.py", standardCmdArgs)
-    args = standardCmdArgs + ["-f", "YAML", "-i", testcontent]
+    args = standardCmdArgs + ["-f", "YAML", "-i", str(testcontent)]
     callscript("icatingest.py", args)
 
 # ============================= hooks ================================
@@ -217,7 +217,7 @@ def setupicat(standardCmdArgs):
 def pytest_report_header(config):
     """Add information on the icat package used in the tests.
     """
-    modpath = os.path.dirname(os.path.abspath(icat.__file__))
+    modpath = Path(icat.__file__).resolve().parent
     if icat_version > "0.0":
         icatserver = icat_version
     else:

--- a/tests/test_01_config.py
+++ b/tests/test_01_config.py
@@ -125,14 +125,13 @@ class TmpFiles():
         for p in self.files:
             p.unlink()
     def addfile(self, path, content):
-        path = path.resolve()
         try:
             path.parent.mkdir(parents=True)
         except FileExistsError:
             pass
         with path.open("wt") as f:
             f.write(content)
-        self.files.append(path)
+        self.files.append(path.resolve())
 
 @pytest.fixture(scope="module")
 def tmpconfigfile(tmpdirsec):

--- a/tests/test_01_config.py
+++ b/tests/test_01_config.py
@@ -102,7 +102,7 @@ promptPass = Yes
 
 class ConfigFile():
     def __init__(self, confdir, content):
-        self._home = Path(confdir)
+        self._home = confdir
         self._dir = self._home / ".icat"
         self._path = self._dir / "icat.cfg"
         self._dir.mkdir()

--- a/tests/test_01_config.py
+++ b/tests/test_01_config.py
@@ -102,21 +102,12 @@ promptPass = Yes
 
 class ConfigFile():
     def __init__(self, confdir, content):
-        self._home = confdir
-        self._dir = self._home / ".icat"
-        self._path = self._dir / "icat.cfg"
-        self._dir.mkdir()
-        with self._path.open("wt") as f:
+        self.home = confdir
+        self.dir = self.home / ".icat"
+        self.path = self.dir / "icat.cfg"
+        self.dir.mkdir()
+        with self.path.open("wt") as f:
             f.write(content)
-    @property
-    def home(self):
-        return str(self._home)
-    @property
-    def dir(self):
-        return str(self._dir)
-    @property
-    def path(self):
-        return str(self._path)
 
 class TmpFiles():
     def __init__(self):
@@ -179,15 +170,15 @@ def test_config_minimal_file(fakeClient, tmpconfigfile, monkeypatch):
 
     # Let the config file be found in the default location, but
     # manipulate the search path such that only the cwd exists.
-    cfgdirs = [ Path(tmpconfigfile.dir, "wobble"), Path(".") ]
+    cfgdirs = [ tmpconfigfile.dir / "wobble", Path(".") ]
     monkeypatch.setattr(icat.config, "cfgdirs", cfgdirs)
-    monkeypatch.chdir(tmpconfigfile.dir)
+    monkeypatch.chdir(str(tmpconfigfile.dir))
 
     args = ["-s", "example_root"]
     config = icat.config.Config(needlogin=False, ids=False, args=args)
     _, conf = config.getconfig()
 
-    ex = ExpectedConf(configFile=["icat.cfg"],
+    ex = ExpectedConf(configFile=[Path("icat.cfg")],
                       configSection="example_root", 
                       url=ex_icat)
     assert ex <= conf
@@ -202,12 +193,12 @@ def test_config_minimal_defaultfile(fakeClient, tmpconfigfile, monkeypatch):
     """
 
     # Manipulate the default search path.
-    monkeypatch.setenv("HOME", tmpconfigfile.home)
+    monkeypatch.setenv("HOME", str(tmpconfigfile.home))
     cfgdirs = [ Path("~/.config/icat").expanduser(),
                 Path("~/.icat").expanduser(),
                 Path("."), ]
     monkeypatch.setattr(icat.config, "cfgdirs", cfgdirs)
-    monkeypatch.chdir(tmpconfigfile.home)
+    monkeypatch.chdir(str(tmpconfigfile.home))
 
     args = ["-s", "example_root"]
     config = icat.config.Config(needlogin=False, ids=False, args=args)
@@ -230,12 +221,12 @@ def test_config_no_defaultvars(tmpconfigfile, monkeypatch):
     """
 
     # Manipulate the default search path.
-    monkeypatch.setenv("HOME", tmpconfigfile.home)
+    monkeypatch.setenv("HOME", str(tmpconfigfile.home))
     cfgdirs = [ Path("~/.config/icat").expanduser(),
                 Path("~/.icat").expanduser(),
                 Path("."), ]
     monkeypatch.setattr(icat.config, "cfgdirs", cfgdirs)
-    monkeypatch.chdir(tmpconfigfile.home)
+    monkeypatch.chdir(str(tmpconfigfile.home))
 
     args = ["-s", "example_root"]
     config = icat.config.Config(defaultvars=False, args=args)
@@ -259,7 +250,7 @@ def test_config_simple_login(fakeClient, tmpconfigfile):
     Standard usage, read everything from a config file.
     """
 
-    args = ["-c", tmpconfigfile.path, "-s", "example_root"]
+    args = ["-c", str(tmpconfigfile.path), "-s", "example_root"]
     _, conf = icat.config.Config(args=args).getconfig()
 
     ex = ExpectedConf(configFile=[tmpconfigfile.path],
@@ -280,7 +271,7 @@ def test_config_override(fakeClient, tmpconfigfile):
     with command line arguments.
     """
 
-    args = ["-c", tmpconfigfile.path, "-s", "example_root", 
+    args = ["-c", str(tmpconfigfile.path), "-s", "example_root",
             "-a", "db", "-u", "rbeck", "-p", "geheim"]
     _, conf = icat.config.Config(args=args).getconfig()
 
@@ -307,7 +298,7 @@ def test_config_askpass(fakeClient, tmpconfigfile, monkeypatch):
         return "mockpass"
     monkeypatch.setattr(getpass, "getpass", mockgetpass)
 
-    args = ["-c", tmpconfigfile.path, "-s", "example_root", 
+    args = ["-c", str(tmpconfigfile.path), "-s", "example_root",
             "-a", "db", "-u", "rbeck"]
     _, conf = icat.config.Config(args=args).getconfig()
 
@@ -336,7 +327,7 @@ def test_config_nopass_askpass(fakeClient, tmpconfigfile, monkeypatch):
         return "mockpass"
     monkeypatch.setattr(getpass, "getpass", mockgetpass)
 
-    args = ["-c", tmpconfigfile.path, "-s", "example_nbour", "-P"]
+    args = ["-c", str(tmpconfigfile.path), "-s", "example_nbour", "-P"]
     _, conf = icat.config.Config(args=args).getconfig()
 
     ex = ExpectedConf(configFile=[tmpconfigfile.path],
@@ -360,7 +351,7 @@ def test_config_askpass_file(fakeClient, tmpconfigfile, monkeypatch):
         return "mockpass"
     monkeypatch.setattr(getpass, "getpass", mockgetpass)
 
-    args = ["-c", tmpconfigfile.path, "-s", "test21"]
+    args = ["-c", str(tmpconfigfile.path), "-s", "test21"]
     _, conf = icat.config.Config(args=args).getconfig()
 
     ex = ExpectedConf(configFile=[tmpconfigfile.path],
@@ -378,7 +369,7 @@ def test_config_environment(fakeClient, tmpconfigfile, monkeypatch):
     """Set some config variables from the environment.
     """
 
-    monkeypatch.setenv("ICAT_CFG", tmpconfigfile.path)
+    monkeypatch.setenv("ICAT_CFG", str(tmpconfigfile.path))
     monkeypatch.setenv("ICAT_AUTH", "db")
     monkeypatch.setenv("http_proxy", "http://www-cache.example.org:3128/")
     monkeypatch.setenv("https_proxy", "http://www-cache.example.org:3128/")
@@ -430,7 +421,7 @@ def test_config_ids(fakeClient, tmpconfigfile, section, ex):
     # We set ids="optional", the idsurl is present in section
     # example_root, but not in example_jdoe.  In the latter case, the
     # configuration variable is present, but set to None..
-    args = ["-c", tmpconfigfile.path, "-s", section]
+    args = ["-c", str(tmpconfigfile.path), "-s", section]
     _, conf = icat.config.Config(ids="optional", args=args).getconfig()
     assert ex <= conf
 
@@ -441,7 +432,7 @@ def test_config_custom_var(fakeClient, tmpconfigfile):
 
     # Note that ldap_filter is not defined in the configuration file,
     # but we have a default value defined here, so this is ok.
-    args = ["-c", tmpconfigfile.path, "-s", "example_root"]
+    args = ["-c", str(tmpconfigfile.path), "-s", "example_root"]
     config = icat.config.Config(args=args)
     config.add_variable('ldap_uri', ("-l", "--ldap-uri"), 
                         dict(help="URL of the LDAP server"),
@@ -475,7 +466,7 @@ def test_config_subst_nosubst(fakeClient, tmpconfigfile):
     But disable the substitution.
     """
 
-    args = ["-c", tmpconfigfile.path, "-s", "example_jdoe"]
+    args = ["-c", str(tmpconfigfile.path), "-s", "example_jdoe"]
     config = icat.config.Config(args=args)
     config.add_variable('greeting', ("--greeting",), 
                         dict(help="Greeting message"),
@@ -500,7 +491,7 @@ def test_config_subst(fakeClient, tmpconfigfile):
     Same as above, but enable the substitution this time.
     """
 
-    args = ["-c", tmpconfigfile.path, "-s", "example_jdoe"]
+    args = ["-c", str(tmpconfigfile.path), "-s", "example_jdoe"]
     config = icat.config.Config(args=args)
     config.add_variable('greeting', ("--greeting",), 
                         dict(help="Greeting message"),
@@ -526,7 +517,7 @@ def test_config_subst_cmdline(fakeClient, tmpconfigfile):
     line.
     """
 
-    args = ["-c", tmpconfigfile.path, "-s", "example_jdoe", 
+    args = ["-c", str(tmpconfigfile.path), "-s", "example_jdoe",
             "-u", "jonny", "-p", "pass"]
     config = icat.config.Config(args=args)
     config.add_variable('greeting', ("--greeting",), 
@@ -550,7 +541,7 @@ def test_config_type_int(fakeClient, tmpconfigfile):
     """Read an integer variable from the configuration file.
     """
 
-    args = ["-c", tmpconfigfile.path, "-s", "example_jdoe"]
+    args = ["-c", str(tmpconfigfile.path), "-s", "example_jdoe"]
     config = icat.config.Config(needlogin=False, args=args)
     config.add_variable('num', ("--num",), 
                         dict(help="Integer variable"), type=int)
@@ -569,7 +560,7 @@ def test_config_type_int_err(fakeClient, tmpconfigfile):
     Same as last one, but have an invalid value this time.
     """
 
-    args = ["-c", tmpconfigfile.path, "-s", "example_jdoe"]
+    args = ["-c", str(tmpconfigfile.path), "-s", "example_jdoe"]
     config = icat.config.Config(needlogin=False, args=args)
     config.add_variable('invnum', ("--invnum",), 
                         dict(help="Integer variable"), type=int)
@@ -593,7 +584,7 @@ def test_config_type_int_err(fakeClient, tmpconfigfile):
 def test_config_type_boolean(fakeClient, tmpconfigfile, flags, ex):
     """Test a boolean configuration variable.
     """
-    args = ["-c", tmpconfigfile.path, "-s", "example_jdoe"] + flags
+    args = ["-c", str(tmpconfigfile.path), "-s", "example_jdoe"] + flags
     config = icat.config.Config(needlogin=False, args=args)
     config.add_variable('flag1', ("--flag1",), 
                         dict(help="Flag 1", action='store_const', const=True), 
@@ -620,7 +611,7 @@ def test_config_type_boolean(fakeClient, tmpconfigfile, flags, ex):
 def test_config_type_flag(fakeClient, tmpconfigfile, flags, ex):
     """Test the special configuration variable type flag.
     """
-    args = ["-c", tmpconfigfile.path, "-s", "example_jdoe"] + flags
+    args = ["-c", str(tmpconfigfile.path), "-s", "example_jdoe"] + flags
     config = icat.config.Config(needlogin=False, args=args)
     config.add_variable('flag1', ("--flag1",), 
                         dict(help="Flag 1"), type=icat.config.flag)
@@ -637,7 +628,7 @@ def test_config_positional(fakeClient, tmpconfigfile):
     7d10764.)
     """
 
-    args = ["-c", tmpconfigfile.path, "-s", "example_jdoe", "test.dat"]
+    args = ["-c", str(tmpconfigfile.path), "-s", "example_jdoe", "test.dat"]
     config = icat.config.Config(args=args)
     config.add_variable('datafile', ("datafile",), 
                         dict(metavar="input.dat", 
@@ -663,7 +654,7 @@ def test_config_disable(fakeClient, tmpconfigfile):
     intended to be used in client code.
     """
 
-    args = ["-c", tmpconfigfile.path, "-s", "example_root"]
+    args = ["-c", str(tmpconfigfile.path), "-s", "example_root"]
     config = icat.config.Config(args=args)
     config.confvariable['promptPass'].disabled = True
     _, conf = config.getconfig()
@@ -696,7 +687,7 @@ def test_config_authinfo_simple(fakeClient, monkeypatch, tmpconfigfile):
     ]
     monkeypatch.setattr(FakeClient, "AuthInfo", authInfo)
 
-    args = ["-c", tmpconfigfile.path, "-s", "example_root"]
+    args = ["-c", str(tmpconfigfile.path), "-s", "example_root"]
     config = icat.config.Config(args=args)
     assert list(config.authenticatorInfo) == authInfo
     _, conf = config.getconfig()
@@ -729,7 +720,7 @@ def test_config_authinfo_anon(fakeClient, monkeypatch, tmpconfigfile):
     ]
     monkeypatch.setattr(FakeClient, "AuthInfo", authInfo)
 
-    args = ["-c", tmpconfigfile.path, "-s", "example_root", "-a", "anon"]
+    args = ["-c", str(tmpconfigfile.path), "-s", "example_root", "-a", "anon"]
     config = icat.config.Config(args=args)
     assert list(config.authenticatorInfo) == authInfo
     _, conf = config.getconfig()
@@ -755,7 +746,7 @@ def test_config_authinfo_anon_only(fakeClient, monkeypatch, tmpconfigfile):
     ]
     monkeypatch.setattr(FakeClient, "AuthInfo", authInfo)
 
-    args = ["-c", tmpconfigfile.path, "-s", "example_anon"]
+    args = ["-c", str(tmpconfigfile.path), "-s", "example_anon"]
     config = icat.config.Config(args=args)
     assert list(config.authenticatorInfo) == authInfo
     _, conf = config.getconfig()
@@ -784,7 +775,7 @@ def test_config_authinfo_strange(fakeClient, monkeypatch, tmpconfigfile):
     ]
     monkeypatch.setattr(FakeClient, "AuthInfo", authInfo)
 
-    args = ["-c", tmpconfigfile.path, "-s", "example_root", 
+    args = ["-c", str(tmpconfigfile.path), "-s", "example_root",
             "-a", "quirks", "--cred_secret", "geheim"]
     config = icat.config.Config(args=args)
     assert list(config.authenticatorInfo) == authInfo
@@ -806,7 +797,7 @@ def test_config_authinfo_no_authinfo(fakeClient, monkeypatch, tmpconfigfile):
     Talk to an old server that does not support getAuthenticatorInfo.
     """
 
-    args = ["-c", tmpconfigfile.path, "-s", "example_root"]
+    args = ["-c", str(tmpconfigfile.path), "-s", "example_root"]
     config = icat.config.Config(args=args)
     client, conf = config.getconfig()
 
@@ -842,7 +833,7 @@ def test_config_authinfo_invalid_auth(fakeClient, monkeypatch, tmpconfigfile):
     ]
     monkeypatch.setattr(FakeClient, "AuthInfo", authInfo)
 
-    args = ["-c", tmpconfigfile.path, "-s", "example_jdoe"]
+    args = ["-c", str(tmpconfigfile.path), "-s", "example_jdoe"]
     config = icat.config.Config(args=args)
     with pytest.raises(icat.exception.ConfigError) as err:
         _, conf = config.getconfig()
@@ -858,16 +849,16 @@ def test_config_cfgpath_default(fakeClient, tmpconfigfile, monkeypatch,
     """
 
     # Manipulate the default search path.
-    monkeypatch.setenv("HOME", tmpconfigfile.home)
+    monkeypatch.setenv("HOME", str(tmpconfigfile.home))
     cfgdirs = [ Path("~/.config/icat").expanduser(),
                 Path("~/.icat").expanduser(),
                 Path("."), ]
     monkeypatch.setattr(icat.config, "cfgdirs", cfgdirs)
-    monkeypatch.chdir(tmpconfigfile.home)
+    monkeypatch.chdir(str(tmpconfigfile.home))
     cpath = Path("~/.config/icat/control.dat").expanduser()
     tmpfiles.addfile(cpath, "control\n")
 
-    args = ["-c", tmpconfigfile.path, "-s", "example_jdoe"]
+    args = ["-c", str(tmpconfigfile.path), "-s", "example_jdoe"]
     config = icat.config.Config(args=args)
     config.add_variable('controlfile', ("--control",), 
                     dict(metavar="control.dat", help="control file"), 
@@ -896,18 +887,18 @@ def test_config_cfgpath_cwd(fakeClient, tmpconfigfile, monkeypatch, tmpfiles):
     """
 
     # Manipulate the default search path.
-    monkeypatch.setenv("HOME", tmpconfigfile.home)
+    monkeypatch.setenv("HOME", str(tmpconfigfile.home))
     cfgdirs = [ Path("~/.config/icat").expanduser(),
                 Path("~/.icat").expanduser(),
                 Path("."), ]
     monkeypatch.setattr(icat.config, "cfgdirs", cfgdirs)
-    monkeypatch.chdir(tmpconfigfile.home)
+    monkeypatch.chdir(str(tmpconfigfile.home))
     cpath = Path("~/.config/icat/control.dat").expanduser()
     tmpfiles.addfile(cpath, "control config dir\n")
-    hpath = Path(tmpconfigfile.home, "control.dat")
+    hpath = tmpconfigfile.home / "control.dat"
     tmpfiles.addfile(hpath, "control home\n")
 
-    args = ["-c", tmpconfigfile.path, "-s", "example_jdoe"]
+    args = ["-c", str(tmpconfigfile.path), "-s", "example_jdoe"]
     config = icat.config.Config(args=args)
     config.add_variable('controlfile', ("--control",), 
                     dict(metavar="control.dat", help="control file"), 
@@ -937,15 +928,15 @@ def test_config_cfgpath_cmdline(fakeClient, tmpconfigfile, monkeypatch,
     """
 
     # Manipulate the default search path.
-    monkeypatch.setenv("HOME", tmpconfigfile.home)
+    monkeypatch.setenv("HOME", str(tmpconfigfile.home))
     cfgdirs = [ Path("~/.config/icat").expanduser(),
                 Path("~/.icat").expanduser(),
                 Path("."), ]
     monkeypatch.setattr(icat.config, "cfgdirs", cfgdirs)
-    monkeypatch.chdir(tmpconfigfile.home)
+    monkeypatch.chdir(str(tmpconfigfile.home))
     cpath = Path("~/.config/icat/control.dat").expanduser()
     tmpfiles.addfile(cpath, "control config dir\n")
-    hpath = Path(tmpconfigfile.home, "control.dat")
+    hpath = tmpconfigfile.home / "control.dat"
     tmpfiles.addfile(hpath, "control home\n")
     if abspath:
         apath = Path("~/custom/cl.dat").expanduser()
@@ -955,7 +946,7 @@ def test_config_cfgpath_cmdline(fakeClient, tmpconfigfile, monkeypatch,
         cfarg = "cl.dat"
     tmpfiles.addfile(apath, "control cmdline\n")
 
-    args = ["-c", tmpconfigfile.path, "-s", "example_jdoe", 
+    args = ["-c", str(tmpconfigfile.path), "-s", "example_jdoe",
             "--control", cfarg]
     config = icat.config.Config(args=args)
     config.add_variable('controlfile', ("--control",), 
@@ -985,19 +976,19 @@ def test_config_client_kwargs(fakeClient, tmpconfigfile, monkeypatch):
     """
 
     # Manipulate the default search path.
-    monkeypatch.setenv("HOME", tmpconfigfile.home)
+    monkeypatch.setenv("HOME", str(tmpconfigfile.home))
     cfgdirs = [ Path("~/.config/icat").expanduser(),
                 Path("~/.icat").expanduser(),
                 Path("."), ]
     monkeypatch.setattr(icat.config, "cfgdirs", cfgdirs)
-    monkeypatch.chdir(tmpconfigfile.home)
+    monkeypatch.chdir(str(tmpconfigfile.home))
 
     # Add proxy settings just to have non-trivial content in client_kwargs.
     monkeypatch.setenv("http_proxy", "http://www-cache.example.org:3128/")
     monkeypatch.setenv("https_proxy", "http://www-cache.example.org:3128/")
     monkeypatch.setenv("no_proxy", "localhost, .example.org")
 
-    args = ["-c", tmpconfigfile.path, "-s", "example_root"]
+    args = ["-c", str(tmpconfigfile.path), "-s", "example_root"]
     config = icat.config.Config(args=args)
     client, conf = config.getconfig()
 
@@ -1070,7 +1061,7 @@ def test_config_subcmd(fakeClient, tmpconfigfile, subcmd):
         "ls": ["ls", "--format", "long"],
         "info": ["info", "--name", "brightness", ],
     }
-    args = ["-c", tmpconfigfile.path, "-s", "example_jdoe"] + sub_args[subcmd]
+    args = ["-c", str(tmpconfigfile.path), "-s", "example_jdoe"] + sub_args[subcmd]
     config = icat.config.Config(args=args)
     subcmds = config.add_subcommands()
 
@@ -1109,7 +1100,7 @@ def test_config_subcmd_err_var_nonunique(fakeClient, tmpconfigfile):
     configurations define the same variables, see for instance "name"
     which is defined in both "create" and "info" in the last test.)
     """
-    args = ["-c", tmpconfigfile.path, "-s", "example_jdoe",
+    args = ["-c", str(tmpconfigfile.path), "-s", "example_jdoe",
             "sub", "--url", "http://example.org/"]
     config = icat.config.Config(args=args)
     subcmds = config.add_subcommands()
@@ -1127,7 +1118,7 @@ def test_config_subcmd_err_subcmd_nonunique(fakeClient, tmpconfigfile):
     Similar situation as last test: sub-command names may not collide
     with already defined variables as well.
     """
-    args = ["-c", tmpconfigfile.path, "-s", "example_jdoe", "url"]
+    args = ["-c", str(tmpconfigfile.path), "-s", "example_jdoe", "url"]
     config = icat.config.Config(args=args)
     with pytest.raises(ValueError) as err:
         subcmds = config.add_subcommands('url')
@@ -1142,7 +1133,7 @@ def test_config_subcmd_err_add_more_vars(fakeClient, tmpconfigfile):
     No more variables may be added to a config after a subcommand has
     been added.
     """
-    args = ["-c", tmpconfigfile.path, "-s", "example_jdoe",
+    args = ["-c", str(tmpconfigfile.path), "-s", "example_jdoe",
             "sub", "--name", "foo"]
     config = icat.config.Config(args=args)
     subcmds = config.add_subcommands()

--- a/tests/test_01_config.py
+++ b/tests/test_01_config.py
@@ -184,6 +184,30 @@ def test_config_minimal_file(fakeClient, tmpconfigfile, monkeypatch):
     assert ex <= conf
 
 
+def test_config_file_expanduser(fakeClient, tmpconfigfile, monkeypatch):
+    """Explicitely point to the config file.
+
+    Indicate the path of the config file in the command line
+    arguments.  Use tilde expansion in this path.
+    """
+
+    # Manipulate the search path such that the config file is not
+    # found in the default path.
+    monkeypatch.setenv("HOME", str(tmpconfigfile.home))
+    cfgdirs = [ tmpconfigfile.dir / "wobble", Path(".") ]
+    monkeypatch.setattr(icat.config, "cfgdirs", cfgdirs)
+    monkeypatch.chdir(str(tmpconfigfile.home))
+
+    args = ["-c", "~/.icat/icat.cfg", "-s", "example_root"]
+    config = icat.config.Config(needlogin=False, ids=False, args=args)
+    _, conf = config.getconfig()
+
+    ex = ExpectedConf(configFile=[tmpconfigfile.path], 
+                      configSection="example_root", 
+                      url=ex_icat)
+    assert ex <= conf
+
+
 def test_config_minimal_defaultfile(fakeClient, tmpconfigfile, monkeypatch):
     """Minimal example.
 

--- a/tests/test_06_ids.py
+++ b/tests/test_06_ids.py
@@ -3,7 +3,6 @@
 
 import datetime
 import filecmp
-import os.path
 import time
 import zipfile
 import pytest
@@ -164,7 +163,7 @@ def test_upload(tmpdirsec, client, case):
         username = tclient.getUserName()
         dataset = getDataset(tclient, case)
         datafileformat = getDatafileFormat(tclient, case)
-        datafile = tclient.new("datafile", name=os.path.basename(f.fname), 
+        datafile = tclient.new("datafile", name=f.fname.name,
                                dataset=dataset, datafileFormat=datafileformat)
         tclient.putData(f.fname, datafile)
         df = getDatafile(tclient, case)
@@ -185,7 +184,7 @@ def method(request):
 def test_download(tmpdirsec, client, case, method):
     with tmpClient(confSection=case['dluser'], ids="mandatory") as tclient:
         if len(case['dfs']) > 1:
-            zfname = os.path.join(tmpdirsec, "%s.zip" % case['dsname'])
+            zfname = tmpdirsec / ("%s.zip" % case['dsname'])
             print("\nDownload %s to file %s" % (case['dsname'], zfname))
             dataset = getDataset(tclient, case)
             query = "Datafile <-> Dataset [id=%d]" % dataset.id
@@ -197,9 +196,9 @@ def test_download(tmpdirsec, client, case, method):
                 while not tclient.isDataPrepared(prepid):
                     time.sleep(5)
                 response = tclient.getData(prepid)
-            with open(zfname, 'wb') as f:
+            with zfname.open('wb') as f:
                 copyfile(response, f)
-            zf = zipfile.ZipFile(zfname, 'r')
+            zf = zipfile.ZipFile(str(zfname), 'r')
             zinfos = zf.infolist()
             assert len(zinfos) == len(case['dfs'])
             for df in case['dfs']:
@@ -213,7 +212,7 @@ def test_download(tmpdirsec, client, case, method):
                 assert zi.file_size == df['testfile'].size
         elif len(case['dfs']) == 1:
             df = case['dfs'][0]
-            dfname = os.path.join(tmpdirsec, "dl_%s" % df['dfname'])
+            dfname = tmpdirsec / ("dl_%s" % df['dfname'])
             print("\nDownload %s to file %s" % (case['dsname'], dfname))
             dataset = getDataset(tclient, case)
             query = "Datafile <-> Dataset [id=%d]" % dataset.id
@@ -225,9 +224,9 @@ def test_download(tmpdirsec, client, case, method):
                 while not tclient.isDataPrepared(prepid):
                     time.sleep(5)
                 response = tclient.getData(prepid)
-            with open(dfname, 'wb') as f:
+            with dfname.open('wb') as f:
                 copyfile(response, f)
-            assert filecmp.cmp(df['testfile'].fname, dfname)
+            assert filecmp.cmp(str(df['testfile'].fname), str(dfname))
         else:
             raise RuntimeError("No datafiles for dataset %s" % case['dsname'])
 

--- a/tests/test_06_ingest.py
+++ b/tests/test_06_ingest.py
@@ -1,7 +1,6 @@
 """Test icatdump and icatingest.
 """
 
-import os.path
 from subprocess import CalledProcessError
 import pytest
 import icat
@@ -11,8 +10,8 @@ from conftest import DummyDatafile, gettestdata, getConfig, callscript
 
 
 # Test input
-ds_params = gettestdata("ingest-ds-params.xml")
-datafiles = gettestdata("ingest-datafiles.xml")
+ds_params = str(gettestdata("ingest-ds-params.xml"))
+datafiles = str(gettestdata("ingest-datafiles.xml"))
 
 @pytest.fixture(scope="module")
 def client(setupicat):
@@ -295,10 +294,10 @@ def test_ingest_duplicate_check_types(tmpdirsec, dataset, cmdargs, inputdata):
         dataset.create()
     # We simply ingest twice the same data, using duplicate=CHECK the
     # second time.  This obviously leads to matching duplicates.
-    inpfile = os.path.join(tmpdirsec, "ingest.xml")
-    with open(inpfile, "wt") as f:
+    inpfile = tmpdirsec / "ingest.xml"
+    with inpfile.open("wt") as f:
         f.write(inputdata)
-    args = cmdargs + ["-i", inpfile]
+    args = cmdargs + ["-i", str(inpfile)]
     callscript("icatingest.py", args)
     callscript("icatingest.py", args + ["--duplicate", "CHECK"])
 
@@ -330,7 +329,7 @@ def test_ingest_datafiles_upload(tmpdirsec, client, dataset, cmdargs):
     dummyfiles = [ DummyDatafile(tmpdirsec, f['dfname'], f['size'], f['mtime'])
                    for f in testdatafiles ]
     args = cmdargs + ["-i", datafiles, "--upload-datafiles", 
-                      "--datafile-dir", tmpdirsec]
+                      "--datafile-dir", str(tmpdirsec)]
     callscript("icatingest.py", args)
     # Verify that the datafiles have been uploaded.
     dataset = client.searchMatching(dataset)


### PR DESCRIPTION
Add support for the [pathlib](https://docs.python.org/3/library/pathlib.html) Python standard  library module (added in Python 3.4). Methods that take a file name argument, such as [icat.client.putData()](https://python-icat.readthedocs.io/en/latest/client.html#icat.client.Client.putData) also accept a `Path` object. All internal processing of filesystem paths is changed to use `pathlib` where appropriate.

This implements and closes #66.