### PR TITLE
Add support for searching for multiple fields

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -5,12 +5,32 @@ Changelog
 0.18.0 (not yet released)
 ~~~~~~~~~~~~~~~~~~~~~~~~~
 
+New features
+------------
+
++ `#76`_, `#78`_: add client side support for searching for multiple
+  fields introduced in icat.server 4.11.0.  Add support for building
+  the corresponding queries in the in class :class:`icat.query.Query`.
+
+Incompatible changes and deprecations
+-------------------------------------
+
++ Since :class:`icat.query.Query` now also accepts a list of attribute
+  names rather then only a single one, the corresponding keyword
+  argument `attribute` has been renamed to `attributes` (in the
+  plural).  Accordingly, the method
+  :meth:`icat.query.Query.setAttribute` has been renamed to
+  :meth:`icat.query.Query.setAttributes`.  The old names are retained
+  as aliases, but are deprecated.
+
 Bug fixes and minor changes
 ---------------------------
 
 + `#79`_: fix an encoding issue in :attr:`icat.client.Client.apiversion`,
   only relevant with Python 2.
 
+.. _#76: https://github.com/icatproject/python-icat/pull/76
+.. _#78: https://github.com/icatproject/python-icat/issues/78
 .. _#79: https://github.com/icatproject/python-icat/pull/79
 
 

--- a/doc/src/tutorial-search.rst
+++ b/doc/src/tutorial-search.rst
@@ -367,12 +367,23 @@ Instead of returning a list of the matching objects, we may also
 request single attributes.  The result will be a list of the attribute
 values of the matching objects.  Listing the names of all datasets::
 
-  >>> query = Query(client, "Dataset", attribute="name")
+  >>> query = Query(client, "Dataset", attributes="name")
   >>> print(query)
   SELECT o.name FROM Dataset o
   >>> client.search(query)
   [e201215, e201216, e208339, e208341, e208342, e208945, e208946, e208947]
 
+As the name of that keyword argument suggests, we may also search for
+multiple attributes at once.  This will a list with the attribute
+values for each object found in the query.  It requires an ICAT server
+version 4.11 or newer though.
+
+  >>> query = Query(client, "Dataset", attributes=["investigation.name", "name", "type.name"])
+  >>> print(query)
+  SELECT i.name, o.name, t.name FROM Dataset o JOIN o.investigation AS i JOIN o.type AS t
+  >>> client.search(query)
+  [[08100122-EF, e201215, raw], [08100122-EF, e201216, raw], [10100601-ST, e208339, raw], [10100601-ST, e208341, raw], [10100601-ST, e208342, raw], [12100409-ST, e208945, raw], [12100409-ST, e208946, raw], [12100409-ST, e208947, analyzed]]
+  
 There are also some aggregate functions that may be applied to search
 results.  Let's count all datasets::
 
@@ -395,7 +406,7 @@ average magnetic field applied in the measurements::
   ...     "type.name": "= 'Magnetic field'",
   ...     "type.units": "= 'T'",
   ... }
-  >>> query = Query(client, "DatasetParameter", conditions=conditions, attribute="numericValue")
+  >>> query = Query(client, "DatasetParameter", conditions=conditions, attributes="numericValue")
   >>> print(query)
   SELECT o.numericValue FROM DatasetParameter o JOIN o.dataset AS ds JOIN ds.investigation AS i JOIN o.type AS t WHERE i.name = '10100601-ST' AND t.name = 'Magnetic field' AND t.units = 'T'
   >>> client.search(query)

--- a/doc/src/tutorial-search.rst
+++ b/doc/src/tutorial-search.rst
@@ -374,15 +374,15 @@ values of the matching objects.  Listing the names of all datasets::
   [e201215, e201216, e208339, e208341, e208342, e208945, e208946, e208947]
 
 As the name of that keyword argument suggests, we may also search for
-multiple attributes at once.  This will a list with the attribute
-values for each object found in the query.  It requires an ICAT server
-version 4.11 or newer though.
+multiple attributes at once.  The result will be a list of attribute
+values rather then a single value for each object found in the query.
+This requires an ICAT server version 4.11 or newer though::
 
-  >>> query = Query(client, "Dataset", attributes=["investigation.name", "name", "type.name"])
+  >>> query = Query(client, "Dataset", attributes=["investigation.name", "name", "complete", "type.name"])
   >>> print(query)
-  SELECT i.name, o.name, t.name FROM Dataset o JOIN o.investigation AS i JOIN o.type AS t
+  SELECT i.name, o.name, o.complete, t.name FROM Dataset o JOIN o.investigation AS i JOIN o.type AS t
   >>> client.search(query)
-  [[08100122-EF, e201215, raw], [08100122-EF, e201216, raw], [10100601-ST, e208339, raw], [10100601-ST, e208341, raw], [10100601-ST, e208342, raw], [12100409-ST, e208945, raw], [12100409-ST, e208946, raw], [12100409-ST, e208947, analyzed]]
+  [[08100122-EF, e201215, False, raw], [08100122-EF, e201216, False, raw], [10100601-ST, e208339, False, raw], [10100601-ST, e208341, False, raw], [10100601-ST, e208342, False, raw], [12100409-ST, e208945, False, raw], [12100409-ST, e208946, False, raw], [12100409-ST, e208947, True, analyzed]]
   
 There are also some aggregate functions that may be applied to search
 results.  Let's count all datasets::

--- a/icat/client.py
+++ b/icat/client.py
@@ -298,7 +298,7 @@ class Client(suds.client.Client):
         :rtype: :class:`list` or :class:`icat.entity.Entity` or any type
         """
         if obj.__class__.__name__ == 'fieldSet':
-            return obj.field
+            return obj.fields
         elif isinstance(obj, suds.sudsobject.Object):
             return self.new(obj)
         else:

--- a/icat/client.py
+++ b/icat/client.py
@@ -287,15 +287,15 @@ class Client(suds.client.Client):
     def getEntity(self, obj):
         """Get the corresponding :class:`icat.entity.Entity` for an object.
 
-        if obj is a fieldSet, return it fields, if obj is any other
-        Suds instance object, create a new object with
-        :meth:`~icat.client.Client.new`.  Otherwise do nothing and
-        return obj unchanged.
+        if obj is a `fieldSet`, return the list of fields.  If obj is
+        any other Suds instance object, create a new entity object
+        with :meth:`~icat.client.Client.new`.  Otherwise do nothing
+        and return obj unchanged.
         
         :param obj: either a Suds instance object or anything.
         :type obj: :class:`suds.sudsobject.Object` or any type
         :return: the new entity object or obj.
-        :rtype: :class:`icat.entity.Entity` or any type
+        :rtype: :class:`list` or :class:`icat.entity.Entity` or any type
         """
         if obj.__class__.__name__ == 'fieldSet':
             return obj.field

--- a/icat/client.py
+++ b/icat/client.py
@@ -287,7 +287,7 @@ class Client(suds.client.Client):
     def getEntity(self, obj):
         """Get the corresponding :class:`icat.entity.Entity` for an object.
 
-        if obj is a fieldSet, return it fields, if obj is any other a
+        if obj is a fieldSet, return it fields, if obj is any other
         Suds instance object, create a new object with
         :meth:`~icat.client.Client.new`.  Otherwise do nothing and
         return obj unchanged.

--- a/icat/client.py
+++ b/icat/client.py
@@ -287,7 +287,8 @@ class Client(suds.client.Client):
     def getEntity(self, obj):
         """Get the corresponding :class:`icat.entity.Entity` for an object.
 
-        If obj is a Suds instance object, create a new object with
+        if obj is a fieldSet, return it fields, if obj is any other a
+        Suds instance object, create a new object with
         :meth:`~icat.client.Client.new`.  Otherwise do nothing and
         return obj unchanged.
         
@@ -296,7 +297,9 @@ class Client(suds.client.Client):
         :return: the new entity object or obj.
         :rtype: :class:`icat.entity.Entity` or any type
         """
-        if isinstance(obj, suds.sudsobject.Object):
+        if obj.__class__.__name__ == 'fieldSet':
+            return obj.field
+        elif isinstance(obj, suds.sudsobject.Object):
             return self.new(obj)
         else:
             return obj

--- a/icat/client.py
+++ b/icat/client.py
@@ -20,9 +20,10 @@ from icat.entity import Entity
 from icat.entities import getTypeMap
 from icat.query import Query
 from icat.exception import *
+from icat.helper import (simpleqp_unquote, parse_attr_val,
+                         ms_timestamp, disable_logger)
 from icat.ids import *
 from icat.sslcontext import create_ssl_context, HTTPSTransport
-from icat.helper import simpleqp_unquote, parse_attr_val, ms_timestamp
 
 __all__ = ['Client']
 
@@ -207,6 +208,12 @@ class Client(suds.client.Client):
         Class = type(self)
         return Class(self.url, **self.kwargs)
 
+
+    def _has_wsdl_type(self, name):
+        """Check if this client's WSDL defines a particular type name.
+        """
+        with disable_logger("suds.resolver"):
+            return self.factory.resolver.find(name)
 
     def new(self, obj, **kwargs):
 

--- a/icat/helper.py
+++ b/icat/helper.py
@@ -34,7 +34,9 @@ True
 """
 
 import sys
+from contextlib import contextmanager
 import datetime
+import logging
 import suds.sax.date
 
 
@@ -219,3 +221,14 @@ def ms_timestamp(dt):
             dt = dt.replace(tzinfo=None) - offs
         ts = 1000 * (dt - datetime.datetime(1970, 1, 1)).total_seconds()
     return int(ts)
+
+
+@contextmanager
+def disable_logger(name):
+    """Context manager to temporarily disable a logger.
+    """
+    logger = logging.getLogger(name)
+    sav_state = logger.disabled
+    logger.disabled = True
+    yield
+    logger.disabled = sav_state

--- a/icat/query.py
+++ b/icat/query.py
@@ -58,8 +58,8 @@ class Query(object):
     :param entity: the type of objects to search for.  This may either
         be an :class:`icat.entity.Entity` subclass or the name of an
         entity type.
-    :param attribute: the attribute that the query shall return.  See
-        the :meth:`~icat.query.Query.setAttribute` method for details.
+    :param attributes: the attributes that the query shall return.  See
+        the :meth:`~icat.query.Query.setAttributes` method for details.
     :param aggregate: the aggregate function to be applied in the
         SELECT clause, if any.  See the
         :meth:`~icat.query.Query.setAggregate` method for details.
@@ -77,8 +77,8 @@ class Query(object):
         details.
     """
 
-    def __init__(self, client, entity, 
-                 attribute=None, aggregate=None, order=None, 
+    def __init__(self, client, entity,
+                 attributes=None, aggregate=None, order=None,
                  conditions=None, includes=None, limit=None):
         """Initialize the query.
         """
@@ -99,7 +99,7 @@ class Query(object):
         else:
             raise EntityTypeError("Invalid entity type '%s'." % type(entity))
 
-        self.setAttribute(attribute)
+        self.setAttributes(attributes)
         self.setAggregate(aggregate)
         self.conditions = dict()
         self.addConditions(conditions)
@@ -172,21 +172,21 @@ class Query(object):
             n += " AS %s" % (subst[obj])
         return n
 
-    def setAttribute(self, attribute):
-        """Set the attribute that the query shall return.
+    def setAttributes(self, attributes):
+        """Set the attributes that the query shall return.
 
-        :param attribute: the name of the attribute.  The result of
+        :param attributes: the name of the attributes.  The result of
             the query will be a list of attribute values for the
-            matching entity objects.  If attribute is :const:`None`,
+            matching entity objects.  If attributes is :const:`None`,
             the result will be the list of matching objects instead.
-        :type attribute: :class:`str`
-        :raise ValueError: if `attribute` is not valid.
+        :type attributes: :class:`str`
+        :raise ValueError: if `attributes` is not valid.
         """
-        if attribute is not None:
+        if attributes is not None:
             # Get the attribute path only to verify that the attribute is valid.
-            for (pattr, attrInfo, rclass) in self._attrpath(attribute):
+            for (pattr, attrInfo, rclass) in self._attrpath(attributes):
                 pass
-        self.attribute = attribute
+        self.attributes = attributes
 
     def setAggregate(self, function):
         """Set the aggregate function to be applied to the result.
@@ -342,12 +342,12 @@ class Query(object):
     def __repr__(self):
         """Return a formal representation of the query.
         """
-        return ("%s(%s, %s, attribute=%s, aggregate=%s, order=%s, "
+        return ("%s(%s, %s, attributes=%s, aggregate=%s, order=%s, "
                 "conditions=%s, includes=%s, limit=%s)"
-                % (self.__class__.__name__, 
-                   repr(self.client), repr(self.entity.BeanName), 
-                   repr(self.attribute), repr(self.aggregate), 
-                   repr(self.order), repr(self.conditions), 
+                % (self.__class__.__name__,
+                   repr(self.client), repr(self.entity.BeanName),
+                   repr(self.attributes), repr(self.aggregate),
+                   repr(self.order), repr(self.conditions),
                    repr(self.includes), repr(self.limit)))
 
     def __str__(self):
@@ -363,16 +363,16 @@ class Query(object):
         distinction between Unicode and string objects anyway.
         """
         joinattrs = { a for a, d in self.order } | set(self.conditions.keys())
-        if self.attribute:
-            joinattrs.add(self.attribute)
+        if self.attributes:
+            joinattrs.add(self.attributes)
         subst = self._makesubst(joinattrs)
-        if self.attribute:
+        if self.attributes:
             if self.client.apiversion >= "4.7.0":
-                res = self._dosubst(self.attribute, subst, False)
+                res = self._dosubst(self.attributes, subst, False)
             else:
                 # Old versions of icat.server do not accept
                 # substitution in the SELECT clause.
-                res = "o.%s" % self.attribute
+                res = "o.%s" % self.attributes
         else:
             res = "o"
         if self.aggregate:
@@ -424,7 +424,7 @@ class Query(object):
         """Return an independent clone of this query.
         """
         q = Query(self.client, self.entity)
-        q.attribute = self.attribute
+        q.attributes = self.attributes
         q.aggregate = self.aggregate
         q.order = list(self.order)
         q.conditions = self.conditions.copy()

--- a/icat/query.py
+++ b/icat/query.py
@@ -77,6 +77,10 @@ class Query(object):
         details.
     :param attribute: alias for `attributes`, retained for
         compatibility.  Deprecated, use `attributes` instead.
+    :raise TypeError: if `entity` is not a valid entity type or if
+        both `attributes` and `attribute` are provided.
+    :raise ValueError: if any of the keyword arguments is not valid,
+        see the corresponding method for details.
 
     .. versionchanged:: 0.18.0
         add support for queries requesting a list of attributes rather
@@ -196,7 +200,9 @@ class Query(object):
             matching entity object.  If attributes is :const:`None`,
             the result will be the list of matching objects instead.
         :type attributes: :class:`str` or :class:`list` of :class:`str`
-        :raise ValueError: if any name in `attributes` is not valid.
+        :raise ValueError: if any name in `attributes` is not valid or
+            if multiple attributes are provided, but the ICAT server
+            does not support this.
 
         .. versionchanged:: 0.18.0
             also accept a list of attribute names.  Renamed from
@@ -236,7 +242,7 @@ class Query(object):
             ":DISTINCT", may be appended to "COUNT", "AVG", and "SUM"
             to combine the respective function with "DISTINCT".
         :type function: :class:`str`
-        :raise ValueError: if `function` is not a valid.
+        :raise ValueError: if `function` is not valid.
         """
         if function:
             if function not in aggregate_fcts:

--- a/icat/query.py
+++ b/icat/query.py
@@ -75,11 +75,18 @@ class Query(object):
     :param limit: a tuple (skip, count) to be used in the LIMIT
         clause.  See the :meth:`~icat.query.Query.setLimit` method for
         details.
+    :param attribute: alias for `attributes`, retained for
+        compatibility.  Deprecated, use `attributes` instead.
+
+    .. versionchanged:: 0.18.0
+        add support for queries requesting a list of attributes rather
+        then a single one.  Consequently, the keyword argument
+        `attribute` has been renamed to `attributes` (in the plural).
     """
 
     def __init__(self, client, entity,
                  attributes=None, aggregate=None, order=None,
-                 conditions=None, includes=None, limit=None):
+                 conditions=None, includes=None, limit=None, attribute=None):
         """Initialize the query.
         """
 
@@ -98,6 +105,13 @@ class Query(object):
                                       % entity.__name__)
         else:
             raise EntityTypeError("Invalid entity type '%s'." % type(entity))
+
+        if attribute is not None:
+            if attributes:
+                raise TypeError("cannot use both, attribute and attributes")
+            warn("The attribute keyword argument is deprecated and will be "
+                 "removed in python-icat 1.0.", DeprecationWarning, 2)
+            attributes = attribute
 
         self.setAttributes(attributes)
         self.setAggregate(aggregate)
@@ -183,6 +197,11 @@ class Query(object):
             the result will be the list of matching objects instead.
         :type attributes: :class:`str` or :class:`list` of :class:`str`
         :raise ValueError: if any name in `attributes` is not valid.
+
+        .. versionchanged:: 0.18.0
+            also accept a list of attribute names.  Renamed from
+            :meth:`setAttribute` to :meth:`setAttributes` (in the
+            plural).
         """
         self.attributes = []
         if attributes:
@@ -445,3 +464,13 @@ class Query(object):
         q.includes = self.includes.copy()
         q.limit = self.limit
         return q
+
+    def setAttribute(self, attribute):
+        """Alias for :meth:`setAttributes`.
+
+        .. deprecated:: 0.18.0
+            use :meth:`setAttributes` instead.
+        """
+        warn("setAttribute() is deprecated "
+             "and will be removed in python-icat 1.0.", DeprecationWarning, 2)
+        self.setAttributes(attribute)

--- a/icatdump.py
+++ b/icatdump.py
@@ -44,7 +44,7 @@ with open_dumpfile(client, conf.file, conf.format, 'w') as dumpfile:
     dumpfile.writedata(getAuthQueries(client))
     dumpfile.writedata(getStaticQueries(client))
     # Dump the investigations each in their own chunk
-    investsearch = Query(client, "Investigation", attribute="id", 
+    investsearch = Query(client, "Investigation", attributes="id",
                          order=["facility.name", "name", "visitId"])
     for i in client.searchChunked(investsearch):
         # We fetch Dataset including DatasetParameter.  This may lead

--- a/tests/test_05_dumpfile.py
+++ b/tests/test_05_dumpfile.py
@@ -86,7 +86,7 @@ def icatdump(client, f, backend):
     with open_dumpfile(client, f, backend, 'w') as dumpfile:
         dumpfile.writedata(getAuthQueries(client))
         dumpfile.writedata(getStaticQueries(client))
-        investsearch = Query(client, "Investigation", attribute="id", 
+        investsearch = Query(client, "Investigation", attributes="id",
                              order=["facility.name", "name", "visitId"])
         for i in client.searchChunked(investsearch):
             dumpfile.writedata(getInvestigationQueries(client, i), chunksize=5)

--- a/tests/test_06_client.py
+++ b/tests/test_06_client.py
@@ -44,17 +44,25 @@ def test_logout_no_session_error(client):
 
 # ======================== test search() ===========================
 
-cet = datetime.timezone(datetime.timedelta(hours=1))
-cest = datetime.timezone(datetime.timedelta(hours=2))
+try:
+    # datetime.timezone has been added in Python 3.2
+    cet = datetime.timezone(datetime.timedelta(hours=1))
+    cest = datetime.timezone(datetime.timedelta(hours=2))
+except AttributeError:
+    # Old Python
+    cet = None
+    cest = None
 
 @pytest.mark.parametrize(("query", "result"), [
-    ("SELECT o.name, o.title, o.startDate FROM Investigation o",
-     [["08100122-EF", "Durol single crystal",
-       datetime.datetime(2008, 3, 13, 11, 39, 42, tzinfo=cet)],
-      ["10100601-ST", "Ni-Mn-Ga flat cone",
-       datetime.datetime(2010, 9, 30, 12, 27, 24, tzinfo=cest)],
-      ["12100409-ST", "NiO SC OF1 JUH HHL",
-       datetime.datetime(2012, 7, 26, 17, 44, 24, tzinfo=cest)]]),
+    pytest.param("SELECT o.name, o.title, o.startDate FROM Investigation o",
+                 [["08100122-EF", "Durol single crystal",
+                   datetime.datetime(2008, 3, 13, 11, 39, 42, tzinfo=cet)],
+                  ["10100601-ST", "Ni-Mn-Ga flat cone",
+                   datetime.datetime(2010, 9, 30, 12, 27, 24, tzinfo=cest)],
+                  ["12100409-ST", "NiO SC OF1 JUH HHL",
+                   datetime.datetime(2012, 7, 26, 17, 44, 24, tzinfo=cest)]],
+                 marks=pytest.mark.skipif("cet is None",
+                                          reason="require datetime.timezone")),
     ("SELECT i.name, ds.name FROM Dataset ds JOIN ds.investigation AS i "
      "WHERE i.startDate < '2011-01-01'",
      [["08100122-EF", "e201215"],
@@ -132,6 +140,7 @@ def test_assertedSearch_range_exact_query(client):
     assert len(objs) == 3
     assert objs[0].BeanName == "User"
 
+@pytest.mark.skipif(cet is None, reason="require datetime.timezone")
 def test_assertedSearch_unique_mulitple_fields(client):
     """Search for some attributes of a unique object with assertedSearch().
     """

--- a/tests/test_06_client.py
+++ b/tests/test_06_client.py
@@ -244,7 +244,7 @@ def test_searchChunked_id(client, query):
     works around this for the standard formulation of the query
     (9901ec6).
     """
-    refq = Query(client, "Investigation", attribute="id", limit=(0,1),
+    refq = Query(client, "Investigation", attributes="id", limit=(0,1),
                  conditions={"name": "= '08100122-EF'"})
     id = client.assertedSearch(refq)[0]
     # The search by id must return exactly one result.  The broken

--- a/tests/test_06_query.py
+++ b/tests/test_06_query.py
@@ -3,6 +3,7 @@
 
 from __future__ import print_function
 import datetime
+from distutils.version import StrictVersion as Version
 import re
 import sys
 import pytest
@@ -493,6 +494,8 @@ def test_query_mulitple_attributes_oldicat_valueerror(client):
     err_pattern = r"\bICAT server\b.*\bnot support\b.*\bmultiple attributes\b"
     assert re.search(err_pattern, str(err.value))
 
+@pytest.mark.skipif(Version(pytest.__version__) < "3.9.0",
+                    reason="pytest.deprecated_call() does not work properly")
 def test_query_deprecated_kwarg_attribute(client):
     """the keyword argument `attribute` to :class:`icat.query.Query`
     is deprecated since 0.18.0.
@@ -503,6 +506,8 @@ def test_query_deprecated_kwarg_attribute(client):
         query = Query(client, "Datafile", attribute="name")
     assert str(query) == str(ref_query)
 
+@pytest.mark.skipif(Version(pytest.__version__) < "3.9.0",
+                    reason="pytest.deprecated_call() does not work properly")
 def test_query_deprecated_method_setAttribute(client):
     """:meth:`icat.query.Query.setAttribute` is deprecated since 0.18.0.
     """

--- a/tests/test_06_query.py
+++ b/tests/test_06_query.py
@@ -2,8 +2,9 @@
 """
 
 from __future__ import print_function
-import sys
 import datetime
+import re
+import sys
 import pytest
 import icat
 import icat.config
@@ -479,6 +480,18 @@ def test_query_mulitple_attributes_related_obj(client):
     print(str(query))
     res = client.search(query)
     assert res == results
+
+def test_query_mulitple_attributes_oldicat_valueerror(client):
+    """Query class should raise ValueError if multiple attributes are
+    requested, but the ICAT server is too old to support this.
+    """
+    if client._has_wsdl_type('fieldSet'):
+        pytest.skip("search for multiple fields is supported by this server")
+
+    with pytest.raises(ValueError) as err:
+        query = Query(client, "Investigation", attributes=["name", "title"])
+    err_pattern = r"\bICAT server\b.*\bnot support\b.*\bmultiple attributes\b"
+    assert re.search(err_pattern, str(err.value))
 
 def test_query_deprecated_kwarg_attribute(client):
     """the keyword argument `attribute` to :class:`icat.query.Query`

--- a/tests/test_06_query.py
+++ b/tests/test_06_query.py
@@ -480,6 +480,27 @@ def test_query_mulitple_attributes_related_obj(client):
     res = client.search(query)
     assert res == results
 
+def test_query_deprecated_kwarg_attribute(client):
+    """the keyword argument `attribute` to :class:`icat.query.Query`
+    is deprecated since 0.18.0.
+    """
+    # create a reference using the new keyword argument
+    ref_query = Query(client, "Datafile", attributes="name")
+    with pytest.deprecated_call():
+        query = Query(client, "Datafile", attribute="name")
+    assert str(query) == str(ref_query)
+
+def test_query_deprecated_method_setAttribute(client):
+    """:meth:`icat.query.Query.setAttribute` is deprecated since 0.18.0.
+    """
+    # create a reference using the new method
+    ref_query = Query(client, "Datafile")
+    ref_query.setAttributes("name")
+    with pytest.deprecated_call():
+        query = Query(client, "Datafile")
+        query.setAttribute("name")
+    assert str(query) == str(ref_query)
+
 @pytest.mark.dependency(depends=['get_investigation'])
 def test_query_aggregate_distinct_attribute(client):
     """Test DISTINCT on an attribute in the search result.

--- a/tests/test_06_query.py
+++ b/tests/test_06_query.py
@@ -403,7 +403,7 @@ def test_query_attribute_datafile_name(client):
     Querying attributes rather then entire objects is a new feature
     added in Issue #28.
     """
-    query = Query(client, "Datafile", attribute="name", order=True, 
+    query = Query(client, "Datafile", attributes="name", order=True,
                   conditions={ "dataset.investigation.id":
                                "= %d" % investigation.id })
     print(str(query))
@@ -419,7 +419,7 @@ def test_query_related_obj_attribute(client):
     This requires icat.server 4.5 or newer to work.
     """
     require_icat_version("4.5.0", "SELECT related object's attribute")
-    query = Query(client, "Datafile", attribute="datafileFormat.name", 
+    query = Query(client, "Datafile", attributes="datafileFormat.name",
                   conditions={ "dataset.investigation.id":
                                "= %d" % investigation.id })
     print(str(query))
@@ -437,7 +437,7 @@ def test_query_aggregate_distinct_attribute(client):
     """
     require_icat_version("4.7.0", "SELECT DISTINCT in queries")
     query = Query(client, "Datafile", 
-                  attribute="datafileFormat.name", 
+                  attributes="datafileFormat.name",
                   conditions={ "dataset.investigation.id":
                                "= %d" % investigation.id })
     print(str(query))
@@ -457,7 +457,7 @@ def test_query_aggregate_distinct_related_obj(client):
     """
     require_icat_version("4.7.0", "SELECT DISTINCT in queries")
     query = Query(client, "Datafile", 
-                  attribute="datafileFormat", 
+                  attributes="datafileFormat",
                   conditions={ "dataset.investigation.id":
                                "= %d" % investigation.id })
     print(str(query))
@@ -507,7 +507,8 @@ def test_query_aggregate_misc(client, attribute, aggregate, expected):
         require_icat_version("4.5.0", "SELECT related object's attribute")
     if "DISTINCT" in aggregate:
         require_icat_version("4.7.0", "SELECT DISTINCT in queries")
-    query = Query(client, "Datafile", attribute=attribute, aggregate=aggregate,
+    query = Query(client, "Datafile",
+                  attributes=attribute, aggregate=aggregate,
                   conditions={ "dataset.investigation.id":
                                "= %d" % investigation.id })
     print(str(query))

--- a/tests/test_09_deprecations.py
+++ b/tests/test_09_deprecations.py
@@ -18,6 +18,8 @@ import icat.exception
 # - Predefined configuration variable configDir.
 #   It's easier to test this in the setting of the test_01_config.py
 #   module.
+# - The attribute keyword argument and the setAttribute() method in
+#   class Query is tested in in the test_06_query.py module.
 
 @pytest.mark.skipif(sys.version_info >= (3, 4),
                     reason="this Python version is not deprecated")


### PR DESCRIPTION
icatproject/icat.server#246 adds support for queries searching for multiple fields.  This PR adds client side support for this in python-icat. It adds special handling of the case that the ICAT `search()` API method returns a `fieldSet`.

This is just the minimal implementation and not yet final.  Still todo:
- [x] add support for corresponding JPQL queries in the `Query` class, ref. #76.
- [x] ~~improve error handling for old `icat.server` versions not supporting this.~~
- [x] add more tests.
- [x] wait for `icat.server` to be released with support for the feature.
- [ ] test with the full matrix of Python and ICAT versions.
- [x] update documentation.