### PR TITLE
Fix encoding issue with client.apiversion and Python 2

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -2,6 +2,18 @@ Changelog
 =========
 
 
+0.18.0 (not yet released)
+~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Bug fixes and minor changes
+---------------------------
+
++ `#79`_: fix an encoding issue in :attr:`icat.client.Client.apiversion`,
+  only relevant with Python 2.
+
+.. _#79: https://github.com/icatproject/python-icat/pull/79
+
+
 0.17.0 (2020-04-30)
 ~~~~~~~~~~~~~~~~~~~
 

--- a/icat/client.py
+++ b/icat/client.py
@@ -139,7 +139,7 @@ class Client(suds.client.Client):
             proxy = {}
         kwargs['transport'] = HTTPSTransport(self.sslContext, proxy=proxy)
         super(Client, self).__init__(self.url, **kwargs)
-        apiversion = self.getApiVersion()
+        apiversion = str(self.getApiVersion())
         # Translate a version having a trailing '-SNAPSHOT' into
         # something that StrictVersion would accept.
         apiversion = re.sub(r'-SNAPSHOT$', 'a1', apiversion)


### PR DESCRIPTION
There is a somewhat obscure issue related with the `apiversion` attribute of class `Client`.  It manifests itself in very special conditions:
- only relevant for Python 2,
- only seem to become apparent when talking to an `icat.server` that is a snapshot version,
- only manifests itself in very particular situations: it leads to failed tests that try to dump YAML into a memory buffer.

The symptom:
```python
>>> import io
>>> import icat.dumpfile_yaml
>>> from icat.dumpfile import open_dumpfile
>>> 
>>> client.apiversion
StrictVersion ('4.11a1')
>>> type(client.apiversion)
<type 'instance'>
>>> query = "SELECT f FROM Facility f" 
>>> stream = io.BytesIO()
>>> with open_dumpfile(client, stream, 'YAML', 'w') as dumpfile:
...     dumpfile.writedata([query])
... 
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/home/abuild/test/python-icat-0.17.0/build/lib/icat/dumpfile.py", line 167, in __enter__
    self.head()
  File "/home/abuild/test/python-icat-0.17.0/build/lib/icat/dumpfile_yaml.py", line 195, in head
    self.outfile.write(head)
TypeError: 'unicode' does not have the buffer interface
```

The cause is related with the fact that Suds uses its own class `suds.sax.text.Text` for the string representation of values returned from the server.