### PR TITLE
Add TypeError as additional ancestor of EntityTypeError

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -11,7 +11,11 @@ Bug fixes and minor changes
 + `#79`_: fix an encoding issue in :attr:`icat.client.Client.apiversion`,
   only relevant with Python 2.
 
++ `#80`_: add :exc:`TypeError` as additional ancestor of
+  :exc:`icat.exception.EntityTypeError`.
+
 .. _#79: https://github.com/icatproject/python-icat/pull/79
+.. _#80: https://github.com/icatproject/python-icat/pull/80
 
 
 0.17.0 (2020-04-30)

--- a/doc/src/exception.rst
+++ b/doc/src/exception.rst
@@ -169,7 +169,8 @@ The class hierarchy for the exceptions is::
    |         +-- IDSNotImplementedError
    +-- InternalError
    +-- ConfigError
-   +-- EntityTypeError
+   +-- TypeError
+   |    +-- EntityTypeError
    +-- VersionMethodError
    +-- SearchResultError
    |    +-- SearchAssertionError
@@ -182,5 +183,6 @@ The class hierarchy for the exceptions is::
         +-- DeprecationWarning
              +-- ICATDeprecationWarning
 
-Here, :exc:`Exception`, :exc:`Warning`, and :exc:`DeprecationWarning`
-are build-in exceptions from the Python standard library.
+Here, :exc:`Exception`, :exc:`TypeError`, :exc:`Warning`, and
+:exc:`DeprecationWarning` are build-in exceptions from the Python
+standard library.

--- a/icat/exception.py
+++ b/icat/exception.py
@@ -346,8 +346,12 @@ class ICATDeprecationWarning(DeprecationWarning):
                % (feature, icatstr))
         super(ICATDeprecationWarning, self).__init__(msg)
 
-class EntityTypeError(_BaseException):
-    """An invalid entity type has been used."""
+class EntityTypeError(_BaseException, TypeError):
+    """An invalid entity type has been used.
+
+    .. versionchanged:: 0.18.0
+        Inherit from :exc:`TypeError`.
+    """
     pass
 
 class VersionMethodError(_BaseException):


### PR DESCRIPTION
`EntityTypeError` is raised in situations where a `TypeError` would also be appropriate. This adds `TypeError` as additional ancestor.