### PR TITLE
Work around an issue in icat.server using DISTINCT in search queries for multiple fields

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -2,6 +2,19 @@ Changelog
 =========
 
 
+0.18.1 (not yet released)
+~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Bug fixes and minor changes
+---------------------------
+
++ `#76`_, `#81`_: work around an issue in icat.server using `DISTINCT`
+  in search queries for multiple fields.
+
+.. _#76: https://github.com/icatproject/python-icat/issues/76
+.. _#81: https://github.com/icatproject/python-icat/pull/81
+
+
 0.18.0 (2021-03-29)
 ~~~~~~~~~~~~~~~~~~~
 

--- a/icat/query.py
+++ b/icat/query.py
@@ -415,8 +415,12 @@ class Query(object):
         else:
             res = "o"
         if self.aggregate:
-            for fct in reversed(self.aggregate.split(':')):
-                res = "%s(%s)" % (fct, res)
+            if len(self.attributes) > 1 and self.aggregate == "DISTINCT":
+                # See discussion in #76
+                res = "%s %s" % (self.aggregate, res)
+            else:
+                for fct in reversed(self.aggregate.split(':')):
+                    res = "%s(%s)" % (fct, res)
         base = "SELECT %s FROM %s o" % (res, self.entity.BeanName)
         joins = ""
         for obj in sorted(subst.keys()):


### PR DESCRIPTION
Omit the brackets for an aggregate function if searching for multiple attributes and the aggregate function is DISTINCT in the `Query` class. This works around an oddity in the parser for JPQL search expressions in `icat.server`.

Close #76.
