### PR TITLE
Change the search result in the case of multiple fields from list to tuple

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -8,11 +8,15 @@ Changelog
 Bug fixes and minor changes
 ---------------------------
 
++ `#82`_: Change the search result in the case of multiple fields from
+  list to tuple.
+
 + `#76`_, `#81`_: work around an issue in icat.server using `DISTINCT`
   in search queries for multiple fields.
 
 .. _#76: https://github.com/icatproject/python-icat/issues/76
 .. _#81: https://github.com/icatproject/python-icat/pull/81
+.. _#82: https://github.com/icatproject/python-icat/pull/82
 
 
 0.18.0 (2021-03-29)

--- a/doc/src/tutorial-search.rst
+++ b/doc/src/tutorial-search.rst
@@ -374,7 +374,7 @@ values of the matching objects.  Listing the names of all datasets::
   [e201215, e201216, e208339, e208341, e208342, e208945, e208946, e208947]
 
 As the name of that keyword argument suggests, we may also search for
-multiple attributes at once.  The result will be a list of attribute
+multiple attributes at once.  The result will be a tuple of attribute
 values rather then a single value for each object found in the query.
 This requires an ICAT server version 4.11 or newer though::
 
@@ -382,7 +382,7 @@ This requires an ICAT server version 4.11 or newer though::
   >>> print(query)
   SELECT i.name, o.name, o.complete, t.name FROM Dataset o JOIN o.investigation AS i JOIN o.type AS t
   >>> client.search(query)
-  [[08100122-EF, e201215, False, raw], [08100122-EF, e201216, False, raw], [10100601-ST, e208339, False, raw], [10100601-ST, e208341, False, raw], [10100601-ST, e208342, False, raw], [12100409-ST, e208945, False, raw], [12100409-ST, e208946, False, raw], [12100409-ST, e208947, True, analyzed]]
+  [(08100122-EF, e201215, False, raw), (08100122-EF, e201216, False, raw), (10100601-ST, e208339, False, raw), (10100601-ST, e208341, False, raw), (10100601-ST, e208342, False, raw), (12100409-ST, e208945, False, raw), (12100409-ST, e208946, False, raw), (12100409-ST, e208947, True, analyzed)]
   
 There are also some aggregate functions that may be applied to search
 results.  Let's count all datasets::

--- a/icat/client.py
+++ b/icat/client.py
@@ -295,7 +295,14 @@ class Client(suds.client.Client):
         :param obj: either a Suds instance object or anything.
         :type obj: :class:`suds.sudsobject.Object` or any type
         :return: the new entity object or obj.
-        :rtype: :class:`list` or :class:`icat.entity.Entity` or any type
+        :rtype: :class:`tuple` or :class:`icat.entity.Entity` or any type
+
+        .. versionchanged:: 0.18.0
+            add support of `fieldSet`.
+
+        .. versionchanged:: 0.18.1
+            changed the return type from :class:`list` to
+            :class:`tuple` in the case of `fieldSet`.
         """
         if obj.__class__.__name__ == 'fieldSet':
             return tuple(obj.fields)

--- a/icat/client.py
+++ b/icat/client.py
@@ -298,7 +298,7 @@ class Client(suds.client.Client):
         :rtype: :class:`list` or :class:`icat.entity.Entity` or any type
         """
         if obj.__class__.__name__ == 'fieldSet':
-            return obj.fields
+            return tuple(obj.fields)
         elif isinstance(obj, suds.sudsobject.Object):
             return self.new(obj)
         else:

--- a/icat/client.py
+++ b/icat/client.py
@@ -287,8 +287,8 @@ class Client(suds.client.Client):
     def getEntity(self, obj):
         """Get the corresponding :class:`icat.entity.Entity` for an object.
 
-        if obj is a `fieldSet`, return the list of fields.  If obj is
-        any other Suds instance object, create a new entity object
+        if obj is a `fieldSet`, return a tuple of the fields.  If obj
+        is any other Suds instance object, create a new entity object
         with :meth:`~icat.client.Client.new`.  Otherwise do nothing
         and return obj unchanged.
         

--- a/tests/test_06_client.py
+++ b/tests/test_06_client.py
@@ -55,21 +55,21 @@ except AttributeError:
 
 @pytest.mark.parametrize(("query", "result"), [
     pytest.param("SELECT o.name, o.title, o.startDate FROM Investigation o",
-                 [["08100122-EF", "Durol single crystal",
-                   datetime.datetime(2008, 3, 13, 11, 39, 42, tzinfo=cet)],
-                  ["10100601-ST", "Ni-Mn-Ga flat cone",
-                   datetime.datetime(2010, 9, 30, 12, 27, 24, tzinfo=cest)],
-                  ["12100409-ST", "NiO SC OF1 JUH HHL",
-                   datetime.datetime(2012, 7, 26, 17, 44, 24, tzinfo=cest)]],
+                 [("08100122-EF", "Durol single crystal",
+                   datetime.datetime(2008, 3, 13, 11, 39, 42, tzinfo=cet)),
+                  ("10100601-ST", "Ni-Mn-Ga flat cone",
+                   datetime.datetime(2010, 9, 30, 12, 27, 24, tzinfo=cest)),
+                  ("12100409-ST", "NiO SC OF1 JUH HHL",
+                   datetime.datetime(2012, 7, 26, 17, 44, 24, tzinfo=cest))],
                  marks=pytest.mark.skipif("cet is None",
                                           reason="require datetime.timezone")),
     ("SELECT i.name, ds.name FROM Dataset ds JOIN ds.investigation AS i "
      "WHERE i.startDate < '2011-01-01'",
-     [["08100122-EF", "e201215"],
-      ["08100122-EF", "e201216"],
-      ["10100601-ST", "e208339"],
-      ["10100601-ST", "e208341"],
-      ["10100601-ST", "e208342"]]),
+     [("08100122-EF", "e201215"),
+      ("08100122-EF", "e201216"),
+      ("10100601-ST", "e208339"),
+      ("10100601-ST", "e208341"),
+      ("10100601-ST", "e208342")]),
 ])
 def test_search_mulitple_fields(client, query, result):
     """Search for mutliple fields.
@@ -148,8 +148,8 @@ def test_assertedSearch_unique_mulitple_fields(client):
         pytest.skip("search for multiple fields not supported by this server")
     query = ("SELECT i.name, i.title, i.startDate FROM Investigation i "
              "WHERE i.name = '08100122-EF'")
-    result = ["08100122-EF", "Durol single crystal",
-              datetime.datetime(2008, 3, 13, 11, 39, 42, tzinfo=cet)]
+    result = ("08100122-EF", "Durol single crystal",
+              datetime.datetime(2008, 3, 13, 11, 39, 42, tzinfo=cet))
     r = client.assertedSearch(query)[0]
     assert isinstance(r, Sequence)
     assert r == result

--- a/tests/test_06_query.py
+++ b/tests/test_06_query.py
@@ -452,14 +452,14 @@ def test_query_mulitple_attributes(client):
     if not client._has_wsdl_type('fieldSet'):
         pytest.skip("search for multiple fields not supported by this server")
 
-    results = [["08100122-EF", "Durol single crystal",
-                datetime.datetime(2008, 3, 13, 10, 39, 42, tzinfo=tzinfo)],
-               ["10100601-ST", "Ni-Mn-Ga flat cone",
-                datetime.datetime(2010, 9, 30, 10, 27, 24, tzinfo=tzinfo)],
-               ["12100409-ST", "NiO SC OF1 JUH HHL",
-                datetime.datetime(2012, 7, 26, 15, 44, 24, tzinfo=tzinfo)]]
+    results = [("08100122-EF", "Durol single crystal",
+                datetime.datetime(2008, 3, 13, 10, 39, 42, tzinfo=tzinfo)),
+               ("10100601-ST", "Ni-Mn-Ga flat cone",
+                datetime.datetime(2010, 9, 30, 10, 27, 24, tzinfo=tzinfo)),
+               ("12100409-ST", "NiO SC OF1 JUH HHL",
+                datetime.datetime(2012, 7, 26, 15, 44, 24, tzinfo=tzinfo))]
     query = Query(client, "Investigation",
-                  attributes=["name", "title", "startDate"], order=True)
+                  attributes=("name", "title", "startDate"), order=True)
     print(str(query))
     res = client.search(query)
     assert res == results
@@ -470,13 +470,13 @@ def test_query_mulitple_attributes_related_obj(client):
     if not client._has_wsdl_type('fieldSet'):
         pytest.skip("search for multiple fields not supported by this server")
 
-    results = [["08100122-EF", "e201215"],
-               ["08100122-EF", "e201216"],
-               ["10100601-ST", "e208339"],
-               ["10100601-ST", "e208341"],
-               ["10100601-ST", "e208342"]]
+    results = [("08100122-EF", "e201215"),
+               ("08100122-EF", "e201216"),
+               ("10100601-ST", "e208339"),
+               ("10100601-ST", "e208341"),
+               ("10100601-ST", "e208342")]
     query = Query(client, "Dataset",
-                  attributes=["investigation.name", "name"], order=True,
+                  attributes=("investigation.name", "name"), order=True,
                   conditions={"investigation.startDate":  "< '2011-01-01'"})
     print(str(query))
     res = client.search(query)
@@ -490,7 +490,7 @@ def test_query_mulitple_attributes_oldicat_valueerror(client):
         pytest.skip("search for multiple fields is supported by this server")
 
     with pytest.raises(ValueError) as err:
-        query = Query(client, "Investigation", attributes=["name", "title"])
+        query = Query(client, "Investigation", attributes=("name", "title"))
     err_pattern = r"\bICAT server\b.*\bnot support\b.*\bmultiple attributes\b"
     assert re.search(err_pattern, str(err.value))
 
@@ -519,7 +519,7 @@ def test_query_mulitple_attributes_distinct(client):
     # The search with DISTINCT yields less items, but if we eliminate
     # duplicates, the result set is the same:
     assert len(res) > len(res_dist)
-    assert set([tuple(l) for l in res]) == set([tuple(l) for l in res_dist])
+    assert set(res) == set(res_dist)
 
 @pytest.mark.skipif(Version(pytest.__version__) < "3.9.0",
                     reason="pytest.deprecated_call() does not work properly")


### PR DESCRIPTION
While working on #81, I noticed another issue in the results of a searching for multiple fields: the `Client.search()` method returns a list of the results. There are situation where it may be convenient to turn that list into a set and in general this works. Note that `Entity` objects are hashable even though they are mutable and that has been made particularly with the intention to allow them to be added as an item to a set.

Now:
```python
>>> query = Query(client, "Investigation")
>>> res = client.search(query)
>>> set(res)
{(investigation){
   createId = "simple/root"
   createTime = 2021-04-13 08:47:18+02:00
   id = 31
   modId = "simple/root"
   modTime = 2021-04-13 08:47:18+02:00
   doi = "00.0815/inv-00122"
   name = "08100122-EF"
   startDate = 2008-03-13 11:39:42+01:00
   title = "Durol single crystal"
   visitId = "1.1-P"
 }, (investigation){
   createId = "simple/root"
   createTime = 2021-04-13 08:47:19+02:00
   id = 33
   modId = "simple/root"
   modTime = 2021-04-13 08:47:19+02:00
   doi = "00.0815/inv-00409"
   endDate = 2012-08-06 03:10:08+02:00
   name = "12100409-ST"
   startDate = 2012-07-26 17:44:24+02:00
   title = "NiO SC OF1 JUH HHL"
   visitId = "1.1-P"
 }, (investigation){
   createId = "simple/root"
   createTime = 2021-04-13 08:47:19+02:00
   id = 32
   modId = "simple/root"
   modTime = 2021-04-13 08:47:19+02:00
   doi = "00.0815/inv-00601"
   endDate = 2010-10-12 17:00:00+02:00
   name = "10100601-ST"
   startDate = 2010-09-30 12:27:24+02:00
   title = "Ni-Mn-Ga flat cone"
   visitId = "1.1-N"
 }}
>>> query = Query(client, "Investigation", attributes="name")
>>> res = client.search(query)
>>> set(res)
{12100409-ST, 08100122-EF, 10100601-ST}
>>> query = Query(client, "Dataset", attributes="investigation.name")
>>> res = client.search(query)
>>> res
[08100122-EF, 08100122-EF, 10100601-ST, 10100601-ST, 10100601-ST, 12100409-ST, 12100409-ST, 12100409-ST]
>>> set(res)
{12100409-ST, 08100122-EF, 10100601-ST}
>>> query = Query(client, "Dataset", attributes=("name", "investigation.name")) 
>>> res = client.search(query)
>>> res
[[e201215, 08100122-EF], [e201216, 08100122-EF], [e208339, 10100601-ST], [e208341, 10100601-ST], [e208342, 10100601-ST], [e208945, 12100409-ST], [e208946, 12100409-ST], [e208947, 12100409-ST]]
>>> set(res)
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
TypeError: unhashable type: 'list'
```

In the case of searching for multiple fields, turning the result into a set fails, because it is a list of lists with attribute values. The present PR changes this to a list of tuples instead.