### PR TITLE
Enable ordering on one to many relationships in class Query

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -2,6 +2,19 @@ Changelog
 =========
 
 
+0.18.2 (not yet released)
+~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Bug fixes and minor changes
+---------------------------
+
++ `#83`_, `#84`_: enable ordering on one to many relationships in
+  class :class:`icat.query.Query`.
+
+.. _#83: https://github.com/icatproject/python-icat/issues/83
+.. _#84: https://github.com/icatproject/python-icat/pull/84
+
+
 0.18.1 (2021-04-13)
 ~~~~~~~~~~~~~~~~~~~
 

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -11,6 +11,11 @@ Bug fixes and minor changes
 + `#83`_, `#84`_: enable ordering on one to many relationships in
   class :class:`icat.query.Query`.
 
++ `#84`_: Add warning classes
+  :exc:`icat.exception.QueryOneToManyOrderWarning` and
+  :exc:`icat.exception.QueryWarning`, the latter being a common base
+  class for warnings emitted during creation of a query.
+
 .. _#83: https://github.com/icatproject/python-icat/issues/83
 .. _#84: https://github.com/icatproject/python-icat/pull/84
 

--- a/doc/src/exception.rst
+++ b/doc/src/exception.rst
@@ -103,7 +103,15 @@ Exceptions raised by python-icat
     :members:
     :show-inheritance:
 
+.. autoexception:: icat.exception.QueryWarning
+    :members:
+    :show-inheritance:
+
 .. autoexception:: icat.exception.QueryNullableOrderWarning
+    :members:
+    :show-inheritance:
+
+.. autoexception:: icat.exception.QueryOneToManyOrderWarning
     :members:
     :show-inheritance:
 
@@ -178,7 +186,9 @@ The class hierarchy for the exceptions is::
    +-- IDSResponseError
    +-- GenealogyError
    +-- Warning
-        +-- QueryNullableOrderWarning
+        +-- QueryWarning
+        |    +-- QueryNullableOrderWarning
+        |    +-- QueryOneToManyOrderWarning
         +-- ClientVersionWarning
         +-- DeprecationWarning
              +-- ICATDeprecationWarning

--- a/icat/exception.py
+++ b/icat/exception.py
@@ -26,7 +26,7 @@ __all__ = [
     # icat.config
     'ConfigError', 
     # icat.query
-    'QueryNullableOrderWarning', 
+    'QueryWarning', 'QueryNullableOrderWarning', 'QueryOneToManyOrderWarning',
     # icat.client, icat.entity
     'ClientVersionWarning', 'ICATDeprecationWarning', 
     'EntityTypeError', 'VersionMethodError', 'SearchResultError', 
@@ -305,13 +305,26 @@ class ConfigError(_BaseException):
 
 # ================ Exceptions raised in icat.query =================
 
-class QueryNullableOrderWarning(Warning):
-    """Warn about using a nullable relation for ordering.
+class QueryWarning(Warning):
+    """Warning while building a query.
+    """
+    pass
+
+class QueryNullableOrderWarning(QueryWarning):
+    """Warn about using a nullable many to one relation for ordering.
     """
     def __init__(self, attr):
-        msg = ("ordering on a nullable relation implicitly "
+        msg = ("ordering on a nullable many to one relation implicitly "
                "adds a '%s IS NOT NULL' condition." % attr)
         super(QueryNullableOrderWarning, self).__init__(msg)
+
+class QueryOneToManyOrderWarning(QueryWarning):
+    """Warn about using a one to many relation for ordering.
+    """
+    def __init__(self, attr):
+        msg = ("ordering on a one to many relation %s may surprisingly "
+               "affect the search result." % attr)
+        super().__init__(msg)
 
 
 # ======== Exceptions raised in icat.client and icat.entity ========

--- a/icat/exception.py
+++ b/icat/exception.py
@@ -307,11 +307,16 @@ class ConfigError(_BaseException):
 
 class QueryWarning(Warning):
     """Warning while building a query.
+
+    .. versionadded:: 0.18.2
     """
     pass
 
 class QueryNullableOrderWarning(QueryWarning):
     """Warn about using a nullable many to one relation for ordering.
+
+    .. versionchanged:: 0.18.2
+        Inherit from :exc:`QueryWarning`.
     """
     def __init__(self, attr):
         msg = ("ordering on a nullable many to one relation implicitly "
@@ -320,6 +325,8 @@ class QueryNullableOrderWarning(QueryWarning):
 
 class QueryOneToManyOrderWarning(QueryWarning):
     """Warn about using a one to many relation for ordering.
+
+    .. versionadded:: 0.18.2
     """
     def __init__(self, attr):
         msg = ("ordering on a one to many relation %s may surprisingly "

--- a/icat/query.py
+++ b/icat/query.py
@@ -291,9 +291,9 @@ class Query(object):
                             warn(QueryNullableOrderWarning(pattr), 
                                  stacklevel=sl)
                     elif attrInfo.relType == "MANY":
-                        raise ValueError("Cannot use one to many relationship "
-                                         "in '%s' to order %s." 
-                                         % (obj, self.entity.BeanName))
+                        sl = 3 if self._init else 2
+                        warn(QueryOneToManyOrderWarning(pattr),
+                             stacklevel=sl)
 
                 if rclass is None:
                     # obj is an attribute, use it right away.

--- a/icat/query.py
+++ b/icat/query.py
@@ -262,8 +262,12 @@ class Query(object):
             name and an order direction, the latter being either "ASC"
             or "DESC" for ascending or descending order respectively.
         :type order: iterable or :class:`bool`
-        :raise ValueError: if `order` contains invalid attributes that
-            either do not exist or contain one to many relationships.
+        :raise ValueError: if any attribute in `order` is not valid.
+
+        .. versionchanged:: 0.18.2
+            allow one to many relationships in `order`.  Emit a
+            :exc:`~icat.exception.QueryOneToManyOrderWarning` rather
+            then raising a :exc:`ValueError` in this case.
         """
         if order is True:
 


### PR DESCRIPTION
- Remove the error condition that prevented to add related objects in a one to many relationships to the `ORDER BY` clause in class `Query`.  Still, emit a warning rather then an error because this may have surprising effects for the search results.
- Add a new warning class `QueryOneToManyOrderWarning` for that purpose and a new class `QueryWarning` as common base for `QueryNullableOrderWarning` and `QueryOneToManyOrderWarning`.

Closes #83.