### PR TITLE
Implement a way to control the join specification used in class Query

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -2,8 +2,17 @@ Changelog
 =========
 
 
-0.19.0 (not yet released)
-~~~~~~~~~~~~~~~~~~~~~~~~~
+0.19.0 (2021-07-20)
+~~~~~~~~~~~~~~~~~~~
+
+New features
+------------
+
++ `#85`_: add an argument `join_specs` to the constructor of class
+  :class:`icat.query.Query` and a corresponding method
+  :meth:`icat.query.Query.setJoinSpecs` to override the join
+  specification to be used in the created query for selected related
+  objects.
 
 Bug fixes and minor changes
 ---------------------------
@@ -18,6 +27,7 @@ Bug fixes and minor changes
 
 .. _#83: https://github.com/icatproject/python-icat/issues/83
 .. _#84: https://github.com/icatproject/python-icat/pull/84
+.. _#85: https://github.com/icatproject/python-icat/pull/85
 
 
 0.18.1 (2021-04-13)

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -2,7 +2,7 @@ Changelog
 =========
 
 
-0.18.2 (not yet released)
+0.19.0 (not yet released)
 ~~~~~~~~~~~~~~~~~~~~~~~~~
 
 Bug fixes and minor changes

--- a/icat/dump_queries.py
+++ b/icat/dump_queries.py
@@ -36,11 +36,9 @@ def getAuthQueries(client):
     return [ Query(client, "User", order=True), 
              Query(client, "Grouping", order=True, 
                    includes={"userGroups", "userGroups.user"}),
-             Query(client, "Rule", order=["what", "id"], 
-                   conditions={"grouping": "IS NULL"}), 
              Query(client, "Rule", order=["grouping.name", "what", "id"], 
-                   conditions={"grouping": "IS NOT NULL"}, 
-                   includes={"grouping"}), 
+                   includes={"grouping"},
+                   join_specs={"grouping": "LEFT JOIN"}),
              Query(client, "PublicStep", order=True) ]
 
 def getStaticQueries(client):

--- a/icat/exception.py
+++ b/icat/exception.py
@@ -308,14 +308,14 @@ class ConfigError(_BaseException):
 class QueryWarning(Warning):
     """Warning while building a query.
 
-    .. versionadded:: 0.18.2
+    .. versionadded:: 0.19.0
     """
     pass
 
 class QueryNullableOrderWarning(QueryWarning):
     """Warn about using a nullable many to one relation for ordering.
 
-    .. versionchanged:: 0.18.2
+    .. versionchanged:: 0.19.0
         Inherit from :exc:`QueryWarning`.
     """
     def __init__(self, attr):
@@ -326,7 +326,7 @@ class QueryNullableOrderWarning(QueryWarning):
 class QueryOneToManyOrderWarning(QueryWarning):
     """Warn about using a one to many relation for ordering.
 
-    .. versionadded:: 0.18.2
+    .. versionadded:: 0.19.0
     """
     def __init__(self, attr):
         msg = ("ordering on a one to many relation %s may surprisingly "

--- a/icat/query.py
+++ b/icat/query.py
@@ -90,7 +90,8 @@ class Query(object):
 
     def __init__(self, client, entity,
                  attributes=None, aggregate=None, order=None,
-                 conditions=None, includes=None, limit=None, attribute=None):
+                 conditions=None, includes=None, limit=None,
+                 join_specs=None, attribute=None):
         """Initialize the query.
         """
 
@@ -125,6 +126,7 @@ class Query(object):
         self.addIncludes(includes)
         self.setOrder(order)
         self.setLimit(limit)
+        self.join_specs = join_specs or dict()
         self._init = None
 
     def _attrpath(self, attrname):
@@ -428,7 +430,8 @@ class Query(object):
         base = "SELECT %s FROM %s o" % (res, self.entity.BeanName)
         joins = ""
         for obj in sorted(subst.keys()):
-            joins += " JOIN %s" % self._dosubst(obj, subst)
+            js = self.join_specs.get(obj, "JOIN")
+            joins += " %s %s" % (js, self._dosubst(obj, subst))
         if self.conditions:
             conds = []
             for a in sorted(self.conditions.keys()):

--- a/icat/query.py
+++ b/icat/query.py
@@ -96,8 +96,10 @@ class Query(object):
         :meth:`~icat.query.Query.setJoinSpecs` method for details.
     :param attribute: alias for `attributes`, retained for
         compatibility.  Deprecated, use `attributes` instead.
-    :raise TypeError: if `entity` is not a valid entity type or if
-        both `attributes` and `attribute` are provided.
+    :raise TypeError: if `entity` is not a valid entity type, if both
+        `attributes` and `attribute` are provided, or if any of the
+        keyword arguments have an invalid type, see the corresponding
+        method for details.
     :raise ValueError: if any of the keyword arguments is not valid,
         see the corresponding method for details.
 

--- a/icat/query.py
+++ b/icat/query.py
@@ -266,7 +266,7 @@ class Query(object):
         :type order: iterable or :class:`bool`
         :raise ValueError: if any attribute in `order` is not valid.
 
-        .. versionchanged:: 0.18.2
+        .. versionchanged:: 0.19.0
             allow one to many relationships in `order`.  Emit a
             :exc:`~icat.exception.QueryOneToManyOrderWarning` rather
             then raising a :exc:`ValueError` in this case.

--- a/icat/query.py
+++ b/icat/query.py
@@ -345,15 +345,17 @@ class Query(object):
 
                 for (pattr, attrInfo, rclass) in self._attrpath(obj):
                     if attrInfo.relType == "ONE":
-                        if (not attrInfo.notNullable and 
-                            pattr not in self.conditions):
+                        if (not attrInfo.notNullable and
+                            pattr not in self.conditions and
+                            pattr not in self.join_specs):
                             sl = 3 if self._init else 2
-                            warn(QueryNullableOrderWarning(pattr), 
+                            warn(QueryNullableOrderWarning(pattr),
                                  stacklevel=sl)
                     elif attrInfo.relType == "MANY":
-                        sl = 3 if self._init else 2
-                        warn(QueryOneToManyOrderWarning(pattr),
-                             stacklevel=sl)
+                        if (pattr not in self.join_specs):
+                            sl = 3 if self._init else 2
+                            warn(QueryOneToManyOrderWarning(pattr),
+                                 stacklevel=sl)
 
                 if rclass is None:
                     # obj is an attribute, use it right away.


### PR DESCRIPTION
Add an argument `join_specs` to the constructor of class `Query` that allows to override the join specification to be used in the created query for selected related objects.   Do not emit `QueryNullableOrderWarning` or `QueryOneToManyOrderWarning` if the concerned relation is in `join_specs`. This has been discussed in #84.

Draft, still missing:
- [x] documentation
- [x] tests