### PR TITLE
SQL Functions for Fields

### DIFF
--- a/icat/query.py
+++ b/icat/query.py
@@ -142,6 +142,8 @@ class Query():
         """
         rclass = self.entity
         pattr = ""
+        if attrname.endswith(')'):
+            attrname = (attrname.split("("))[1].split(")")[0]
         for attr in attrname.split('.'):
             if pattr:
                 pattr += ".%s" % attr
@@ -169,6 +171,8 @@ class Query():
             i = obj.rfind('.')
             if i < 0:
                 continue
+            if obj.endswith(')'):
+                obj = (obj.split("("))[1].split(")")[0]
             obj = obj[:i]
             for (o, attrInfo, oclass) in self._attrpath(obj):
                 if o not in subst:
@@ -373,7 +377,9 @@ class Query():
         """
         if conditions:
             for a in conditions.keys():
-                a_name = (a.split("("))[1].split(")")[0]
+                a_name = a
+                if a.endswith(')'):
+                    a_name = (a.split("("))[1].split(")")[0]
                 for (pattr, attrInfo, rclass) in self._attrpath(a_name):
                     pass
                 if a in self.conditions:
@@ -469,10 +475,13 @@ class Query():
         if self.conditions:
             conds = []
             for a in sorted(self.conditions.keys()):
-                sql_function_name = a.split("(")[0]
-                a_name = (a.split("("))[1].split(")")[0]
+                a_name = a
+                if a.endswith(')'):
+                    sql_function_name = a.split("(")[0]
+                    a_name = (a.split("("))[1].split(")")[0]
                 attr = self._dosubst(a_name, subst, False)
-                attr = f"{sql_function_name}({attr})"
+                if "sql_function_name" in locals():
+                    attr = f"{sql_function_name}({attr})"
                 cond = self.conditions[a]
                 if isinstance(cond, str):
                     conds.append("%s %s" % (attr, cond))

--- a/icat/query.py
+++ b/icat/query.py
@@ -373,7 +373,8 @@ class Query():
         """
         if conditions:
             for a in conditions.keys():
-                for (pattr, attrInfo, rclass) in self._attrpath(a):
+                a_name = (a.split("("))[1].split(")")[0]
+                for (pattr, attrInfo, rclass) in self._attrpath(a_name):
                     pass
                 if a in self.conditions:
                     conds = []
@@ -468,7 +469,10 @@ class Query():
         if self.conditions:
             conds = []
             for a in sorted(self.conditions.keys()):
-                attr = self._dosubst(a, subst, False)
+                sql_function_name = a.split("(")[0]
+                a_name = (a.split("("))[1].split(")")[0]
+                attr = self._dosubst(a_name, subst, False)
+                attr = f"{sql_function_name}({attr})"
                 cond = self.conditions[a]
                 if isinstance(cond, str):
                     conds.append("%s %s" % (attr, cond))


### PR DESCRIPTION
As per #86, I've made some changes to allow SQL functions to be added to fields. I came across an issue where my first commit broke queries with conditions using related fields, but I've since fixed that. I've ran these changes on DataGateway API's tests (which have use cases of related fields, 'ordinary' queries, included entities etc.) and these all pass. 

You might feel these changes require a refactor or could be put in a more appropriate place within Python ICAT and unit tests and documentation from Python ICAT's side. Hopefully this is a good start for this to happen so you don't need to implement our request completely from scratch. I've created a PR so it's easier for yourself (and STFC colleagues) to see the status of this.

For awareness, I'm on leave next week (week commencing 2nd August) so I won't be able to respond/reply to comments. 