### PR TITLE
Support for JPQL Functions on Query Conditions

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -2,6 +2,32 @@ Changelog
 =========
 
 
+0.20.0 (not yet released)
+~~~~~~~~~~~~~~~~~~~~~~~~~
+
+New features
+------------
+
++ `#86`_, `#89`_: allow SQL functions to be used on the attributes in
+  the condtions and order keys in class :class:`icat.query.Query`.
+
+Incompatible changes and new bugs
+---------------------------------
+
++ `#94`_: the implementation of `#89`_ changed the internal data
+  structures in :attr:`icat.query.Query.conditions` and
+  :attr:`icat.query.Query.order`.  These attributes are considered
+  internal and deliberately not documented, so one could argue that
+  this is not an incompatible change, though.  But the changes also
+  have an impact on the return value of
+  :meth:`icat.query.Query.__repr__` such that it is not suitable to
+  recreate the query object.
+
+.. _#86: https://github.com/icatproject/python-icat/issues/86
+.. _#89: https://github.com/icatproject/python-icat/pull/89
+.. _#94: https://github.com/icatproject/python-icat/issues/94
+
+
 0.19.0 (2021-07-20)
 ~~~~~~~~~~~~~~~~~~~
 

--- a/doc/src/tutorial-search.rst
+++ b/doc/src/tutorial-search.rst
@@ -183,6 +183,40 @@ We may also include related objects in the search results::
      visitId = "1.1-N"
    }]
 
+Python ICAT supports the use of some JPQL functions when specifying
+which attribute a condition should be applied to.  Consider the
+following query::
+
+  >>> query = Query(client, "Investigation", conditions={"LENGTH(title)": "= 18"})
+  >>> print(query)
+  SELECT o FROM Investigation o WHERE LENGTH(o.title) = 18
+  >>> client.search(query)
+  [(investigation){
+     createId = "simple/root"
+     createTime = 2021-10-05 14:09:57+00:00
+     id = 430
+     modId = "simple/root"
+     modTime = 2021-10-05 14:09:57+00:00
+     doi = "00.0815/inv-00601"
+     endDate = 2010-10-12 15:00:00+00:00
+     name = "10100601-ST"
+     startDate = 2010-09-30 10:27:24+00:00
+     title = "Ni-Mn-Ga flat cone"
+     visitId = "1.1-N"
+   }, (investigation){
+     createId = "simple/root"
+     createTime = 2021-10-05 14:09:58+00:00
+     id = 431
+     modId = "simple/root"
+     modTime = 2021-10-05 14:09:58+00:00
+     doi = "00.0815/inv-00409"
+     endDate = 2012-08-06 01:10:08+00:00
+     name = "12100409-ST"
+     startDate = 2012-07-26 15:44:24+00:00
+     title = "NiO SC OF1 JUH HHL"
+     visitId = "1.1-P"
+   }]
+
 The conditions in a query may also be put on the attributes of related
 objects.  This allows rather complex queries.  Let us search for the
 datasets in this investigation that have been measured in a magnetic

--- a/icat/query.py
+++ b/icat/query.py
@@ -396,7 +396,13 @@ class Query(object):
             more then one condition on a single attribute.  If the
             query already has a condition on a given attribute, it
             will be turned into a list with the new condition(s)
-            appended.
+            appended.  The attribute name (the key of the condition)
+            can be wrapped with a JPQL function (such as
+            "UPPER(title)"), with each part of the key being split in
+            `_split_db_functs()`.  When the condition is added to
+            `self.conditions`, the condition's key is changed to a
+            tuple to represent the attribute name and the JPQL
+            function respectively.
         :type conditions: :class:`dict`
         :raise ValueError: if any key in `conditions` is not valid.
         """

--- a/icat/query.py
+++ b/icat/query.py
@@ -215,6 +215,15 @@ class Query(object):
             n += " AS %s" % (subst[obj])
         return n
 
+    def _split_db_functs(self, a):
+        if a.endswith(")"):
+            jpql_function_name = a.split("(")[0]
+            attr_name = (a.split("("))[1].split(")")[0]
+
+            return (attr_name, jpql_function_name)
+
+        return (a, None)
+
     def setAttributes(self, attributes):
         """Set the attributes that the query shall return.
 

--- a/icat/query.py
+++ b/icat/query.py
@@ -356,8 +356,12 @@ class Query(object):
 
                 for (pattr, attrInfo, rclass) in self._attrpath(obj):
                     if attrInfo.relType == "ONE":
+                        conditions_attrs = [
+                            attr_name
+                            for attr_name, jpql_funct in self.conditions
+                        ]
                         if (not attrInfo.notNullable and
-                            pattr not in self.conditions and
+                            pattr not in conditions_attrs and
                             pattr not in self.join_specs):
                             sl = 3 if self._init else 2
                             warn(QueryNullableOrderWarning(pattr),

--- a/tests/test_06_query.py
+++ b/tests/test_06_query.py
@@ -291,13 +291,17 @@ def test_query_condition_jpql_function(client):
     This test also applies `UPPER()` on the data to mitigate instances of Oracle
     databases which are case sensitive.
     """
-    conditions = {"UPPER(title)": "like UPPER('%Ni-Mn-Ga flat cone%')"}
+    conditions = {
+        "UPPER(title)": "like UPPER('%Ni-Mn-Ga flat cone%')",
+        "UPPER(datasets.name)": "like UPPER('%e208341%')",
+    }
     query = Query(client, "Investigation", conditions=conditions)
     print(str(query))
 
     expected_query_str = (
-        "SELECT o FROM Investigation o WHERE UPPER(o.title) like"
-        " UPPER('%Ni-Mn-Ga flat cone%')"
+        "SELECT o FROM Investigation o JOIN o.datasets AS s1"
+        " WHERE UPPER(s1.name) like UPPER('%e208341%') AND"
+        " UPPER(o.title) like UPPER('%Ni-Mn-Ga flat cone%')"
     )
     assert str(query) == expected_query_str
 

--- a/tests/test_06_query.py
+++ b/tests/test_06_query.py
@@ -308,6 +308,18 @@ def test_query_condition_jpql_function(client):
     res = client.search(query)
     assert len(res) == 1
 
+@pytest.mark.xfail(reason="See comment in #89")
+def test_query_condition_jpql_function_mixed(client):
+    """Mix conditions with and without JPQL function on the same attribute.
+    This test case failed for an early implementation of JPQL
+    functions, see discussion in #89.
+    """
+    conditions = { "LENGTH(fullName)": "> 11", "fullName": "> 'C'" }
+    query = Query(client, "User", conditions=conditions)
+    print(str(query))
+    res = client.search(query)
+    assert len(res) == 3
+
 def test_query_rule_order(client):
     """Rule does not have a constraint, id is included in the natural order.
     """

--- a/tests/test_06_query.py
+++ b/tests/test_06_query.py
@@ -285,6 +285,25 @@ def test_query_condition_obj(client):
     res = client.search(query)
     assert len(res) == 60
 
+@pytest.mark.dependency(depends=['get_investigation'])
+def test_query_condition_jpql_function(client):
+    """Functions may be applied to field names of conditions.
+    This test also applies `UPPER()` on the data to mitigate instances of Oracle
+    databases which are case sensitive.
+    """
+    conditions = {"UPPER(title)": "like UPPER('%Ni-Mn-Ga flat cone%')"}
+    query = Query(client, "Investigation", conditions=conditions)
+    print(str(query))
+
+    expected_query_str = (
+        "SELECT o FROM Investigation o WHERE UPPER(o.title) like"
+        " UPPER('%Ni-Mn-Ga flat cone%')"
+    )
+    assert str(query) == expected_query_str
+
+    res = client.search(query)
+    assert len(res) == 1
+
 def test_query_rule_order(client):
     """Rule does not have a constraint, id is included in the natural order.
     """


### PR DESCRIPTION
Since my last PR, I went back and made some changes to my implementation of #86. I've created a new branch for this as we would like to target this for a 0.20.0 but also it was easier for me to start from a fresh branch.

The changes mean that when conditions are put into `self.conditions`, the key of the condition becomes a tuple:
`{("title", "UPPER"): "like '%PolICE%'"}`

This means that a user can create a condition in the same way that they do in 0.19.0. A user will not notice any difference with these changes, but they will be able to make use of the new feature if desired.

Where `self.conditions` is accessed, I have made changes to work with the new key format, particularly in `__str__`.

I've tried to address all of your comments of my previous implementation:
- I've added a test in `test_06_query.py` (dac6a3d37d193860e55350deefdedb955dd485f7 & ce681262cde631b89239dd79069bf21de899c6a9) - this tests the functionality on an attribute as well as an attribute from a related entity. It uses the `UPPER()` function which is DataGateway's intended use case for this. I did also test `LENGTH()` for the tutorial which worked but didn't add this as a explicit test
- I've created a dedicated function to split the attribute name from the function name, `_split_db_functs` (851fef2e7bb88b96e0a048318d1d54c4156372c6)
- I've made sure the split function is only executed where for the query conditions (e141e547bdfdf7cd6b0a5782f24400cdaf9aae1b).  It is only called in `addConditions()` as this is the only intended place for this feature for the moment. There are no calls in low level functions now.
- I have also documented this in the docstring of `addConditions()` and the tutorial (c825b800646ae3f3725e708fd935306851f83536)