### PR TITLE
Fix documentation build

### DIFF
--- a/.rtd-require
+++ b/.rtd-require
@@ -1,3 +1,4 @@
+docutils<0.18
 setuptools_scm
 suds-community
 PyYAML

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -2,6 +2,17 @@ Changelog
 =========
 
 
+0.20.1 (not yet released)
+~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Bug fixes and minor changes
+---------------------------
+
++ `#96`_: Fix failing build of the documentation at Read the Docs.
+
+.. _#96: https://github.com/icatproject/python-icat/pull/96
+
+
 0.20.0 (2021-10-29)
 ~~~~~~~~~~~~~~~~~~~
 


### PR DESCRIPTION
Pin `docutils<0.18` when building the documentation at Read the Docs to fix build errors.  Ref. sphinx-doc/sphinx#9727.