### PR TITLE
Get/set query conditions via string input

### DIFF
--- a/icat/query.py
+++ b/icat/query.py
@@ -225,6 +225,13 @@ class Query(object):
         if not m:
             raise ValueError("Invalid attribute '%s'" % attr)
         return m.group(2,1)
+    
+    def _cond_value(self, rhs, func):
+        rhs = rhs.replace('%', '%%')
+        if func:
+            return "%s(%%s) %s" % (func, rhs)
+        else:
+            return "%%s %s" % (rhs)
 
     def setAttributes(self, attributes):
         """Set the attributes that the query shall return.
@@ -427,12 +434,6 @@ class Query(object):
         .. versionchanged:: 0.20.0
             allow a JPQL function in the attribute.
         """
-        def _cond_value(rhs, func):
-            rhs = rhs.replace('%', '%%')
-            if func:
-                return "%s(%%s) %s" % (func, rhs)
-            else:
-                return "%%s %s" % (rhs)
         if conditions:
             for k in conditions.keys():
                 if isinstance(conditions[k], basestring):
@@ -442,7 +443,7 @@ class Query(object):
                 a, jpql_func = self._split_db_functs(k)
                 for (pattr, attrInfo, rclass) in self._attrpath(a):
                     pass
-                v = [ _cond_value(rhs, jpql_func) for rhs in conds ]
+                v = [ self._cond_value(rhs, jpql_func) for rhs in conds ]
                 if a in self.conditions:
                     self.conditions[a].extend(v)
                 else:

--- a/icat/query.py
+++ b/icat/query.py
@@ -448,6 +448,9 @@ class Query(object):
                 else:
                     self.conditions[a] = v
 
+    def setConditionsByString(self, str_conditions):
+        self.str_conditions = str_conditions
+
     def addIncludes(self, includes):
         """Add related objects to build the INCLUDE clause from.
 

--- a/icat/query.py
+++ b/icat/query.py
@@ -551,7 +551,8 @@ class Query(object):
         if self.conditions:
             conds = self.get_conditions_as_str()
             where = " WHERE " + " AND ".join(conds)
-        elif self.str_conditions:where = " WHERE " + self.str_conditions
+        elif self.str_conditions:
+            where = " WHERE " + self.str_conditions
             
         else:
             where = ""

--- a/tests/test_06_query.py
+++ b/tests/test_06_query.py
@@ -297,6 +297,21 @@ def test_query_str_condition(client):
         f"SELECT o FROM Investigation o WHERE {conditions_string}"
     )
 
+def test_query_search_conditions(client):
+    """Test that conditions can be searched in `Query()`"""
+    conditions = {
+        "title": "like '%Ni-Mn-Ga flat cone%'",
+        "datasets.name": "like '%e208341%'",
+    }
+    query = Query(client, "Investigation", conditions=conditions)
+    print(str(query))
+
+    conds = query.search_conditions(
+        "title", {"title": "%s like '%%Ni-Mn-Ga flat cone%%'"},
+    )
+
+    assert conds == ["o.title like '%Ni-Mn-Ga flat cone%'"]
+
 def test_query_condition_jpql_function(client):
     """Functions may be applied to field names of conditions.
     This test also applies `UPPER()` on the data to mitigate instances

--- a/tests/test_06_query.py
+++ b/tests/test_06_query.py
@@ -285,6 +285,18 @@ def test_query_condition_obj(client):
     res = client.search(query)
     assert len(res) == 60
 
+def test_query_str_condition(client):
+    """Conditions can be manually constructed into a string and be passed to
+    `Query()` for use in the string representation of the class
+    """
+    conditions_string = "(o.name = 'test name' OR o.id = '3')"
+    query = Query(client, "Investigation",
+                  str_conditions=conditions_string)
+    print(str(query))
+    assert str(query) == (
+        f"SELECT o FROM Investigation o WHERE {conditions_string}"
+    )
+
 def test_query_condition_jpql_function(client):
     """Functions may be applied to field names of conditions.
     This test also applies `UPPER()` on the data to mitigate instances


### PR DESCRIPTION
Here are some proposed changes I'd like to make to Python ICAT which we help us implement the search API.

I have moved the building of the WHERE clause from `__str__()` to its own function (`get_conditions_as_str()`) so it can be more easily exposed to the search API. I've also moved some code into `get_joinattrs()` as this is used in a couple of places. This is just coding moving to their own functions so we can access more easily, there is no additional functionality in this part of the changes.

The additional functionality is `str_conditions`. This will allow us to pass in a string of conditions ready to be used in `__str__()`. You can see a demonstration of this in the test I've added. This functionality means we can build the WHERE clause ourselves and use `Query()` for the rest of the query building. We will be able to build complex WHERE clauses and use `OR`, so this PR will close #93.

I'll leave this as a draft pull request while we're still working out how to implement certain aspects of the search API (e.g. convert a request filter input in the PaNOSC data model to the ICAT schema) but it would be good if you could take a look and give us your thoughts on these changes :)