### PR TITLE
Fix tests failing with PyYAML 6.0

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -56,6 +56,8 @@ Incompatible changes and deprecations
 Bug fixes and minor changes
 ---------------------------
 
++ `#101`_: Fix tests failing with PyYAML 6.0.
+
 + Some (more) example scripts now require ICAT 4.4.0 or newer.
 
 .. _#66: https://github.com/icatproject/python-icat/issues/66

--- a/doc/examples/add-investigation-data.py
+++ b/doc/examples/add-investigation-data.py
@@ -55,7 +55,7 @@ if conf.datafile == "-":
     f = sys.stdin
 else:
     f = open(conf.datafile, 'r')
-data = yaml.load(f)
+data = yaml.safe_load(f)
 f.close()
 
 try:

--- a/doc/examples/add-job.py
+++ b/doc/examples/add-job.py
@@ -55,7 +55,7 @@ if conf.datafile == "-":
     f = sys.stdin
 else:
     f = open(conf.datafile, 'r')
-data = yaml.load(f)
+data = yaml.safe_load(f)
 f.close()
 
 try:

--- a/doc/examples/create-investigation.py
+++ b/doc/examples/create-investigation.py
@@ -56,7 +56,7 @@ if conf.datafile == "-":
     f = sys.stdin
 else:
     f = open(conf.datafile, 'r')
-data = yaml.load(f)
+data = yaml.safe_load(f)
 f.close()
 
 try:

--- a/doc/examples/create-sampletype.py
+++ b/doc/examples/create-sampletype.py
@@ -31,7 +31,7 @@ if conf.datafile == "-":
     f = sys.stdin
 else:
     f = open(conf.datafile, 'r')
-data = yaml.load(f)
+data = yaml.safe_load(f)
 f.close()
 
 try:

--- a/doc/examples/init-icat.py
+++ b/doc/examples/init-icat.py
@@ -62,7 +62,7 @@ if conf.datafile == "-":
     f = sys.stdin
 else:
     f = open(conf.datafile, 'r')
-data = yaml.load(f)
+data = yaml.safe_load(f)
 f.close()
 
 

--- a/doc/examples/querytest.py
+++ b/doc/examples/querytest.py
@@ -27,7 +27,7 @@ if conf.datafile == "-":
     f = sys.stdin
 else:
     f = open(conf.datafile, 'r')
-data = yaml.load(f)
+data = yaml.safe_load(f)
 f.close()
 
 


### PR DESCRIPTION
Calling `yaml.load()` without providing the `Loader` argument has been deprecated in PyYAML 5.1 and been dropped in PyYAML 6.0. This updates several example scripts to call `yaml.safe_load()` instead than `yaml.load()` (which is essentially the same as adding a `SafeLoader` argument in the `yaml.load()` call).

Note that while the change is only in examples, some of them are also used in the test suite. So this change also fixes the tests to fail with PyYAML 6.0.