### PR TITLE
Allow to directly pass configuration values in the icat.config.Config() call

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -8,6 +8,10 @@ Changelog
 New features
 ------------
 
++ `#77`_, `#103`_: Add a keyword argument `preset` to allow directly
+  passing configuration values to the constructor of class
+  :class:`icat.config.Config`.
+
 + `#66`_, `#75`_: Add pathlib support: methods that take a file name
   argument also accept a :class:`pathlib.Path` object. Internal
   representation of filesystem paths are changed to use
@@ -53,6 +57,9 @@ Incompatible changes and deprecations
 + Drop helper function :func:`icat.exception.stripCause`, deprecated
   in 0.14.0.
 
++ Deprecate :data:`icat.config.defaultsection`.  Use the new `preset`
+  keyword argument to :class:`icat.config.Config` instead.
+
 Bug fixes and minor changes
 ---------------------------
 
@@ -63,7 +70,9 @@ Bug fixes and minor changes
 .. _#66: https://github.com/icatproject/python-icat/issues/66
 .. _#74: https://github.com/icatproject/python-icat/issues/74
 .. _#75: https://github.com/icatproject/python-icat/pull/75
+.. _#77: https://github.com/icatproject/python-icat/issues/77
 .. _#101: https://github.com/icatproject/python-icat/pull/101
+.. _#103: https://github.com/icatproject/python-icat/pull/103
 
 
 0.21.0 (2022-01-28)

--- a/doc/src/config.rst
+++ b/doc/src/config.rst
@@ -148,11 +148,11 @@ for the configuration variables are as follows:
 +=================+=============================+=======================+================+===========+==============+
 | `configFile`    | ``-c``, ``--configfile``    | ``ICAT_CFG``          | depends        | no        | \(1)         |
 +-----------------+-----------------------------+-----------------------+----------------+-----------+--------------+
-| `configSection` | ``-s``, ``--configsection`` | ``ICAT_CFG_SECTION``  | :const:`None`  | no        | \(2)         |
+| `configSection` | ``-s``, ``--configsection`` | ``ICAT_CFG_SECTION``  | :const:`None`  | no        |              |
 +-----------------+-----------------------------+-----------------------+----------------+-----------+--------------+
 | `url`           | ``-w``, ``--url``           | ``ICAT_SERVICE``      |                | yes       |              |
 +-----------------+-----------------------------+-----------------------+----------------+-----------+--------------+
-| `idsurl`        | ``--idsurl``                | ``ICAT_DATA_SERVICE`` | :const:`None`  | depends   | \(3)         |
+| `idsurl`        | ``--idsurl``                | ``ICAT_DATA_SERVICE`` | :const:`None`  | depends   | \(2)         |
 +-----------------+-----------------------------+-----------------------+----------------+-----------+--------------+
 | `checkCert`     | ``--check-certificate``,    |                       | :const:`True`  | no        |              |
 |                 | ``--no-check-certificate``  |                       |                |           |              |
@@ -163,13 +163,13 @@ for the configuration variables are as follows:
 +-----------------+-----------------------------+-----------------------+----------------+-----------+--------------+
 | `no_proxy`      | ``--no-proxy``              | ``no_proxy``          | :const:`None`  | no        |              |
 +-----------------+-----------------------------+-----------------------+----------------+-----------+--------------+
-| `auth`          | ``-a``, ``--auth``          | ``ICAT_AUTH``         |                | yes       | \(4)         |
+| `auth`          | ``-a``, ``--auth``          | ``ICAT_AUTH``         |                | yes       | \(3)         |
 +-----------------+-----------------------------+-----------------------+----------------+-----------+--------------+
-| `username`      | ``-u``, ``--user``          | ``ICAT_USER``         |                | yes       | \(4),(5)     |
+| `username`      | ``-u``, ``--user``          | ``ICAT_USER``         |                | yes       | \(3),(4)     |
 +-----------------+-----------------------------+-----------------------+----------------+-----------+--------------+
-| `password`      | ``-p``, ``--pass``          |                       | interactive    | yes       | \(4),(5),(6) |
+| `password`      | ``-p``, ``--pass``          |                       | interactive    | yes       | \(3),(4),(5) |
 +-----------------+-----------------------------+-----------------------+----------------+-----------+--------------+
-| `promptPass`    | ``-P``, ``--prompt-pass``   |                       | :const:`False` | no        | \(4),(5),(6) |
+| `promptPass`    | ``-P``, ``--prompt-pass``   |                       | :const:`False` | no        | \(3),(4),(5) |
 +-----------------+-----------------------------+-----------------------+----------------+-----------+--------------+
 
 Mandatory means that an error will be raised in
@@ -180,20 +180,17 @@ Notes:
 
 1. The default value for `configFile` depends on the operating system.
 
-2. The default value for `configSection` may be changed in
-   :data:`icat.config.defaultsection`.
-
-3. The configuration variable `idsurl` will not be set up at all, or
+2. The configuration variable `idsurl` will not be set up at all, or
    be set up as a mandatory, or as an optional variable, if the `ids`
    argument to the constructor of :class:`icat.config.Config` is set
    to :const:`False`, to "mandatory", or to "optional" respectively.
 
-4. If the argument `needlogin` to the constructor of
+3. If the argument `needlogin` to the constructor of
    :class:`icat.config.Config` is set to :const:`False`, the
    configuration variables `auth`, `username`, `password`,
    `promptPass`, and `credentials` will be left out.
 
-5. If the ICAT server supports the
+4. If the ICAT server supports the
    :meth:`icat.client.Client.getAuthenticatorInfo` API call
    (icat.server 4.9.0 and newer), the server will be queried about the
    credentials required for the authenticator indicated by the value
@@ -202,7 +199,7 @@ Notes:
    setup only if any of the credentials is marked as hidden in the
    authenticator information.
 
-6. The user will be prompted for the password if `promptPass` is
+5. The user will be prompted for the password if `promptPass` is
    :const:`True`, if no `password` is provided in the command line or
    the configuration file, or if the `username`, but not the
    `password` has been provided by command line arguments.  This

--- a/doc/src/tutorial-config-advanced.rst
+++ b/doc/src/tutorial-config-advanced.rst
@@ -385,3 +385,25 @@ object's ID is 10, so we write::
   deleting the User object with ID 10...
   done
 
+Preset configuration values in the program
+------------------------------------------
+
+It is possible to preset the value for configuration variables in the
+program, using the `preset` keyword argument to
+:class:`~icat.config.Config`.  Consider the following example program:
+
+.. literalinclude:: ../tutorial/config-preset.py
+
+You can call this as follows::
+
+  $ python config-preset.py
+  Login to https://icat.example.com:8181 was successful.
+  User: simple/root
+
+Note that we did not specify the configuration section on the command
+line, yet the program picked the configuration values from the
+`myicat_root` section in the configuration file.  Setting values using
+the `preset` keyword argument has a similar effect as setting a
+default for the respective configuration variable.  But it also allows
+to override the default for configuration variables that are
+predefined by :mod:`icat.config`.

--- a/doc/tutorial/config-preset.py
+++ b/doc/tutorial/config-preset.py
@@ -1,0 +1,12 @@
+#! /usr/bin/python
+
+import icat
+import icat.config
+
+config = icat.config.Config(ids="optional",
+                            preset={"configSection": "myicat_root"})
+client, conf = config.getconfig()
+client.login(conf.auth, conf.credentials)
+
+print("Login to %s was successful." % (conf.url))
+print("User: %s" % (client.getUserName()))

--- a/icat/config.py
+++ b/icat/config.py
@@ -342,6 +342,18 @@ class ConfigSourceInteractive(ConfigSource):
             return variable.get(getpass.getpass(prompt))
 
 
+class ConfigSourcePreset(ConfigSource):
+    """Apply presets of configuration values from the calling script.
+    """
+
+    def __init__(self, values):
+        super().__init__()
+        self.preset_values = values
+
+    def get(self, variable):
+        return variable.get(self.preset_values.get(variable.name))
+
+
 class ConfigSourceDefault(ConfigSource):
     """Handle the case that some variable is not set from any other source.
     """
@@ -628,6 +640,8 @@ class Config(BaseConfig):
         variable, if this is set to :const:`False`, to 'mandatory', or
         to 'optional' respectively.
     :type ids: :class:`bool` or :class:`str`
+    :param preset: mapping of configuration variable names to preset values.
+    :type preset: :class:`dict`
     :param args: list of command line arguments or :const:`None`.  If
         not set, the command line arguments will be taken from
         :data:`sys.argv`.
@@ -635,7 +649,7 @@ class Config(BaseConfig):
     """
 
     def __init__(self, defaultvars=True, needlogin=True, ids="optional", 
-                 args=None):
+                 preset=None, args=None):
         """Initialize the object.
         """
         super().__init__(argparse.ArgumentParser())
@@ -645,8 +659,13 @@ class Config(BaseConfig):
         self.conffile = ConfigSourceFile(defaultFiles)
         self.interactive = ConfigSourceInteractive()
         self.defaults = ConfigSourceDefault()
-        self.sources = [ self.cmdargs, self.environ, self.conffile, 
-                         self.interactive, self.defaults ]
+        if preset:
+            self.preset = ConfigSourcePreset(preset)
+            self.sources = [ self.cmdargs, self.environ, self.conffile,
+                             self.interactive, self.preset, self.defaults ]
+        else:
+            self.sources = [ self.cmdargs, self.environ, self.conffile,
+                             self.interactive, self.defaults ]
         self.args = args
         self._add_fundamental_variables()
         if defaultvars:

--- a/icat/config.py
+++ b/icat/config.py
@@ -671,6 +671,11 @@ class Config(BaseConfig):
             self.sources = [ self.cmdargs, self.environ, self.conffile,
                              self.interactive, self.defaults ]
         self.args = args
+        if defaultsection is not None:
+            warnings.warn("Deprecated setting of 'defaultsection' detected. "
+                          "Use the 'preset' keyword argument "
+                          "to class 'Config' instead.",
+                          DeprecationWarning, stacklevel=2)
         self._add_fundamental_variables()
         if defaultvars:
             self.needlogin = needlogin

--- a/icat/config.py
+++ b/icat/config.py
@@ -37,7 +37,11 @@ else:
 cfgfile = "icat.cfg"
 """Configuration file name"""
 defaultsection = None
-"""Default value for `configSection`"""
+"""Default value for `configSection`
+
+.. deprecated:: 1.0.0
+   Use the `preset` keyword argument to :class:`icat.config.Config` instead.
+"""
 
 # Internal hack, intentionally not documented.
 _argparse_divert_syserr = True

--- a/icat/config.py
+++ b/icat/config.py
@@ -644,7 +644,11 @@ class Config(BaseConfig):
         variable, if this is set to :const:`False`, to 'mandatory', or
         to 'optional' respectively.
     :type ids: :class:`bool` or :class:`str`
-    :param preset: mapping of configuration variable names to preset values.
+    :param preset: mapping of configuration variable names to preset
+        values.  These preset values override the default value for
+        the corresponding variable.  Note that command line arguments,
+        environment variables, and settings in the configuration files
+        still take precedence over the preset values.
     :type preset: :class:`dict`
     :param args: list of command line arguments or :const:`None`.  If
         not set, the command line arguments will be taken from

--- a/icat/config.py
+++ b/icat/config.py
@@ -662,7 +662,7 @@ class Config(BaseConfig):
         if preset:
             self.preset = ConfigSourcePreset(preset)
             self.sources = [ self.cmdargs, self.environ, self.conffile,
-                             self.interactive, self.preset, self.defaults ]
+                             self.preset, self.interactive, self.defaults ]
         else:
             self.sources = [ self.cmdargs, self.environ, self.conffile,
                              self.interactive, self.defaults ]

--- a/tests/test_01_config.py
+++ b/tests/test_01_config.py
@@ -92,6 +92,10 @@ username = nbour
 url = https://icat.example.com/ICATService/ICAT?wsdl
 auth = anon
 
+[example_quirks]
+url = https://icat.example.com/ICATService/ICAT?wsdl
+auth = quirks
+
 [test21]
 url = https://icat.example.com/ICATService/ICAT?wsdl
 auth = simple
@@ -180,6 +184,34 @@ def test_config_minimal_file(fakeClient, tmpconfigfile, monkeypatch):
 
     ex = ExpectedConf(configFile=[Path("icat.cfg")],
                       configSection="example_root", 
+                      url=ex_icat)
+    assert ex <= conf
+
+
+def test_config_minimal_file_preset(fakeClient, tmpconfigfile, monkeypatch):
+    """Minimal example.
+
+    Almost the same as test_config_minimal_file(), but set the section
+    to be read from the config file as a preset variable rather than
+    faking the comandline arguments.
+
+    The `preset` keyword argument to `Config()` was added in response
+    to the feature request Issue #77.
+    """
+
+    # Let the config file be found in the default location, but
+    # manipulate the search path such that only the cwd exists.
+    cfgdirs = [ tmpconfigfile.dir / "wobble", Path(".") ]
+    monkeypatch.setattr(icat.config, "cfgdirs", cfgdirs)
+    monkeypatch.chdir(str(tmpconfigfile.dir))
+
+    preset = {"configSection": "example_root"}
+    config = icat.config.Config(needlogin=False, ids=False,
+                                preset=preset, args=())
+    _, conf = config.getconfig()
+
+    ex = ExpectedConf(configFile=[Path("icat.cfg")],
+                      configSection="example_root",
                       url=ex_icat)
     assert ex <= conf
 
@@ -799,14 +831,51 @@ def test_config_authinfo_strange(fakeClient, monkeypatch, tmpconfigfile):
     ]
     monkeypatch.setattr(FakeClient, "AuthInfo", authInfo)
 
-    args = ["-c", str(tmpconfigfile.path), "-s", "example_root",
-            "-a", "quirks", "--cred_secret", "geheim"]
+    args = ["-c", str(tmpconfigfile.path), "-s", "example_quirks",
+            "--cred_secret", "geheim"]
     config = icat.config.Config(args=args)
     assert list(config.authenticatorInfo) == authInfo
     _, conf = config.getconfig()
 
     ex = ExpectedConf(configFile=[tmpconfigfile.path],
-                      configSection="example_root",
+                      configSection="example_quirks",
+                      url=ex_icat,
+                      auth="quirks",
+                      promptPass=False,
+                      cred_secret="geheim",
+                      credentials={'secret': 'geheim'})
+    assert ex <= conf
+    assert not hasattr(conf, 'username')
+
+
+def test_config_authinfo_strange_preset(fakeClient, monkeypatch, tmpconfigfile):
+    """Talk to a server that requests strange credential keys.
+
+    Almost the same as test_config_authinfo_strange(), but set the
+    configuration as preset variables rather than faking the
+    comandline arguments.
+
+    The `preset` keyword argument to `Config()` was added in response
+    to the feature request Issue #77.  One major use case for
+    requesting that feature was related to custom authenticators.
+    """
+
+    secretkey = Namespace(name='secret', hide=True)
+    authInfo = [
+        Namespace(mnemonic="quirks",
+                  keys=[secretkey]),
+    ]
+    monkeypatch.setattr(FakeClient, "AuthInfo", authInfo)
+
+    preset = {"configFile": str(tmpconfigfile.path),
+              "configSection": "example_quirks",
+              "cred_secret": "geheim",}
+    config = icat.config.Config(preset=preset, args=())
+    assert list(config.authenticatorInfo) == authInfo
+    _, conf = config.getconfig()
+
+    ex = ExpectedConf(configFile=[tmpconfigfile.path],
+                      configSection="example_quirks",
                       url=ex_icat,
                       auth="quirks",
                       promptPass=False,

--- a/tests/test_09_deprecations.py
+++ b/tests/test_09_deprecations.py
@@ -4,4 +4,9 @@
 import pytest
 import icat
 
-# No deprecations for the moment.
+# Deprecations not tested in this module:
+# - Module variable icat.config.defaultsection.
+#   It's easier to test this in the setting of the test_01_config.py
+#   module.
+#
+# No other deprecations for the moment.


### PR DESCRIPTION
Add a `preset` keyword argument to the constructor of class `icat.config.Config`.  If set, it must be a mapping of configuration variable names to values. This will override the default values of the respective configuration variables.

In difference to what was suggested in #77, I decided to name that keyword argument `preset` and to make the values set in the argument only defaults, e.g. settings in command line arguments, environment variables, and configuration files still take precedence.

Deprecate the module variable `icat.config.defaultsection` in favour of this new feature.

Close #77.