### PR TITLE
Make the obj argument to client.new() case insensitive

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -8,6 +8,9 @@ Changelog
 New features
 ------------
 
++ `#102`_, `#104`_: Make the obj argument to client.new() case
+  insensitive.
+
 + `#77`_, `#103`_: Add a keyword argument `preset` to allow directly
   passing configuration values to the constructor of class
   :class:`icat.config.Config`.
@@ -72,7 +75,9 @@ Bug fixes and minor changes
 .. _#75: https://github.com/icatproject/python-icat/pull/75
 .. _#77: https://github.com/icatproject/python-icat/issues/77
 .. _#101: https://github.com/icatproject/python-icat/pull/101
+.. _#102: https://github.com/icatproject/python-icat/issues/102
 .. _#103: https://github.com/icatproject/python-icat/pull/103
+.. _#104: https://github.com/icatproject/python-icat/pull/104
 
 
 0.21.0 (2022-01-28)

--- a/doc/src/tutorial-create.rst
+++ b/doc/src/tutorial-create.rst
@@ -24,7 +24,7 @@ The :meth:`~icat.client.Client.search` result shows that there is no
 ``Facility`` object in ICAT.  Let's create one.  In the same session,
 type::
 
-  >>> f1 = client.new("facility")
+  >>> f1 = client.new("Facility")
   >>> f1.name = "Fac1"
   >>> f1.fullName = "Facility 1"
   >>> f1.id = client.create(f1)
@@ -54,7 +54,7 @@ arguments to set the attributes of the new object.  Furthermore, the
 :meth:`~icat.entity.Entity.create` method to create this object in the
 ICAT server.  We thus could achieve the same as above like this::
 
-  >>> f2 = client.new("facility", name="Fac2", fullName="Facility 2")
+  >>> f2 = client.new("Facility", name="Fac2", fullName="Facility 2")
   >>> f2.create()
 
 To verify the result, we check again::
@@ -94,7 +94,7 @@ the output from the :meth:`~icat.client.Client.search` call above.
 
 Now consider the following example::
 
-  >>> pt1 = client.new("parameterType")
+  >>> pt1 = client.new("ParameterType")
   >>> pt1.name = "Test parameter type 1"
   >>> pt1.units = "pct"
   >>> pt1.applicableToDataset = True
@@ -112,14 +112,14 @@ On the other hand, there is also a one to many relationship between
 ``ParameterType`` and ``PermissibleStringValue`` in the ICAT schema.
 Let's create a ``ParameterType`` with string values::
 
-  >>> pt2 = client.new("parameterType")
+  >>> pt2 = client.new("ParameterType")
   >>> pt2.name = "Test parameter type 2"
   >>> pt2.units = "N/A"
   >>> pt2.applicableToDataset = True
   >>> pt2.valueType = "STRING"
   >>> pt2.facility = f1
   >>> for v in ["buono", "brutto", "cattivo"]:
-  ...     psv = client.new("permissibleStringValue", value=v)
+  ...     psv = client.new("PermissibleStringValue", value=v)
   ...     pt2.permissibleStringValues.append(psv)
   ...
   >>> pt2.create()
@@ -259,7 +259,7 @@ is a convenience method in python-icat roughly equivalent to::
 
   >>> rules = []
   >>> for w in queries:
-  ...     r = client.new("rule", crudFlags="R", what=w)
+  ...     r = client.new("Rule", crudFlags="R", what=w)
   ...     rules.append(r)
   ...
   >>> client.createMany(rules)

--- a/doc/src/tutorial-ids.rst
+++ b/doc/src/tutorial-ids.rst
@@ -55,7 +55,7 @@ so let's create one::
 
   >>> from icat.query import Query
   >>> investigation = client.assertedSearch(Query(client, "Investigation", conditions={"name": "= '12100409-ST'"}))[0]
-  >>> dataset = client.new("dataset")
+  >>> dataset = client.new("Dataset")
   >>> dataset.investigation = investigation
   >>> dataset.type = client.assertedSearch(Query(client, "DatasetType", conditions={"name": "= 'other'"}))[0]
   >>> dataset.name = "greetings"
@@ -67,7 +67,7 @@ For each of the files, we create a new datafile object and call the
 
   >>> df_format = client.assertedSearch(Query(client, "DatafileFormat", conditions={"name": "= 'Text'"}))[0]
   >>> for fname in ("greet-jdoe.txt", "greet-nbour.txt", "greet-rbeck.txt"):
-  ...     datafile = client.new("datafile", name=fname, dataset=dataset, datafileFormat=df_format)
+  ...     datafile = client.new("Datafile", name=fname, dataset=dataset, datafileFormat=df_format)
   ...     client.putData(fname, datafile)
   ...
   (datafile){

--- a/doc/src/tutorial-search.rst
+++ b/doc/src/tutorial-search.rst
@@ -809,7 +809,7 @@ first glance, it has a particular use case::
       If it already exists, search and return it, create it, if not.
       """
       try:
-          dataset = client.new("dataset")
+          dataset = client.new("Dataset")
           query = Query(client, "Investigation", conditions={
               "name": "= '%s'" % inv_name
           })

--- a/doc/tutorial/config-sub-commands.py
+++ b/doc/tutorial/config-sub-commands.py
@@ -37,7 +37,7 @@ if conf.mode.name == "list":
     print(client.search(conf.entity))
 elif conf.mode.name == "create":
     print("creating a new %s object named %s..." % (conf.entity, conf.name))
-    obj = client.new(conf.entity.lower(), name=conf.name)
+    obj = client.new(conf.entity, name=conf.name)
     obj.create()
 elif conf.mode.name == "delete":
     print("deleting the %s object with ID %s..." % (conf.entity, conf.id))

--- a/icat/client.py
+++ b/icat/client.py
@@ -249,12 +249,12 @@ class Client(suds.client.Client):
                                       % instancetype)
         elif isinstance(obj, str):
             # obj is the name of an instance type, create the instance
-            instancetype = obj
             try:
-                Class = self.typemap[instancetype]
+                Class = self.typemap[obj.lower()]
             except KeyError:
                 raise EntityTypeError("Invalid instance type '%s'." 
-                                      % instancetype)
+                                      % obj)
+            instancetype = Class.getInstanceName()
             instance = self.factory.create(instancetype)
             # The factory creates a whole tree of dummy objects for
             # all relationships of the instance object and the

--- a/icat/client.py
+++ b/icat/client.py
@@ -220,12 +220,13 @@ class Client(suds.client.Client):
 
         """Instantiate a new :class:`icat.entity.Entity` object.
 
-        If obj is a string, take it as the name of an instance type.
-        Create a new instance object of this type and lookup the class
-        for the object in the :attr:`typemap` using this type name.
-        If obj is an instance object, look up its class name in the
-        typemap to determine the class.  If obj is :const:`None`, do
-        nothing and return :const:`None`.
+        If obj is a Suds instance object or a string, lookup the
+        corresponding entity class in the :attr:`typemap`.  If obj is
+        a string, this lookup is case insensitive and a new entity
+        object is instantiated.  If obj is a Suds instance object, an
+        entity object corresponding to this instance object is
+        instantiated.  If obj is :const:`None`, do nothing and return
+        :const:`None`.
         
         :param obj: either a Suds instance object, a name of an
             instance type, or :const:`None`.

--- a/icat/entities.py
+++ b/icat/entities.py
@@ -287,7 +287,6 @@ def getTypeMap(client):
             bases = (parent, mixin)
         else:
             bases = (parent,)
-        instanceName = beanName[0].lower() + beanName[1:]
         cls = type(str(beanName), bases, attrs)
         addType(typemap, cls)
     return typemap

--- a/icat/entities.py
+++ b/icat/entities.py
@@ -228,7 +228,12 @@ def getTypeMap(client):
     :rtype: :class:`dict`
 
     """
-    typemap = { 'entityBaseBean': Entity, }
+    def addType(typemap, cls):
+        instanceName = cls.getInstanceName()
+        typemap[instanceName] = cls
+
+    typemap = dict()
+    addType(typemap, Entity)
     for beanName in itertools.chain(('Parameter',), client.getEntityNames()):
         try:
             parent = typemap[_parent[beanName]]
@@ -282,5 +287,6 @@ def getTypeMap(client):
         else:
             bases = (parent,)
         instanceName = beanName[0].lower() + beanName[1:]
-        typemap[instanceName] = type(str(beanName), bases, attrs)
+        cls = type(str(beanName), bases, attrs)
+        addType(typemap, cls)
     return typemap

--- a/icat/entities.py
+++ b/icat/entities.py
@@ -231,6 +231,7 @@ def getTypeMap(client):
     def addType(typemap, cls):
         instanceName = cls.getInstanceName()
         typemap[instanceName] = cls
+        typemap[instanceName.lower()] = cls
 
     typemap = dict()
     addType(typemap, Entity)

--- a/icat/entity.py
+++ b/icat/entity.py
@@ -55,6 +55,14 @@ class Entity():
     """
 
     @classmethod
+    def getInstanceName(cls):
+        """Get the name of this class in the ICAT WSDL"""
+        if cls is Entity:
+            return 'entityBaseBean'
+        else:
+            return cls.__name__[0].lower() + cls.__name__[1:]
+
+    @classmethod
     def getInstance(cls, obj):
         """Get the corresponding instance from an object."""
         if obj is None:

--- a/tests/test_06_client.py
+++ b/tests/test_06_client.py
@@ -36,6 +36,40 @@ def test_logout_no_session_error(client):
     with tmpSessionId(client, "-=- Invalid -=-"):
         client.logout()
 
+# ========================== test new() ============================
+
+def test_new_obj_instance(client):
+    """Pass an instance object to new.
+    """
+    entity = client.assertedSearch("Facility")[0]
+    obj = client.new(entity.instance)
+    assert obj == entity
+
+@pytest.mark.parametrize(("typename", "beanname"), [
+    ("investigation", "Investigation"),
+    ("Investigation", "Investigation"),
+    ("INVESTIGATION", "Investigation"),
+    ("investigationUser", "InvestigationUser"),
+    ("InvestigationUser", "InvestigationUser"),
+    ("INVESTIGATIONUSER", "InvestigationUser"),
+])
+def test_new_obj_name(client, typename, beanname):
+    """Pass the name of the object type to new.
+
+    In earlier versions, this name was case sensitive and needed to be
+    spelled as indicated in the WSDL downloaded from icat.server.  In
+    #104, this has been changed, so that the type name is case
+    insensitive now.  As result, the type can now be spelled as in the
+    ICAT schema.
+    """
+    obj = client.new(typename)
+    assert obj.BeanName == beanname
+
+def test_new_obj_none(client):
+    """Pass None to new.
+    """
+    assert client.new(None) is None
+
 # ======================== test search() ===========================
 
 cet = datetime.timezone(datetime.timedelta(hours=1))


### PR DESCRIPTION
This makes the `obj` argument to `icat.client.Client.new()` case insensitive, if it is a string, e.g. a type name. It closes #102.

In detail:
- add a class method `icat.entity.Entity.getInstanceName()` that returns the instance name, e.g. the name of the type as declared in the WSDL.
- add each class with the instance name (as before) and with the lower case instance name (new) as key to the client typemap.
- lookup the lowercase `obj` argument in the typemap in `icat.client.Client.new()`.

Draft, still missing: documentation and tests.