### PR TITLE
Review build tool chain

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,12 +1,9 @@
-*~
 __pycache__/
-/.version
 /MANIFEST
+/_meta.py
 /build/
 /dist/
-/icat.cfg
 /icat/__init__.py
-/tests/.cache/
 /tests/data/example_data.yaml
 /tests/data/icat.cfg
 /tests/data/icatdump-*.xml

--- a/.gitignore
+++ b/.gitignore
@@ -1,8 +1,6 @@
-*.pyc
 *~
 __pycache__/
 /.version
-/.vscode
 /MANIFEST
 /build/
 /dist/

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -66,6 +66,9 @@ Incompatible changes and deprecations
 Bug fixes and minor changes
 ---------------------------
 
++ `#98`_, `#105`_: Review build tool chain.  Add a helper class
+  :class:`icat.helper.Version`.
+
 + `#101`_: Fix tests failing with PyYAML 6.0.
 
 + Some (more) example scripts now require ICAT 4.4.0 or newer.
@@ -74,10 +77,12 @@ Bug fixes and minor changes
 .. _#74: https://github.com/icatproject/python-icat/issues/74
 .. _#75: https://github.com/icatproject/python-icat/pull/75
 .. _#77: https://github.com/icatproject/python-icat/issues/77
+.. _#98: https://github.com/icatproject/python-icat/issues/98
 .. _#101: https://github.com/icatproject/python-icat/pull/101
 .. _#102: https://github.com/icatproject/python-icat/issues/102
 .. _#103: https://github.com/icatproject/python-icat/pull/103
 .. _#104: https://github.com/icatproject/python-icat/pull/104
+.. _#105: https://github.com/icatproject/python-icat/pull/105
 
 
 0.21.0 (2022-01-28)

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,8 +1,8 @@
-include .version
 include CHANGES.rst
 include LICENSE.txt
 include MANIFEST.in
 include README.rst
+include _meta.py
 include doc/examples/*.py
 include doc/examples/example_data.yaml
 include doc/examples/icat.cfg

--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,5 @@
 PYTHON = python3
 
-BUILDLIB = $(abspath build/lib)
-
 
 build:
 	$(PYTHON) setup.py build
@@ -12,33 +10,28 @@ test:
 sdist: doc-man
 	$(PYTHON) setup.py sdist
 
-doc-html: build
-	$(MAKE) -C doc html PYTHONPATH=$(BUILDLIB)
+doc-html: meta
+	$(MAKE) -C doc html PYTHONPATH=$(CURDIR)
 
-doc-man: build
-	$(MAKE) -C doc man PYTHONPATH=$(BUILDLIB)
-
+doc-man: meta
+	$(MAKE) -C doc man PYTHONPATH=$(CURDIR)
 
 clean:
-	rm -f *~ icat/*~ tests/*~ doc/*~ doc/examples/*~
 	rm -rf build
+	rm -rf __pycache__
 	rm -rf tests/data/example_data.yaml
 	rm -rf tests/data/icatdump-* tests/data/ingest-*.xml
 	rm -rf tests/scripts
 
 distclean: clean
-	rm -rf tests/.cache
-	rm -f MANIFEST .version
-	rm -rf python_icat.egg-info
-	rm -f *.pyc icat/*.pyc tests/*.pyc
-	rm -rf __pycache__ icat/__pycache__ tests/__pycache__
+	rm -f MANIFEST _meta.py
 	rm -f icat/__init__.py
 	rm -rf dist
+	rm -rf tests/.pytest_cache
 	$(MAKE) -C doc distclean
 
+meta:
+	$(PYTHON) setup.py meta
 
-init_py:
-	$(PYTHON) setup.py init_py
 
-
-.PHONY: build test sdist doc-html clean distclean init_py
+.PHONY: build test sdist doc-html doc-man clean distclean meta

--- a/README.rst
+++ b/README.rst
@@ -35,6 +35,8 @@ Python
 Required library packages
 .........................
 
++ `setuptools`_
+
 + `packaging`_
 
 + Suds.  The original version by Jeff Ortel is not maintained anymore
@@ -45,16 +47,6 @@ Required library packages
   suds-community does not work with older ICAT servers, see below.
 
 .. __: `suds-jurko`_
-
-Conflicts with other packages
-.............................
-
-+ `setuptools`_ >= 58.0
-
-  There is a breaking change in setuptools 58.0 that affects all
-  python-icat releases older than upcoming 1.0.  You must either not
-  install setuptools at all or at least downgrade it to 57.5 or older
-  in order to install python-icat.
 
 Optional library packages
 .........................
@@ -255,10 +247,10 @@ permissions and limitations under the License.
 
 .. _ICAT: https://icatproject.org/
 .. _PyPI site: https://pypi.org/project/python-icat/
+.. _setuptools: https://github.com/pypa/setuptools/
 .. _packaging: https://github.com/pypa/packaging
 .. _suds-jurko: https://bitbucket.org/jurko/suds
 .. _suds-community: https://github.com/suds-community/suds
-.. _setuptools: https://github.com/pypa/setuptools
 .. _PyYAML: https://github.com/yaml/pyyaml
 .. _lxml: https://lxml.de/
 .. _Requests: https://requests.readthedocs.io/

--- a/README.rst
+++ b/README.rst
@@ -33,6 +33,8 @@ Python:
 
 Required Library packages:
 
++ `packaging`_
+
 + Suds.  The original version by Jeff Ortel is not maintained anymore
   since very long time and not recommended.  There are several forks
   around, most of them short-lived.  Two of them have been evaluated
@@ -238,6 +240,7 @@ permissions and limitations under the License.
 
 .. _ICAT: https://icatproject.org/
 .. _PyPI site: https://pypi.org/project/python-icat/
+.. _packaging: https://github.com/pypa/packaging
 .. _suds-jurko: https://bitbucket.org/jurko/suds
 .. _suds-community: https://github.com/suds-community/suds
 .. _PyYAML: https://github.com/yaml/pyyaml

--- a/doc/src/conf.py
+++ b/doc/src/conf.py
@@ -6,7 +6,8 @@
 # full list see the documentation:
 # http://www.sphinx-doc.org/en/master/config
 
-import icat
+import _meta
+
 
 # -- Project information -----------------------------------------------------
 
@@ -16,7 +17,7 @@ copyright = ('2013–2022, '
 author = 'Rolf Krahl'
 
 # The full version, including alpha/beta/rc tags
-release = icat.__version__
+release = _meta.__version__
 # The short X.Y version
 version = ".".join(release.split(".")[0:2])
 
@@ -60,15 +61,15 @@ exclude_patterns = []
 pygments_style = 'sphinx'
 
 
-# -- Options for autodoc extension ---------------------------------------------
+# -- Options for autodoc extension -------------------------------------------
 
 autodoc_member_order = 'bysource'
 
-# -- Options for intersphinx extension -----------------------------------------
+# -- Options for intersphinx extension ---------------------------------------
 
 intersphinx_mapping = {'python': ('https://docs.python.org/3', None)}
 
-# -- Options for HTML output ---------------------------------------------------
+# -- Options for HTML output -------------------------------------------------
 
 # The theme to use for HTML and HTML Help pages.  See the documentation for
 # a list of builtin themes.

--- a/doc/src/helper.rst
+++ b/doc/src/helper.rst
@@ -7,6 +7,10 @@
    This module is intended for the internal use in python-icat.  Most
    users will not need to use it directly or even care about it.
 
+.. autoclass:: icat.helper.Version
+    :members:
+    :show-inheritance:
+
 .. autofunction:: icat.helper.simpleqp_quote
 
 .. autofunction:: icat.helper.simpleqp_unquote

--- a/icat/client.py
+++ b/icat/client.py
@@ -4,7 +4,6 @@ This is the only module that needs to be imported to use the icat.
 """
 
 import atexit
-from distutils.version import StrictVersion as Version
 import logging
 import os
 from pathlib import Path
@@ -20,7 +19,7 @@ import suds.sudsobject
 from icat.entities import getTypeMap
 from icat.entity import Entity
 from icat.exception import *
-from icat.helper import (simpleqp_unquote, parse_attr_val,
+from icat.helper import (Version, simpleqp_unquote, parse_attr_val,
                          ms_timestamp, disable_logger)
 from icat.ids import *
 from icat.query import Query
@@ -141,11 +140,7 @@ class Client(suds.client.Client):
             proxy = {}
         kwargs['transport'] = HTTPSTransport(self.sslContext, proxy=proxy)
         super().__init__(self.url, **kwargs)
-        apiversion = str(self.getApiVersion())
-        # Translate a version having a trailing '-SNAPSHOT' into
-        # something that StrictVersion would accept.
-        apiversion = re.sub(r'-SNAPSHOT$', 'a1', apiversion)
-        self.apiversion = Version(apiversion)
+        self.apiversion = Version(self.getApiVersion())
         log.debug("Connect to %s, ICAT version %s", url, self.apiversion)
 
         if self.apiversion < '4.3.0':

--- a/icat/helper.py
+++ b/icat/helper.py
@@ -36,7 +36,59 @@ True
 from contextlib import contextmanager
 import datetime
 import logging
+import re
+import packaging.version
 import suds.sax.date
+
+
+class Version(packaging.version.Version):
+    """A variant of packaging.version.Version.
+
+    This version class features a special handling of the '-SNAPSHOT'
+    suffix being used for ICAT prereleases.  It furthermore adds
+    comparison with strings.
+
+    >>> version = Version('4.11.1')
+    >>> version == '4.11.1'
+    True
+    >>> version < '4.9.3'
+    False
+    >>> version = Version('5.0.0-SNAPSHOT')
+    >>> version
+    <Version('5.0.0a1')>
+    >>> version > '4.11.1'
+    True
+    >>> version < '5.0.0'
+    True
+    >>> version == '5.0.0a1'
+    True
+    """
+    def __init__(self, version):
+        super().__init__(re.sub(r'-SNAPSHOT$', 'a1', version))
+    def __lt__(self, other):
+        if isinstance(other, str):
+            other = type(self)(other)
+        return super().__lt__(other)
+    def __le__(self, other):
+        if isinstance(other, str):
+            other = type(self)(other)
+        return super().__le__(other)
+    def __eq__(self, other):
+        if isinstance(other, str):
+            other = type(self)(other)
+        return super().__eq__(other)
+    def __ge__(self, other):
+        if isinstance(other, str):
+            other = type(self)(other)
+        return super().__ge__(other)
+    def __gt__(self, other):
+        if isinstance(other, str):
+            other = type(self)(other)
+        return super().__gt__(other)
+    def __ne__(self, other):
+        if isinstance(other, str):
+            other = type(self)(other)
+        return super().__ne__(other)
 
 
 def simpleqp_quote(obj):

--- a/icat/ids.py
+++ b/icat/ids.py
@@ -9,7 +9,6 @@ author.
 """
 
 from collections.abc import Mapping, Iterable
-from distutils.version import StrictVersion as Version
 import getpass
 import json
 import re
@@ -23,6 +22,7 @@ import zlib
 
 from icat.entity import Entity
 from icat.exception import *
+from icat.helper import Version
 
 # For Python versions older then 3.6.0b1, the standard library does
 # not support sending the body using chunked transfer encoding.  Need
@@ -203,11 +203,7 @@ class IDSClient():
         else:
             self.opener = build_opener(HTTPHandler, httpsHandler, 
                                        IDSHTTPErrorHandler)
-        apiversion = self.version()["version"]
-        # Translate a version having a trailing '-SNAPSHOT' into
-        # something that StrictVersion would accept.
-        apiversion = re.sub(r'-SNAPSHOT$', 'a1', apiversion)
-        self.apiversion = Version(apiversion)
+        self.apiversion = Version(self.version()["version"])
 
     def ping(self):
         """Check that the server is alive and is an IDS server.

--- a/python-icat.spec
+++ b/python-icat.spec
@@ -78,6 +78,7 @@ This package contains the manual pages for the command line scripts.
 %package -n python%{python3_pkgversion}-icat
 Summary:	Python interface to ICAT and IDS
 Requires:	%{name} = %{version}
+Requires:	python%{python3_pkgversion}-packaging
 Requires:	python%{python3_pkgversion}-suds
 %if 0%{?suse_version}
 Recommends:	%{name}-man
@@ -98,6 +99,7 @@ $long_description
 %package -n python%{python3_other_pkgversion}-icat
 Summary:	Python interface to ICAT and IDS
 Requires:	%{name} = %{version}
+Requires:	python%{python3_other_pkgversion}-packaging
 Requires:	python%{python3_other_pkgversion}-suds
 %if 0%{?centos_version} || 0%{?rhel_version} || 0%{?fedora_version}
 Requires(pre):	chkconfig

--- a/python-icat.spec
+++ b/python-icat.spec
@@ -39,9 +39,11 @@ Group:		Development/Languages/Python
 Url:		$url
 Source:		%{name}-%{version}.tar.gz
 BuildArch:	noarch
-BuildRequires:	python%{python3_pkgversion}-devel >= 3.4
+BuildRequires:	python%{python3_pkgversion} >= 3.4
+BuildRequires:	python%{python3_pkgversion}-setuptools
 %if 0%{?python3_other_pkgversion}
-BuildRequires:	python%{python3_other_pkgversion}-devel >= 3.4
+BuildRequires:	python%{python3_other_pkgversion} >= 3.4
+BuildRequires:	python%{python3_other_pkgversion}-setuptools
 %endif
 %if 0%{?suse_version}
 BuildRequires:	fdupes

--- a/setup.py
+++ b/setup.py
@@ -8,7 +8,6 @@ is based on Suds and extends it with ICAT specific features.
 .. _ICAT: https://icatproject.org/
 """
 
-from __future__ import print_function
 import distutils.command.build_py
 import distutils.command.sdist
 import distutils.core

--- a/setup.py
+++ b/setup.py
@@ -155,6 +155,19 @@ class build_py(setuptools.command.build_py.build_py):
         super().run()
 
 
+# There are several forks of the original suds package around, most of
+# them short-lived.  Two of them have been evaluated with python-icat
+# and found to work: suds-jurko and the more recent suds-community.
+# The latter has been renamed to suds.  We don't want to force to use
+# one particular suds clone.  Therefore, we first try if (any clone
+# of) suds is already installed and only add suds to install_requires
+# if not.
+requires = ["packaging"]
+try:
+    import suds
+except ImportError:
+    requires.append("suds")
+
 with Path("README.rst").open("rt", encoding="utf8") as f:
     readme = f.read()
 
@@ -185,7 +198,7 @@ setup(
     ],
     packages = ["icat"],
     python_requires = ">=3.4",
-    install_requires = ["packaging", "suds"],
+    install_requires = requires,
     scripts = ["icatdump.py", "icatingest.py", "wipeicat.py"],
     cmdclass = dict(cmdclass,
                     meta=meta,

--- a/setup.py
+++ b/setup.py
@@ -154,7 +154,7 @@ setup(
     author_email = "rolf.krahl@helmholtz-berlin.de",
     url = "https://github.com/icatproject/python-icat",
     license = "Apache-2.0",
-    requires = ["suds"],
+    requires = ["packaging", "suds"],
     packages = ["icat"],
     scripts = ["icatdump.py", "icatingest.py", "wipeicat.py"],
     classifiers = [

--- a/setup.py
+++ b/setup.py
@@ -8,14 +8,15 @@ is based on Suds and extends it with ICAT specific features.
 .. _ICAT: https://icatproject.org/
 """
 
-import distutils.command.build_py
+import setuptools
+from setuptools import setup
+import setuptools.command.build_py
 import distutils.command.sdist
-import distutils.core
-from distutils.core import setup
-import distutils.log
+from distutils import log
 from glob import glob
 import os
 import os.path
+from pathlib import Path
 import string
 import sys
 try:
@@ -26,33 +27,31 @@ except (ImportError, AttributeError):
 try:
     import setuptools_scm
     version = setuptools_scm.get_version()
-    with open(".version", "wt") as f:
-        f.write(version)
 except (ImportError, LookupError):
     try:
-        with open(".version", "rt") as f:
-            version = f.read()
-    except (OSError, IOError):
-        distutils.log.warn("warning: cannot determine version number")
+        import _meta
+        version = _meta.__version__
+    except ImportError:
+        log.warn("warning: cannot determine version number")
         version = "UNKNOWN"
 
 
 if sys.version_info < (3, 4):
-    distutils.log.warn("warning: Python %d.%d is not supported! "
-                       "This package requires Python 3.4 or newer."
-                       % sys.version_info[:2])
+    log.warn("warning: Python %d.%d is not supported! "
+             "This package requires Python 3.4 or newer."
+             % sys.version_info[:2])
 
 
-doclines = __doc__.strip().split("\n")
+docstring = __doc__
 
 
-class init_py(distutils.core.Command):
+class meta(setuptools.Command):
 
-    description = "generate the main __init__.py file"
+    description = "generate meta files"
     user_options = []
-    init_template = '''"""%s"""
+    init_template = '''"""%(doc)s"""
 
-__version__ = "%s"
+__version__ = "%(version)s"
 
 #
 # Default import
@@ -60,6 +59,9 @@ __version__ = "%s"
 
 from icat.client import *
 from icat.exception import *
+'''
+    meta_template = '''
+__version__ = "%(version)s"
 '''
 
     def initialize_options(self):
@@ -72,20 +74,25 @@ from icat.exception import *
                 self.package_dir[name] = convert_path(path)
 
     def run(self):
+        values = {
+            'version': self.distribution.get_version(),
+            'doc': docstring
+        }
         try:
             pkgname = self.distribution.packages[0]
         except IndexError:
-            distutils.log.warn("warning: no package defined")
+            log.warn("warning: no package defined")
         else:
-            pkgdir = self.package_dir.get(pkgname, pkgname)
-            ver = self.distribution.get_version()
-            if not os.path.isdir(pkgdir):
-                os.mkdir(pkgdir)
-            with open(os.path.join(pkgdir, "__init__.py"), "wt") as f:
-                print(self.init_template % (__doc__, ver), file=f)
+            pkgdir = Path(self.package_dir.get(pkgname, pkgname))
+            if not pkgdir.is_dir():
+                pkgdir.mkdir()
+            with (pkgdir / "__init__.py").open("wt") as f:
+                print(self.init_template % values, file=f)
+        with Path("_meta.py").open("wt") as f:
+            print(self.meta_template % values, file=f)
 
 
-class build_test(distutils.core.Command):
+class build_test(setuptools.Command):
     """Copy all stuff needed for the tests (example scripts, test data)
     into the test directory.
     """
@@ -123,47 +130,49 @@ class build_test(distutils.core.Command):
             self.copy_file(src, dest, preserve_mode=False)
 
 
+# Note: Do not use setuptools for making the source distribution,
+# rather use the good old distutils instead.
+# Rationale: https://rhodesmill.org/brandon/2009/eby-magic/
 class sdist(distutils.command.sdist.sdist):
     def run(self):
-        self.run_command('init_py')
-        distutils.command.sdist.sdist.run(self)
+        self.run_command('meta')
+        super().run()
         subst = {
             "version": self.distribution.get_version(),
             "url": self.distribution.get_url(),
-            "description": self.distribution.get_description(),
-            "long_description": self.distribution.get_long_description(),
+            "description": docstring.split("\n")[0],
+            "long_description": docstring.split("\n", maxsplit=2)[2].strip(),
         }
         for spec in glob("*.spec"):
-            with open(spec, "rt") as inf:
-                with open(os.path.join(self.dist_dir, spec), "wt") as outf:
+            with Path(spec).open('rt') as inf:
+                with Path(self.dist_dir, spec).open('wt') as outf:
                     outf.write(string.Template(inf.read()).substitute(subst))
 
 
-class build_py(distutils.command.build_py.build_py):
+class build_py(setuptools.command.build_py.build_py):
     def run(self):
-        self.run_command('init_py')
-        distutils.command.build_py.build_py.run(self)
+        self.run_command('meta')
+        super().run()
 
+
+with Path("README.rst").open("rt", encoding="utf8") as f:
+    readme = f.read()
 
 setup(
     name = "python-icat",
     version = version,
-    description = doclines[0],
-    long_description = "\n".join(doclines[2:]),
+    description = docstring.split("\n")[0],
+    long_description = readme,
+    url = "https://github.com/icatproject/python-icat",
     author = "Rolf Krahl",
     author_email = "rolf.krahl@helmholtz-berlin.de",
-    url = "https://github.com/icatproject/python-icat",
     license = "Apache-2.0",
-    requires = ["packaging", "suds"],
-    packages = ["icat"],
-    scripts = ["icatdump.py", "icatingest.py", "wipeicat.py"],
     classifiers = [
         "Development Status :: 5 - Production/Stable",
         "Intended Audience :: Developers",
         "License :: OSI Approved :: Apache Software License",
         "Operating System :: OS Independent",
         "Programming Language :: Python",
-        "Programming Language :: Python :: 3",
         "Programming Language :: Python :: 3.4",
         "Programming Language :: Python :: 3.5",
         "Programming Language :: Python :: 3.6",
@@ -174,9 +183,13 @@ setup(
         "Programming Language :: Python :: 3.11",
         "Topic :: Software Development :: Libraries :: Python Modules",
     ],
+    packages = ["icat"],
+    python_requires = ">=3.4",
+    install_requires = ["packaging", "suds"],
+    scripts = ["icatdump.py", "icatingest.py", "wipeicat.py"],
     cmdclass = dict(cmdclass,
+                    meta=meta,
                     build_py=build_py,
                     build_test=build_test,
-                    init_py=init_py,
                     sdist=sdist),
 )

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -2,7 +2,6 @@
 """
 
 import datetime
-from distutils.version import StrictVersion as Version
 import locale
 import logging
 import os
@@ -17,6 +16,7 @@ import zlib
 import pytest
 import icat
 import icat.config
+from icat.helper import Version
 try:
     from suds.sax.date import UtcTimezone
 except ImportError:

--- a/tests/test_01_helper.py
+++ b/tests/test_01_helper.py
@@ -2,8 +2,36 @@
 """
 
 import datetime
+import packaging.version
 import pytest
 from icat.helper import *
+
+@pytest.mark.parametrize(("vstr", "checks"), [
+    ("4.11.1", [
+        (lambda v: v == "4.11.1", True),
+        (lambda v: v < "4.11.1", False),
+        (lambda v: v > "4.11.1", False),
+        (lambda v: v < "5.0.0", True),
+        (lambda v: v > "4.11.0", True),
+        (lambda v: v > "4.9.3", True),
+        (lambda v: v == packaging.version.Version("4.11.1"), True),
+    ]),
+    ("5.0.0-SNAPSHOT", [
+        (lambda v: v == "5.0.0", False),
+        (lambda v: v < "5.0.0", True),
+        (lambda v: v > "4.11.1", True),
+        (lambda v: v == "5.0.0-SNAPSHOT", True),
+        (lambda v: v == "5.0.0a1", True),
+        (lambda v: v < "5.0.0a2", True),
+        (lambda v: v < "5.0.0b1", True),
+    ]),
+])
+def test_version(vstr, checks):
+    """Test class Version.
+    """
+    version = Version(vstr)
+    for check, res in checks:
+        assert check(version) == res
 
 def test_helper_quote():
     """Test simpleqp_quote() and simpleqp_unquote()


### PR DESCRIPTION
Review tool chain to build the package:

- switch from `distutils` to `setuptools` in `setup.py` where appropriate,
- generate a `_meta` module to store the version number,
- misc review.

Furthermore add a helper class `icat.helper.Version` based on `packaging.version.Version` to replace `distutils.version.StrictVersion`.

Close #98.