### PR TITLE
Fix the test suite to work if either PyYAML or lxml is not available

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -2,6 +2,19 @@ Changelog
 =========
 
 
+1.1.0 (not yet released)
+~~~~~~~~~~~~~~~~~~~~~~~~
+
+Bug fixes and minor changes
+---------------------------
+
++ `#115`_, `#116`_: Fix the test suite to work if either PyYAML or
+  lxml is not available.
+
+.. _#115: https://github.com/icatproject/python-icat/issues/115
+.. _#116: https://github.com/icatproject/python-icat/pull/116
+
+
 1.0.0 (2022-12-21)
 ~~~~~~~~~~~~~~~~~~
 

--- a/doc/src/install.rst
+++ b/doc/src/install.rst
@@ -40,6 +40,12 @@ are not required to install python-icat and use its core features:
   Only needed to use the YAML backend of :ref:`icatdump` and
   :ref:`icatingest` and to run the example scripts.
 
+  The test suite uses :ref:`icatingest` with the YAML backend to
+  create reference content in the test ICAT server.  While it is
+  technically possible to run the tests without PyYAML, most of the
+  tests will be skipped in that case, so the results will not be very
+  meaningful.
+
 + `lxml`_
 
   Only needed to use the XML backend of :ref:`icatdump` and

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -16,6 +16,15 @@ import zlib
 import pytest
 import icat
 import icat.config
+import icat.dumpfile
+try:
+    import icat.dumpfile_xml
+except ImportError:
+    pass
+try:
+    import icat.dumpfile_yaml
+except ImportError:
+    pass
 from icat.helper import Version
 try:
     from suds.sax.date import UtcTimezone
@@ -143,6 +152,10 @@ except:
 def require_icat_version(minversion, reason):
     if icat_version < minversion:
         _skip("need ICAT server version %s or newer: %s" % (minversion, reason))
+
+def require_dumpfile_backend(backend):
+    if backend not in icat.dumpfile.Backends.keys():
+        _skip("need %s backend for icat.dumpfile" % (backend))
 
 
 def get_reference_dumpfile(ext = "yaml"):

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -234,6 +234,7 @@ def standardCmdArgs():
 
 @pytest.fixture(scope="session")
 def setupicat(standardCmdArgs):
+    require_dumpfile_backend("YAML")
     testcontent = get_reference_dumpfile()
     callscript("wipeicat.py", standardCmdArgs)
     args = standardCmdArgs + ["-f", "YAML", "-i", str(testcontent)]

--- a/tests/test_05_dump.py
+++ b/tests/test_05_dump.py
@@ -12,6 +12,7 @@ except ImportError:
 import icat
 import icat.config
 from conftest import (getConfig, icat_version, gettestdata,
+                      require_dumpfile_backend,
                       get_reference_dumpfile, get_reference_summary,
                       callscript, filter_file, yaml_filter, xml_filter)
 
@@ -112,6 +113,7 @@ def test_ingest(ingestcase, standardCmdArgs):
     """Restore the ICAT content from a dumpfile.
     """
     backend, filetype = ingestcase
+    require_dumpfile_backend(backend)
     refdump = backends[backend]['refdump']
     if filetype == 'FILE':
         args = standardCmdArgs + ["-f", backend, "-i", str(refdump)]
@@ -128,6 +130,7 @@ def test_check_content(ingestcheck, standardCmdArgs, tmpdirsec, case):
     """Dump the content and check that we get the reference dump file back.
     """
     backend, filetype = case
+    require_dumpfile_backend(backend)
     refdump = backends[backend]['refdump']
     fileext = backends[backend]['fileext']
     dump = tmpdirsec / ("dump" + fileext)

--- a/tests/test_05_dumpfile.py
+++ b/tests/test_05_dumpfile.py
@@ -7,7 +7,10 @@ uses the internal API icat.dumpfile.
 
 import filecmp
 import io
-from lxml import etree
+try:
+    from lxml import etree
+except ImportError:
+    etree = None
 import pytest
 try:
     from pytest_dependency import depends
@@ -139,6 +142,8 @@ def test_ingest(ingestcase, client):
         icatingest(client, stream, backend)
         stream.close()
     elif filetype == 'ETREE':
+        if etree is None:
+            pytest.skip("Need lxml")
         with refdump.open("rb") as f:
             icatdata = etree.parse(f)
         icatingest(client, icatdata, backend)

--- a/tests/test_05_dumpfile.py
+++ b/tests/test_05_dumpfile.py
@@ -22,7 +22,8 @@ import icat.config
 from icat.dump_queries import *
 from icat.dumpfile import open_dumpfile
 from icat.query import Query
-from conftest import (getConfig, get_reference_dumpfile, callscript,
+from conftest import (getConfig, require_dumpfile_backend,
+                      get_reference_dumpfile, callscript,
                       filter_file, yaml_filter, xml_filter)
 
 
@@ -38,7 +39,6 @@ backends = {
         'filter': yaml_filter,
     },
 }
-assert backends.keys() == icat.dumpfile.Backends.keys()
 
 # The following cases are tuples of a backend and a file type (regular
 # file, stdin/stdout, in-memory stream).  They are used for both,
@@ -129,6 +129,7 @@ def test_ingest(ingestcase, client):
     """Restore the ICAT content from a dumpfile.
     """
     backend, filetype = ingestcase
+    require_dumpfile_backend(backend)
     refdump = backends[backend]['refdump']
     if filetype == 'FILE':
         icatingest(client, refdump, backend)
@@ -155,6 +156,7 @@ def test_check_content(ingestcheck, client, tmpdirsec, case):
     """Dump the content and check that we get the reference dump file back.
     """
     backend, filetype = case
+    require_dumpfile_backend(backend)
     refdump = backends[backend]['refdump']
     fileext = backends[backend]['fileext']
     dump = tmpdirsec / ("dump" + fileext)

--- a/tests/test_05_dumpfile.py
+++ b/tests/test_05_dumpfile.py
@@ -18,8 +18,6 @@ import icat
 import icat.config
 from icat.dump_queries import *
 from icat.dumpfile import open_dumpfile
-import icat.dumpfile_xml
-import icat.dumpfile_yaml
 from icat.query import Query
 from conftest import (getConfig, get_reference_dumpfile, callscript,
                       filter_file, yaml_filter, xml_filter)

--- a/tests/test_05_legacy_ingest.py
+++ b/tests/test_05_legacy_ingest.py
@@ -23,7 +23,7 @@ except ImportError:
 import icat
 import icat.config
 from conftest import (getConfig, icat_version, require_icat_version,
-                      gettestdata, callscript,
+                      require_dumpfile_backend, gettestdata, callscript,
                       filter_file, yaml_filter, xml_filter)
 
 
@@ -87,6 +87,7 @@ def ingestcheck(ingestcase, request):
 def test_ingest(ingestcase, standardCmdArgs):
     """Ingest a legacy dumpfile.
     """
+    require_dumpfile_backend(ingestcase)
     legacy_dump, _ = backends[ingestcase]['dumpfiles']
     args = standardCmdArgs + ["-f", ingestcase, "-i", str(legacy_dump)]
     callscript("icatingest.py", args)
@@ -94,6 +95,7 @@ def test_ingest(ingestcase, standardCmdArgs):
 def test_check_content(ingestcheck, standardCmdArgs, tmpdirsec):
     """Dump the content and check that we get the reference dump file back.
     """
+    require_dumpfile_backend(ingestcheck)
     _, ref_dump = backends[ingestcheck]['dumpfiles']
     fileext = backends[ingestcheck]['fileext']
     dump = tmpdirsec / ("dump" + fileext)

--- a/tests/test_05_setup.py
+++ b/tests/test_05_setup.py
@@ -18,6 +18,7 @@ import icat
 import icat.config
 from icat.query import Query
 from conftest import (getConfig, icat_version, gettestdata,
+                      require_dumpfile_backend,
                       get_reference_dumpfile, get_reference_summary,
                       callscript, filter_file, yaml_filter)
 
@@ -393,6 +394,7 @@ def test_add_datacollections(data, user, objects):
 def test_check_content(standardCmdArgs, tmpdirsec):
     """Dump the resulting content and compare with a reference dump.
     """
+    require_dumpfile_backend("YAML")
     dump = tmpdirsec / "dump.yaml"
     fdump = tmpdirsec / "dump-filter.yaml"
     reffdump = tmpdirsec / "dump-filter-ref.yaml"

--- a/tests/test_05_setup.py
+++ b/tests/test_05_setup.py
@@ -9,7 +9,10 @@ dump file.
 
 import filecmp
 import re
-import yaml
+try:
+    import yaml
+except ImportError:
+    yaml = None
 import pytest
 import icat
 import icat.config
@@ -50,6 +53,8 @@ summary_study_filter = (re.compile(r"^((?:Study(?:Investigation)?)\s*) : \d+$"),
 
 @pytest.fixture(scope="module")
 def data():
+    if yaml is None:
+        pytest.skip("Need yaml")
     with testinput.open('r') as f:
         return yaml.safe_load(f)
 
@@ -132,6 +137,8 @@ def fix_file_size(inv_name):
 
 @pytest.mark.dependency(name="init")
 def test_init(standardCmdArgs):
+    if yaml is None:
+        pytest.skip("Need yaml")
     callscript("wipeicat.py", standardCmdArgs)
     callscript("init-icat.py", standardCmdArgs + [str(testinput)])
 

--- a/tests/test_06_ingest.py
+++ b/tests/test_06_ingest.py
@@ -6,7 +6,8 @@ import pytest
 import icat
 import icat.config
 from icat.query import Query
-from conftest import DummyDatafile, gettestdata, getConfig, callscript
+from conftest import (DummyDatafile, require_dumpfile_backend,
+                      gettestdata, getConfig, callscript)
 
 
 # Test input
@@ -21,6 +22,7 @@ def client(setupicat):
 
 @pytest.fixture(scope="module")
 def cmdargs(setupicat):
+    require_dumpfile_backend("XML")
     _, conf = getConfig(confSection="acord", ids="mandatory")
     return conf.cmdargs + ["-f", "XML"]
 


### PR DESCRIPTION
Fix the test suite so that it does not completely fail if either `PyYAML` or `lxml` is not available. Only the tests that depend on the respective library module will be skipped if it is not available.

Close #115.
