### PR TITLE
Adapt to upcoming Python 3.12

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -11,8 +11,11 @@ Bug fixes and minor changes
 + `#115`_, `#116`_: Fix the test suite to work if either PyYAML or
   lxml is not available.
 
++ `#117`_: Fixed deprecation warnings from upcoming Python 3.12.
+
 .. _#115: https://github.com/icatproject/python-icat/issues/115
 .. _#116: https://github.com/icatproject/python-icat/pull/116
+.. _#117: https://github.com/icatproject/python-icat/pull/117
 
 
 1.0.0 (2022-12-21)

--- a/doc/examples/create-datafile.py
+++ b/doc/examples/create-datafile.py
@@ -66,7 +66,8 @@ query = Query(client, "Investigation",
 investigation = client.assertedSearch(query)[0]
 
 fstats = df_path.stat()
-modTime = datetime.datetime.utcfromtimestamp(fstats.st_mtime).isoformat() + "Z"
+utc = datetime.timezone.utc
+modTime = datetime.datetime.fromtimestamp(fstats.st_mtime, tz=utc)
 datafile = client.new("Datafile")
 datafile.datafileFormat = dff
 datafile.name = conf.datafile.name

--- a/icat/dumpfile_xml.py
+++ b/icat/dumpfile_xml.py
@@ -8,14 +8,8 @@ from lxml import etree
 import icat
 import icat.dumpfile
 from icat.query import Query
-try:
-    utc = datetime.timezone.utc
-except AttributeError:
-    try:
-        from suds.sax.date import UtcTimezone
-        utc = UtcTimezone()
-    except ImportError:
-        utc = None
+
+utc = datetime.timezone.utc
 
 
 # ------------------------------------------------------------
@@ -185,13 +179,10 @@ class XMLDumpFileWriter(icat.dumpfile.DumpFileWriter):
                     # dependency of server settings in the dumpfile.
                     # Assume v.isoformat() to have a valid timezone
                     # suffix.
-                    if utc:
-                        v = v.astimezone(utc)
-                    v = v.isoformat()
+                    v = v.astimezone(tz=utc).isoformat()
                 else:
-                    # v has no timezone info, assume it to be UTC, append
-                    # the corresponding timezone suffix.
-                    v = v.isoformat() + 'Z'
+                    # v has no timezone info, assume it to be UTC.
+                    v = v.replace(tzinfo=utc).isoformat()
             else:
                 v = str(v)
             etree.SubElement(d, attr).text = v
@@ -208,7 +199,7 @@ class XMLDumpFileWriter(icat.dumpfile.DumpFileWriter):
 
     def head(self):
         """Write a header with some meta information to the data file."""
-        date = datetime.datetime.utcnow().strftime("%Y-%m-%dT%H:%M:%S+00:00")
+        date = datetime.datetime.now(tz=utc).isoformat()
         head = etree.Element("head")
         etree.SubElement(head, "date").text = date
         etree.SubElement(head, "service").text = self.client.url

--- a/icat/dumpfile_yaml.py
+++ b/icat/dumpfile_yaml.py
@@ -5,14 +5,8 @@ import datetime
 import yaml
 import icat
 import icat.dumpfile
-try:
-    utc = datetime.timezone.utc
-except AttributeError:
-    try:
-        from suds.sax.date import UtcTimezone
-        utc = UtcTimezone()
-    except ImportError:
-        utc = None
+
+utc = datetime.timezone.utc
 
 
 # List of entity types.  This defines in particular the order in which
@@ -182,13 +176,10 @@ class YAMLDumpFileWriter(icat.dumpfile.DumpFileWriter):
                     # dependency of server settings in the dumpfile.
                     # Assume v.isoformat() to have a valid timezone
                     # suffix.
-                    if utc:
-                        v = v.astimezone(utc)
-                    v = v.isoformat()
+                    v = v.astimezone(tz=utc).isoformat()
                 else:
-                    # v has no timezone info, assume it to be UTC, append
-                    # the corresponding timezone suffix.
-                    v = v.isoformat() + 'Z'
+                    # v has no timezone info, assume it to be UTC.
+                    v = v.replace(tzinfo=utc).isoformat()
             else:
                 v = str(v)
             d[attr] = v
@@ -206,8 +197,8 @@ class YAMLDumpFileWriter(icat.dumpfile.DumpFileWriter):
 
     def head(self):
         """Write a header with some meta information to the data file."""
-        dateformat = "%a, %d %b %Y %H:%M:%S +0000"
-        date = datetime.datetime.utcnow().strftime(dateformat)
+        dateformat = "%a, %d %b %Y %H:%M:%S %z"
+        date = datetime.datetime.now(tz=utc).strftime(dateformat)
         head = """%%YAML 1.1
 # Date: %s
 # Service: %s

--- a/setup.py
+++ b/setup.py
@@ -194,6 +194,7 @@ setup(
         "Programming Language :: Python :: 3.9",
         "Programming Language :: Python :: 3.10",
         "Programming Language :: Python :: 3.11",
+        "Programming Language :: Python :: 3.12",
         "Topic :: Software Development :: Libraries :: Python Modules",
     ],
     packages = ["icat"],


### PR DESCRIPTION
Tested with Python 3.12.0b1, so let's assume it will work with the Python 3.12 release as well and update the package metadata accordingly.

Fixed deprecation warnings: `datetime.datetime.utcfromtimestamp()` and `datetime.datetime.utcnow()` are deprecated in Python 3.12, so avoid using them. At the same time, take the opportunity to simplify some code by depending on `datetime.timezone.utc`: it is in the standard library since Python 3.2, so no need any more to check its availability.

**Note**:  Python 3.12.0b1 breaks the current release version of [lxml](https://lxml.de/).  This is expected to be fixed in lxml 5.0.0 but that version has not been released yet. So the tests were not complete, I could not run any of the tests that depend on lxml with Python 3.12.0b1. We might wait a while for this issue to be fixed in lxml and then rerun the tests before merging. Otherwise, we may as well just assume that there is no issue related to python-icat with that, and merge nevertheless.
