### PR TITLE
Extend icatdata XSD adding extra attributes to reference objects

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -8,11 +8,16 @@ Changelog
 Bug fixes and minor changes
 ---------------------------
 
++ `#112`_, `#118`_: Extend icatdata XSD adding extra attributes to
+  reference objects.
+
 + `#115`_, `#116`_: Fix the test suite to work if either PyYAML or
   lxml is not available.
 
+.. _#112: https://github.com/icatproject/python-icat/issues/112
 .. _#115: https://github.com/icatproject/python-icat/issues/115
 .. _#116: https://github.com/icatproject/python-icat/pull/116
+.. _#118: https://github.com/icatproject/python-icat/pull/118
 
 
 1.0.0 (2022-12-21)

--- a/doc/icatdata-4.10.xsd
+++ b/doc/icatdata-4.10.xsd
@@ -36,6 +36,8 @@
     <!-- entity object references -->
     <xsd:element name="applicationRef" type="applicationRef" 
 		 minOccurs="0" maxOccurs="unbounded"/>
+    <xsd:element name="dataCollectionRef" type="dataCollectionRef"
+		 minOccurs="0" maxOccurs="unbounded"/>
     <xsd:element name="datafileRef" type="datafileRef" 
 		 minOccurs="0" maxOccurs="unbounded"/>
     <xsd:element name="datafileFormatRef" type="datafileFormatRef" 
@@ -59,6 +61,8 @@
     <xsd:element name="sampleRef" type="sampleRef" 
 		 minOccurs="0" maxOccurs="unbounded"/>
     <xsd:element name="sampleTypeRef" type="sampleTypeRef" 
+		 minOccurs="0" maxOccurs="unbounded"/>
+    <xsd:element name="studyRef" type="studyRef"
 		 minOccurs="0" maxOccurs="unbounded"/>
     <xsd:element name="userRef" type="userRef" 
 		 minOccurs="0" maxOccurs="unbounded"/>
@@ -203,6 +207,14 @@
   </xsd:complexContent>
 </xsd:complexType>
 
+<xsd:complexType name="dataCollectionRef">
+  <xsd:complexContent>
+    <xsd:extension base="entityReference">
+      <xsd:attribute name="doi" type="xsd:string"/>
+    </xsd:extension>
+  </xsd:complexContent>
+</xsd:complexType>
+
 <xsd:complexType name="datafileRef">
   <xsd:complexContent>
     <xsd:extension base="entityReference">
@@ -327,6 +339,14 @@
   </xsd:complexContent>
 </xsd:complexType>
 
+<xsd:complexType name="studyRef">
+  <xsd:complexContent>
+    <xsd:extension base="entityReference">
+      <xsd:attribute name="pid" type="xsd:string"/>
+    </xsd:extension>
+  </xsd:complexContent>
+</xsd:complexType>
+
 <xsd:complexType name="userRef">
   <xsd:complexContent>
     <xsd:extension base="entityReference">
@@ -401,7 +421,7 @@
   <xsd:complexContent>
     <xsd:extension base="entityBase">
       <xsd:sequence>
-	<xsd:element name="dataCollection" type="entityReference" 
+	<xsd:element name="dataCollection" type="dataCollectionRef"
 		     minOccurs="0"/>
 	<xsd:element name="datafile" type="datafileRef" minOccurs="0"/>
       </xsd:sequence>
@@ -413,7 +433,7 @@
   <xsd:complexContent>
     <xsd:extension base="entityBase">
       <xsd:sequence>
-	<xsd:element name="dataCollection" type="entityReference" 
+	<xsd:element name="dataCollection" type="dataCollectionRef"
 		     minOccurs="0"/>
 	<xsd:element name="dataset" type="datasetRef" minOccurs="0"/>
       </xsd:sequence>
@@ -431,7 +451,7 @@
 	<xsd:element name="rangeBottom" type="xsd:double" minOccurs="0"/>
 	<xsd:element name="rangeTop" type="xsd:double" minOccurs="0"/>
 	<xsd:element name="stringValue" type="xsd:string" minOccurs="0"/>
-	<xsd:element name="dataCollection" type="entityReference" 
+	<xsd:element name="dataCollection" type="dataCollectionRef"
 		     minOccurs="0"/>
 	<xsd:element name="type" type="parameterTypeRef" minOccurs="0"/>
       </xsd:sequence>
@@ -771,9 +791,9 @@
       <xsd:sequence>
 	<xsd:element name="arguments" type="xsd:string" minOccurs="0"/>
 	<xsd:element name="application" type="applicationRef" minOccurs="0"/>
-	<xsd:element name="inputDataCollection" type="entityReference" 
+	<xsd:element name="inputDataCollection" type="dataCollectionRef"
 		     minOccurs="0"/>
-	<xsd:element name="outputDataCollection" type="entityReference" 
+	<xsd:element name="outputDataCollection" type="dataCollectionRef"
 		     minOccurs="0"/>
       </xsd:sequence>
     </xsd:extension>
@@ -991,7 +1011,7 @@
       <xsd:sequence>
 	<xsd:element name="investigation" type="investigationRef" 
 		     minOccurs="0"/>
-	<xsd:element name="study" type="entityReference" minOccurs="0"/>
+	<xsd:element name="study" type="studyRef" minOccurs="0"/>
       </xsd:sequence>
     </xsd:extension>
   </xsd:complexContent>

--- a/doc/icatdata-4.10.xsd
+++ b/doc/icatdata-4.10.xsd
@@ -212,6 +212,7 @@
       <xsd:attribute name="dataset.investigation.visitId" type="xsd:string"/>
       <xsd:attribute name="dataset.name" type="xsd:string"/>
       <xsd:attribute name="name" type="xsd:string"/>
+      <xsd:attribute name="doi" type="xsd:string"/>
     </xsd:extension>
   </xsd:complexContent>
 </xsd:complexType>
@@ -233,6 +234,7 @@
       <xsd:attribute name="investigation.name" type="xsd:string"/>
       <xsd:attribute name="investigation.visitId" type="xsd:string"/>
       <xsd:attribute name="name" type="xsd:string"/>
+      <xsd:attribute name="doi" type="xsd:string"/>
     </xsd:extension>
   </xsd:complexContent>
 </xsd:complexType>
@@ -267,6 +269,7 @@
     <xsd:extension base="entityReference">
       <xsd:attribute name="facility.name" type="xsd:string"/>
       <xsd:attribute name="name" type="xsd:string"/>
+      <xsd:attribute name="pid" type="xsd:string"/>
     </xsd:extension>
   </xsd:complexContent>
 </xsd:complexType>
@@ -277,6 +280,7 @@
       <xsd:attribute name="facility.name" type="xsd:string"/>
       <xsd:attribute name="name" type="xsd:string"/>
       <xsd:attribute name="visitId" type="xsd:string"/>
+      <xsd:attribute name="doi" type="xsd:string"/>
     </xsd:extension>
   </xsd:complexContent>
 </xsd:complexType>
@@ -296,6 +300,7 @@
       <xsd:attribute name="facility.name" type="xsd:string"/>
       <xsd:attribute name="name" type="xsd:string"/>
       <xsd:attribute name="units" type="xsd:string"/>
+      <xsd:attribute name="pid" type="xsd:string"/>
     </xsd:extension>
   </xsd:complexContent>
 </xsd:complexType>
@@ -307,6 +312,7 @@
       <xsd:attribute name="investigation.name" type="xsd:string"/>
       <xsd:attribute name="investigation.visitId" type="xsd:string"/>
       <xsd:attribute name="name" type="xsd:string"/>
+      <xsd:attribute name="pid" type="xsd:string"/>
     </xsd:extension>
   </xsd:complexContent>
 </xsd:complexType>
@@ -325,6 +331,8 @@
   <xsd:complexContent>
     <xsd:extension base="entityReference">
       <xsd:attribute name="name" type="xsd:string"/>
+      <xsd:attribute name="email" type="xsd:string"/>
+      <xsd:attribute name="orcidId" type="xsd:string"/>
     </xsd:extension>
   </xsd:complexContent>
 </xsd:complexType>

--- a/doc/icatdata-4.3.xsd
+++ b/doc/icatdata-4.3.xsd
@@ -212,6 +212,7 @@
       <xsd:attribute name="dataset.investigation.visitId" type="xsd:string"/>
       <xsd:attribute name="dataset.name" type="xsd:string"/>
       <xsd:attribute name="name" type="xsd:string"/>
+      <xsd:attribute name="doi" type="xsd:string"/>
     </xsd:extension>
   </xsd:complexContent>
 </xsd:complexType>
@@ -233,6 +234,7 @@
       <xsd:attribute name="investigation.name" type="xsd:string"/>
       <xsd:attribute name="investigation.visitId" type="xsd:string"/>
       <xsd:attribute name="name" type="xsd:string"/>
+      <xsd:attribute name="doi" type="xsd:string"/>
     </xsd:extension>
   </xsd:complexContent>
 </xsd:complexType>
@@ -277,6 +279,7 @@
       <xsd:attribute name="facility.name" type="xsd:string"/>
       <xsd:attribute name="name" type="xsd:string"/>
       <xsd:attribute name="visitId" type="xsd:string"/>
+      <xsd:attribute name="doi" type="xsd:string"/>
     </xsd:extension>
   </xsd:complexContent>
 </xsd:complexType>

--- a/doc/icatdata-4.4.xsd
+++ b/doc/icatdata-4.4.xsd
@@ -212,6 +212,7 @@
       <xsd:attribute name="dataset.investigation.visitId" type="xsd:string"/>
       <xsd:attribute name="dataset.name" type="xsd:string"/>
       <xsd:attribute name="name" type="xsd:string"/>
+      <xsd:attribute name="doi" type="xsd:string"/>
     </xsd:extension>
   </xsd:complexContent>
 </xsd:complexType>
@@ -233,6 +234,7 @@
       <xsd:attribute name="investigation.name" type="xsd:string"/>
       <xsd:attribute name="investigation.visitId" type="xsd:string"/>
       <xsd:attribute name="name" type="xsd:string"/>
+      <xsd:attribute name="doi" type="xsd:string"/>
     </xsd:extension>
   </xsd:complexContent>
 </xsd:complexType>
@@ -277,6 +279,7 @@
       <xsd:attribute name="facility.name" type="xsd:string"/>
       <xsd:attribute name="name" type="xsd:string"/>
       <xsd:attribute name="visitId" type="xsd:string"/>
+      <xsd:attribute name="doi" type="xsd:string"/>
     </xsd:extension>
   </xsd:complexContent>
 </xsd:complexType>

--- a/doc/icatdata-4.7.xsd
+++ b/doc/icatdata-4.7.xsd
@@ -212,6 +212,7 @@
       <xsd:attribute name="dataset.investigation.visitId" type="xsd:string"/>
       <xsd:attribute name="dataset.name" type="xsd:string"/>
       <xsd:attribute name="name" type="xsd:string"/>
+      <xsd:attribute name="doi" type="xsd:string"/>
     </xsd:extension>
   </xsd:complexContent>
 </xsd:complexType>
@@ -233,6 +234,7 @@
       <xsd:attribute name="investigation.name" type="xsd:string"/>
       <xsd:attribute name="investigation.visitId" type="xsd:string"/>
       <xsd:attribute name="name" type="xsd:string"/>
+      <xsd:attribute name="doi" type="xsd:string"/>
     </xsd:extension>
   </xsd:complexContent>
 </xsd:complexType>
@@ -277,6 +279,7 @@
       <xsd:attribute name="facility.name" type="xsd:string"/>
       <xsd:attribute name="name" type="xsd:string"/>
       <xsd:attribute name="visitId" type="xsd:string"/>
+      <xsd:attribute name="doi" type="xsd:string"/>
     </xsd:extension>
   </xsd:complexContent>
 </xsd:complexType>
@@ -325,6 +328,8 @@
   <xsd:complexContent>
     <xsd:extension base="entityReference">
       <xsd:attribute name="name" type="xsd:string"/>
+      <xsd:attribute name="email" type="xsd:string"/>
+      <xsd:attribute name="orcidId" type="xsd:string"/>
     </xsd:extension>
   </xsd:complexContent>
 </xsd:complexType>

--- a/doc/icatdata-4.7.xsd
+++ b/doc/icatdata-4.7.xsd
@@ -36,6 +36,8 @@
     <!-- entity object references -->
     <xsd:element name="applicationRef" type="applicationRef" 
 		 minOccurs="0" maxOccurs="unbounded"/>
+    <xsd:element name="dataCollectionRef" type="dataCollectionRef"
+		 minOccurs="0" maxOccurs="unbounded"/>
     <xsd:element name="datafileRef" type="datafileRef" 
 		 minOccurs="0" maxOccurs="unbounded"/>
     <xsd:element name="datafileFormatRef" type="datafileFormatRef" 
@@ -199,6 +201,14 @@
       <xsd:attribute name="facility.name" type="xsd:string"/>
       <xsd:attribute name="name" type="xsd:string"/>
       <xsd:attribute name="version" type="xsd:string"/>
+    </xsd:extension>
+  </xsd:complexContent>
+</xsd:complexType>
+
+<xsd:complexType name="dataCollectionRef">
+  <xsd:complexContent>
+    <xsd:extension base="entityReference">
+      <xsd:attribute name="doi" type="xsd:string"/>
     </xsd:extension>
   </xsd:complexContent>
 </xsd:complexType>
@@ -398,7 +408,7 @@
   <xsd:complexContent>
     <xsd:extension base="entityBase">
       <xsd:sequence>
-	<xsd:element name="dataCollection" type="entityReference" 
+	<xsd:element name="dataCollection" type="dataCollectionRef"
 		     minOccurs="0"/>
 	<xsd:element name="datafile" type="datafileRef" minOccurs="0"/>
       </xsd:sequence>
@@ -410,7 +420,7 @@
   <xsd:complexContent>
     <xsd:extension base="entityBase">
       <xsd:sequence>
-	<xsd:element name="dataCollection" type="entityReference" 
+	<xsd:element name="dataCollection" type="dataCollectionRef"
 		     minOccurs="0"/>
 	<xsd:element name="dataset" type="datasetRef" minOccurs="0"/>
       </xsd:sequence>
@@ -428,7 +438,7 @@
 	<xsd:element name="rangeBottom" type="xsd:double" minOccurs="0"/>
 	<xsd:element name="rangeTop" type="xsd:double" minOccurs="0"/>
 	<xsd:element name="stringValue" type="xsd:string" minOccurs="0"/>
-	<xsd:element name="dataCollection" type="entityReference" 
+	<xsd:element name="dataCollection" type="dataCollectionRef"
 		     minOccurs="0"/>
 	<xsd:element name="type" type="parameterTypeRef" minOccurs="0"/>
       </xsd:sequence>
@@ -765,9 +775,9 @@
       <xsd:sequence>
 	<xsd:element name="arguments" type="xsd:string" minOccurs="0"/>
 	<xsd:element name="application" type="applicationRef" minOccurs="0"/>
-	<xsd:element name="inputDataCollection" type="entityReference" 
+	<xsd:element name="inputDataCollection" type="dataCollectionRef"
 		     minOccurs="0"/>
-	<xsd:element name="outputDataCollection" type="entityReference" 
+	<xsd:element name="outputDataCollection" type="dataCollectionRef"
 		     minOccurs="0"/>
       </xsd:sequence>
     </xsd:extension>

--- a/doc/icatdata-5.0.xsd
+++ b/doc/icatdata-5.0.xsd
@@ -36,6 +36,8 @@
     <!-- entity object references -->
     <xsd:element name="applicationRef" type="applicationRef"
 		 minOccurs="0" maxOccurs="unbounded"/>
+    <xsd:element name="dataCollectionRef" type="dataCollectionRef"
+		 minOccurs="0" maxOccurs="unbounded"/>
     <xsd:element name="dataPublicationRef" type="dataPublicationRef"
 		 minOccurs="0" maxOccurs="unbounded"/>
     <xsd:element name="dataPublicationTypeRef" type="dataPublicationTypeRef"
@@ -69,6 +71,8 @@
     <xsd:element name="sampleRef" type="sampleRef"
 		 minOccurs="0" maxOccurs="unbounded"/>
     <xsd:element name="sampleTypeRef" type="sampleTypeRef"
+		 minOccurs="0" maxOccurs="unbounded"/>
+    <xsd:element name="studyRef" type="studyRef"
 		 minOccurs="0" maxOccurs="unbounded"/>
     <xsd:element name="techniqueRef" type="techniqueRef"
 		 minOccurs="0" maxOccurs="unbounded"/>
@@ -247,6 +251,14 @@
   </xsd:complexContent>
 </xsd:complexType>
 
+<xsd:complexType name="dataCollectionRef">
+  <xsd:complexContent>
+    <xsd:extension base="entityReference">
+      <xsd:attribute name="doi" type="xsd:string"/>
+    </xsd:extension>
+  </xsd:complexContent>
+</xsd:complexType>
+
 <xsd:complexType name="dataPublicationRef">
   <xsd:complexContent>
     <xsd:extension base="entityReference">
@@ -419,6 +431,14 @@
   </xsd:complexContent>
 </xsd:complexType>
 
+<xsd:complexType name="studyRef">
+  <xsd:complexContent>
+    <xsd:extension base="entityReference">
+      <xsd:attribute name="pid" type="xsd:string"/>
+    </xsd:extension>
+  </xsd:complexContent>
+</xsd:complexType>
+
 <xsd:complexType name="techniqueRef">
   <xsd:complexContent>
     <xsd:extension base="entityReference">
@@ -519,7 +539,7 @@
   <xsd:complexContent>
     <xsd:extension base="entityBase">
       <xsd:sequence>
-	<xsd:element name="dataCollection" type="entityReference"
+	<xsd:element name="dataCollection" type="dataCollectionRef"
 		     minOccurs="0"/>
 	<xsd:element name="datafile" type="datafileRef" minOccurs="0"/>
       </xsd:sequence>
@@ -531,7 +551,7 @@
   <xsd:complexContent>
     <xsd:extension base="entityBase">
       <xsd:sequence>
-	<xsd:element name="dataCollection" type="entityReference"
+	<xsd:element name="dataCollection" type="dataCollectionRef"
 		     minOccurs="0"/>
 	<xsd:element name="dataset" type="datasetRef" minOccurs="0"/>
       </xsd:sequence>
@@ -543,7 +563,7 @@
   <xsd:complexContent>
     <xsd:extension base="entityBase">
       <xsd:sequence>
-	<xsd:element name="dataCollection" type="entityReference"
+	<xsd:element name="dataCollection" type="dataCollectionRef"
 		     minOccurs="0"/>
 	<xsd:element name="investigation" type="investigationRef"
 		     minOccurs="0"/>
@@ -562,7 +582,7 @@
 	<xsd:element name="rangeBottom" type="xsd:double" minOccurs="0"/>
 	<xsd:element name="rangeTop" type="xsd:double" minOccurs="0"/>
 	<xsd:element name="stringValue" type="xsd:string" minOccurs="0"/>
-	<xsd:element name="dataCollection" type="entityReference"
+	<xsd:element name="dataCollection" type="dataCollectionRef"
 		     minOccurs="0"/>
 	<xsd:element name="type" type="parameterTypeRef" minOccurs="0"/>
       </xsd:sequence>
@@ -579,7 +599,7 @@
 	<xsd:element name="publicationDate" type="xsd:dateTime" minOccurs="0"/>
 	<xsd:element name="subject" type="xsd:string" minOccurs="0"/>
 	<xsd:element name="title" type="xsd:string"/>
-	<xsd:element name="content" type="entityReference" minOccurs="0"/>
+	<xsd:element name="content" type="dataCollectionRef" minOccurs="0"/>
 	<xsd:element name="facility" type="facilityRef" minOccurs="0"/>
 	<xsd:element name="type" type="dataPublicationTypeRef" minOccurs="0"/>
 	<xsd:element name="dates" type="dataPublicationDate"
@@ -1077,9 +1097,9 @@
       <xsd:sequence>
 	<xsd:element name="arguments" type="xsd:string" minOccurs="0"/>
 	<xsd:element name="application" type="applicationRef" minOccurs="0"/>
-	<xsd:element name="inputDataCollection" type="entityReference"
+	<xsd:element name="inputDataCollection" type="dataCollectionRef"
 		     minOccurs="0"/>
-	<xsd:element name="outputDataCollection" type="entityReference"
+	<xsd:element name="outputDataCollection" type="dataCollectionRef"
 		     minOccurs="0"/>
       </xsd:sequence>
     </xsd:extension>
@@ -1313,7 +1333,7 @@
       <xsd:sequence>
 	<xsd:element name="investigation" type="investigationRef"
 		     minOccurs="0"/>
-	<xsd:element name="study" type="entityReference" minOccurs="0"/>
+	<xsd:element name="study" type="studyRef" minOccurs="0"/>
       </xsd:sequence>
     </xsd:extension>
   </xsd:complexContent>

--- a/doc/icatdata-5.0.xsd
+++ b/doc/icatdata-5.0.xsd
@@ -285,6 +285,7 @@
       <xsd:attribute name="dataset.investigation.visitId" type="xsd:string"/>
       <xsd:attribute name="dataset.name" type="xsd:string"/>
       <xsd:attribute name="name" type="xsd:string"/>
+      <xsd:attribute name="doi" type="xsd:string"/>
     </xsd:extension>
   </xsd:complexContent>
 </xsd:complexType>
@@ -306,6 +307,7 @@
       <xsd:attribute name="investigation.name" type="xsd:string"/>
       <xsd:attribute name="investigation.visitId" type="xsd:string"/>
       <xsd:attribute name="name" type="xsd:string"/>
+      <xsd:attribute name="doi" type="xsd:string"/>
     </xsd:extension>
   </xsd:complexContent>
 </xsd:complexType>
@@ -341,6 +343,7 @@
     <xsd:extension base="entityReference">
       <xsd:attribute name="funderName" type="xsd:string"/>
       <xsd:attribute name="awardNumber" type="xsd:string"/>
+      <xsd:attribute name="funderIdentifier" type="xsd:string"/>
     </xsd:extension>
   </xsd:complexContent>
 </xsd:complexType>
@@ -358,6 +361,7 @@
     <xsd:extension base="entityReference">
       <xsd:attribute name="facility.name" type="xsd:string"/>
       <xsd:attribute name="name" type="xsd:string"/>
+      <xsd:attribute name="pid" type="xsd:string"/>
     </xsd:extension>
   </xsd:complexContent>
 </xsd:complexType>
@@ -368,6 +372,7 @@
       <xsd:attribute name="facility.name" type="xsd:string"/>
       <xsd:attribute name="name" type="xsd:string"/>
       <xsd:attribute name="visitId" type="xsd:string"/>
+      <xsd:attribute name="doi" type="xsd:string"/>
     </xsd:extension>
   </xsd:complexContent>
 </xsd:complexType>
@@ -387,6 +392,7 @@
       <xsd:attribute name="facility.name" type="xsd:string"/>
       <xsd:attribute name="name" type="xsd:string"/>
       <xsd:attribute name="units" type="xsd:string"/>
+      <xsd:attribute name="pid" type="xsd:string"/>
     </xsd:extension>
   </xsd:complexContent>
 </xsd:complexType>
@@ -398,6 +404,7 @@
       <xsd:attribute name="investigation.name" type="xsd:string"/>
       <xsd:attribute name="investigation.visitId" type="xsd:string"/>
       <xsd:attribute name="name" type="xsd:string"/>
+      <xsd:attribute name="pid" type="xsd:string"/>
     </xsd:extension>
   </xsd:complexContent>
 </xsd:complexType>
@@ -416,6 +423,7 @@
   <xsd:complexContent>
     <xsd:extension base="entityReference">
       <xsd:attribute name="name" type="xsd:string"/>
+      <xsd:attribute name="pid" type="xsd:string"/>
     </xsd:extension>
   </xsd:complexContent>
 </xsd:complexType>
@@ -424,6 +432,8 @@
   <xsd:complexContent>
     <xsd:extension base="entityReference">
       <xsd:attribute name="name" type="xsd:string"/>
+      <xsd:attribute name="email" type="xsd:string"/>
+      <xsd:attribute name="orcidId" type="xsd:string"/>
     </xsd:extension>
   </xsd:complexContent>
 </xsd:complexType>


### PR DESCRIPTION
Extend `icatdata`  XML Schema Definition files:

Add new `entityReference` types:

- `dataCollectionRef` defining an extra attribute `doi`,
- `studyRef` defining an extra attribute `pid`.

Add extra attributes to existing `entityReference` types:

- `doi` to `datafileRef`,
- `doi` to `datasetRef`,
- `funderIdentifier` to `fundingReferenceRef`,
- `pid` to `instrumentRef`,
- `doi` to `investigationRef`,
- `pid` to `parameterTypeRef`,
- `pid` to `sampleRef`,
- `email` and `orcidId` to `userRef`.

In all cases, these extra attributes allow the respective entity objects to be referenced by those attributes. E.g. you could have something like
```xml
<icatdata>
  <data>
    <dataset id="Dataset_1">
      <!-- ... -->
      <datasetInstruments>
        <instrument pid="doi:10.5442/NI000004"/>
      </datasetInstruments>
      <datasetTechniques>
        <technique pid="PaNET:PaNET01196"/>
      </datasetTechniques>
    </dataset>
  </data>
</icatdata>
```
in an `icatdata.xml` file. E.g. a dataset linking to an instrument and a technique referencing those objects by their respective `pid` attribute.

Close #112,

Note that this does not change the behavior of any part of `python-icat` in any way. The XSD files are provided as a reference for convenience only, but are not actually used to validate any XML input in the code. `icatingest` did support such references as cited above already before and in fact, the XSD files are documented to be somewaht too restricted anyway.