### PR TITLE
Remove attribute icat.config.Configuration._config

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -11,6 +11,9 @@ Bug fixes and minor changes
 + `#112`_, `#118`_: Extend icatdata XSD adding extra attributes to
   reference objects.
 
++ `#119`_, `#120`_: Remove `_config` attribute from
+  :class:`icat.config.Configuration`.
+
 + `#115`_, `#116`_: Fix the test suite to work if either PyYAML or
   lxml is not available.
 
@@ -18,6 +21,8 @@ Bug fixes and minor changes
 .. _#115: https://github.com/icatproject/python-icat/issues/115
 .. _#116: https://github.com/icatproject/python-icat/pull/116
 .. _#118: https://github.com/icatproject/python-icat/pull/118
+.. _#119: https://github.com/icatproject/python-icat/issues/119
+.. _#120: https://github.com/icatproject/python-icat/pull/120
 
 
 1.0.0 (2022-12-21)

--- a/icat/config.py
+++ b/icat/config.py
@@ -377,26 +377,37 @@ class Configuration():
     """
     def __init__(self, config):
         self._config = config
+        self._varnames = None
+
+    @property
+    def varnames(self):
+        if self._varnames:
+            return self._varnames
+        else:
+            return ([var.name for var in self._config.confvariables] +
+                    self._config.ReservedVariables)
+
+    def _freeze_varnames(self):
+        self._varnames = ([var.name for var in self._config.confvariables] +
+                          self._config.ReservedVariables)
+        del self._config
 
     def __str__(self):
         typename = type(self).__name__
         arg_strings = []
-        vars = [var.name for var in self._config.confvariables] \
-            + self._config.ReservedVariables
         with warnings.catch_warnings():
             warnings.simplefilter("ignore")
-            for f in vars:
+            for f in self.varnames:
                 if hasattr(self, f):
                     arg_strings.append('%s=%r' % (f, getattr(self, f)))
         return '%s(%s)' % (typename, ', '.join(arg_strings))
 
     def as_dict(self):
         """Return the configuration as a :class:`dict`."""
-        vars = [var.name for var in self._config.confvariables] \
-            + self._config.ReservedVariables
         with warnings.catch_warnings():
             warnings.simplefilter("ignore")
-            d = { f:getattr(self, f) for f in vars if hasattr(self, f) }
+            d = { f:getattr(self, f)
+                  for f in self.varnames if hasattr(self, f) }
         return d
 
 
@@ -725,6 +736,7 @@ class Config(BaseConfig):
                 for k in self.authenticatorInfo.getCredentialKeys(config.auth)
             }
 
+        config._freeze_varnames()
         return (self.client, config)
 
     def _add_fundamental_variables(self):


### PR DESCRIPTION
- Freeze the variable names in the `icat.config.Configuration` object before returning it from `icat.config.Config.getconfig()`,
- At the same, delete the `_config` attribute in this object.

Close #119