### PR TITLE
Fix a memory leak in Client.Register

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -21,12 +21,14 @@ Bug fixes and minor changes
 + `#115`_, `#116`_: Fix the test suite to work if either PyYAML or
   lxml is not available.
 
+.. _#111: https://github.com/icatproject/python-icat/issues/111
 .. _#112: https://github.com/icatproject/python-icat/issues/112
 .. _#115: https://github.com/icatproject/python-icat/issues/115
 .. _#116: https://github.com/icatproject/python-icat/pull/116
 .. _#118: https://github.com/icatproject/python-icat/pull/118
 .. _#119: https://github.com/icatproject/python-icat/issues/119
 .. _#120: https://github.com/icatproject/python-icat/pull/120
+.. _#121: https://github.com/icatproject/python-icat/pull/121
 
 
 1.0.0 (2022-12-21)

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -11,6 +11,10 @@ Bug fixes and minor changes
 + `#112`_, `#118`_: Extend icatdata XSD adding extra attributes to
   reference objects.
 
++ `#111`_, `#121`_: Change the type of
+  :attr:`icat.client.Client.Register` to
+  :class:`weakref.WeakValueDictionary`, fixing a memory leak.
+
 + `#119`_, `#120`_: Remove `_config` attribute from
   :class:`icat.config.Configuration`.
 

--- a/doc/src/client.rst
+++ b/doc/src/client.rst
@@ -15,6 +15,9 @@ manages the interaction with an ICAT service as a client.
 
         The register of all active clients.
 
+        .. versionchanged:: 1.1.0
+            changed type to :class:`weakref.WeakValueDictionary`.
+
     .. attribute:: AutoRefreshRemain
 
         Number of minutes to leave in the session before automatic

--- a/icat/client.py
+++ b/icat/client.py
@@ -169,9 +169,9 @@ class Client(suds.client.Client):
         :const:`True`).  The client should not be used any more after
         calling this method.
         """
+        if self.autoLogout:
+            self.logout()
         if id(self) in self.Register:
-            if self.autoLogout:
-                self.logout()
             del self.Register[id(self)]
 
     def add_ids(self, url, proxy=None):

--- a/icat/client.py
+++ b/icat/client.py
@@ -78,7 +78,11 @@ class Client(suds.client.Client):
     """
 
     Register = weakref.WeakValueDictionary()
-    """The register of all active clients."""
+    """The register of all active clients.
+
+    .. versionchanged:: 1.1.0
+        changed type to :class:`weakref.WeakValueDictionary`.
+    """
 
     AutoRefreshRemain = 30
     """Number of minutes to leave in the session before automatic refresh

--- a/icat/client.py
+++ b/icat/client.py
@@ -11,6 +11,7 @@ import re
 import time
 import urllib.parse
 from warnings import warn
+import weakref
 
 import suds
 import suds.client
@@ -76,7 +77,7 @@ class Client(suds.client.Client):
         for details.
     """
 
-    Register = {}
+    Register = weakref.WeakValueDictionary()
     """The register of all active clients."""
 
     AutoRefreshRemain = 30
@@ -92,9 +93,10 @@ class Client(suds.client.Client):
         class instances, e.g. on all clients that have not yet been
         cleaned up.
         """
-        cl = list(cls.Register.values())
-        for c in cl:
-            c.cleanup()
+        for r in list(cls.Register.valuerefs()):
+            c = r()
+            if c:
+                c.cleanup()
 
     def _schedule_auto_refresh(self, t=None):
         now = time.time()

--- a/tests/test_04_client_cleanup.py
+++ b/tests/test_04_client_cleanup.py
@@ -70,7 +70,6 @@ def test_no_autologout_cleanup_call(registerClient):
     client.cleanup()
     assert len(SessionRegisterClient.Sessions) == 1
 
-@pytest.mark.xfail(reason="Issue #111")
 def test_client_delete(registerClient):
     """client logs in, client does not log out, but is explicitely
     deleted, which invokes cleanup(), which automatically logs the
@@ -88,7 +87,6 @@ def test_client_delete(registerClient):
     assert r() is None
     assert len(SessionRegisterClient.Sessions) == 0
 
-@pytest.mark.xfail(reason="Issue #111")
 def test_client_garbage_collect(registerClient):
     """client logs in, client does not log out, but the last reference to
     it vanisches.  The client is eventually garbage collected (forced

--- a/tests/test_04_client_cleanup.py
+++ b/tests/test_04_client_cleanup.py
@@ -36,8 +36,8 @@ def registerClient(monkeypatch):
     SessionRegisterClient.Sessions.clear()
     monkeypatch.setattr(icat.config, "Client", SessionRegisterClient)
     yield
-    logger.info("%d sessions still active during tear down",
-                len(SessionRegisterClient.Sessions))
+    logger.debug("%d sessions still active during tear down",
+                 len(SessionRegisterClient.Sessions))
 
 def test_explicit_logout(registerClient):
     """client logs in and client logs out, as simple as that.

--- a/tests/test_04_client_cleanup.py
+++ b/tests/test_04_client_cleanup.py
@@ -1,0 +1,117 @@
+"""Test whether Client.cleanup() is properly called in all cases.
+"""
+
+import gc
+import logging
+import pytest
+import icat
+import icat.config
+from conftest import getConfig
+
+logger = logging.getLogger(__name__)
+
+class SessionRegisterClient(icat.Client):
+    """An ICAT Client class that separately keeps track of open sessions.
+    """
+
+    Sessions = set()
+
+    def login(self, auth, credentials):
+        super().login(auth, credentials)
+        self.Sessions.add(self.sessionId)
+        return self.sessionId
+
+    def logout(self):
+        if self.sessionId:
+            self.Sessions.discard(self.sessionId)
+        super().logout()
+
+# The ICAT client is instantiated in icat.config.Config.  Note that we
+# must monkeypatch the icat.config module rather than icat.client, as
+# the former already imported the Client class at this point.
+
+@pytest.fixture(scope="function")
+def registerClient(monkeypatch):
+    SessionRegisterClient.Sessions.clear()
+    monkeypatch.setattr(icat.config, "Client", SessionRegisterClient)
+    yield
+    logger.info("%d sessions still active during tear down",
+                len(SessionRegisterClient.Sessions))
+
+def test_explicit_logout(registerClient):
+    """client logs in and client logs out, as simple as that.
+    """
+    client, conf = getConfig(confSection="acord")
+    client.login(conf.auth, conf.credentials)
+    assert len(SessionRegisterClient.Sessions) == 1
+    client.logout()
+    assert len(SessionRegisterClient.Sessions) == 0
+
+def test_cleanup_call(registerClient):
+    """client logs in, client does not log out, but cleanup() is called
+    instead which automatically logs the client out.
+    """
+    client, conf = getConfig(confSection="acord")
+    client.login(conf.auth, conf.credentials)
+    assert len(SessionRegisterClient.Sessions) == 1
+    client.cleanup()
+    assert len(SessionRegisterClient.Sessions) == 0
+
+def test_no_autologout_cleanup_call(registerClient):
+    """client logs in, client does not log out, but cleanup() is called
+    instead.  But the client is marked not to auto logout.  The
+    session remains active.
+    """
+    client, conf = getConfig(confSection="acord")
+    client.autoLogout = False
+    client.login(conf.auth, conf.credentials)
+    assert len(SessionRegisterClient.Sessions) == 1
+    client.cleanup()
+    assert len(SessionRegisterClient.Sessions) == 1
+
+@pytest.mark.xfail(reason="Issue #111")
+def test_client_delete(registerClient):
+    """client logs in, client does not log out, but is explicitely
+    deleted, which invokes cleanup(), which automatically logs the
+    client out.
+    """
+    client, conf = getConfig(confSection="acord")
+    client.login(conf.auth, conf.credentials)
+    assert len(SessionRegisterClient.Sessions) == 1
+    del client
+    assert len(SessionRegisterClient.Sessions) == 0
+
+@pytest.mark.xfail(reason="Issue #111")
+def test_client_garbage_collect(registerClient):
+    """client logs in, client does not log out, but the last reference to
+    it vanisches.  The client is eventually garbage collected (forced
+    in this test), which invokes cleanup(), which automatically logs
+    the client out.
+    """
+    client, conf = getConfig(confSection="acord")
+    client.login(conf.auth, conf.credentials)
+    assert len(SessionRegisterClient.Sessions) == 1
+    client = None
+    gc.collect()
+    assert len(SessionRegisterClient.Sessions) == 0
+
+def test_cleanupall(registerClient):
+    """Three clients, all logged in.  The first logs out, the other two
+    remain logged in.  The second is marked not to auto logout.  The
+    classmethod cleanupall() is called, which invokes cleanup() for
+    all three.  This logs the third out, the session for the second
+    remains active.
+    """
+    client1, conf1 = getConfig(confSection="acord")
+    sessionId1 = client1.login(conf1.auth, conf1.credentials)
+    client2, conf2 = getConfig(confSection="ahau")
+    client2.autoLogout = False
+    sessionId2 = client2.login(conf2.auth, conf2.credentials)
+    client3, conf3 = getConfig(confSection="jbotu")
+    sessionId3 = client3.login(conf3.auth, conf3.credentials)
+    assert len(SessionRegisterClient.Sessions) == 3
+    client1.logout()
+    assert len(SessionRegisterClient.Sessions) == 2
+    icat.Client.cleanupall()
+    assert len(SessionRegisterClient.Sessions) == 1
+    assert sessionId2 in SessionRegisterClient.Sessions


### PR DESCRIPTION
Use a `weakref.WeakValueDictionary` in `client.Register` to avoid spurious references to `Client` objects preventing these objects to be discarded by the garbage collector.

Close #111.