### PR TITLE
Review documentation

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -14,6 +14,8 @@ New features
 Bug fixes and minor changes
 ---------------------------
 
++ `#126`_, `#127`_: Update outdated documentation.
+
 + `#112`_, `#118`_: Extend icatdata XSD adding extra attributes to
   reference objects.
 
@@ -36,6 +38,8 @@ Bug fixes and minor changes
 .. _#120: https://github.com/icatproject/python-icat/pull/120
 .. _#121: https://github.com/icatproject/python-icat/pull/121
 .. _#124: https://github.com/icatproject/python-icat/pull/124
+.. _#126: https://github.com/icatproject/python-icat/issues/126
+.. _#127: https://github.com/icatproject/python-icat/pull/127
 
 
 1.0.0 (2022-12-21)

--- a/doc/src/client.rst
+++ b/doc/src/client.rst
@@ -11,17 +11,9 @@ manages the interaction with an ICAT service as a client.
 
     .. rubric:: Class attributes
 
-    .. attribute:: Register
+    .. autoattribute:: Register
 
-        The register of all active clients.
-
-        .. versionchanged:: 1.1.0
-            changed type to :class:`weakref.WeakValueDictionary`.
-
-    .. attribute:: AutoRefreshRemain
-
-        Number of minutes to leave in the session before automatic
-        refresh should be called.
+    .. autoattribute:: AutoRefreshRemain
 
     .. rubric:: Instance attributes
 

--- a/doc/src/client.rst
+++ b/doc/src/client.rst
@@ -29,6 +29,9 @@ manages the interaction with an ICAT service as a client.
 
         Version of the ICAT server this client connects to.
 
+	.. versionchanged:: 1.0.0
+            changed type to :class:`icat.helper.Version`
+
     .. attribute:: autoLogout
 
         Flag whether the client should logout automatically on exit.

--- a/doc/src/config.rst
+++ b/doc/src/config.rst
@@ -46,9 +46,7 @@ added.  The main class that client programs interact with is
 
     Class attributes (read only):
 
-    .. attribute:: ReservedVariables = ['credentials']
-
-        Reserved names of configuration variables.
+    .. autoattribute:: ReservedVariables
 
     Instance methods:
 

--- a/doc/src/dump_queries.rst
+++ b/doc/src/dump_queries.rst
@@ -32,7 +32,7 @@ The queries are adapted to the ICAT server version the client is
 connected to.
 
 .. versionchanged:: 1.0.0
-    Review the partition to take the schema extensions in ICAT 5.0
+    review the partition to take the schema extensions in ICAT 5.0
     into account and include the new entity types.
 
 .. autofunction:: icat.dump_queries.getAuthQueries

--- a/doc/src/dump_queries.rst
+++ b/doc/src/dump_queries.rst
@@ -8,29 +8,43 @@
    script.  Most users will not need to use it directly or even care
    about it.
 
-The icatdump data is written in chunks, see the documentation of
-:mod:`icat.dumpfile` for details why this is needed.  The partition
-used here is the following:
+:ref:`ICAT-data-files` are written in chunks.  The partition used here
+is the following:
 
 1. One chunk with all objects that define authorization (User, Group,
    Rule, PublicStep).
 2. All static content in one chunk, e.g. all objects not related to
    individual investigations and that need to be present, before we
    can add investigations.
-3. The investigation data.  All content related to individual
+3. FundingReferences.
+4. The investigation data.  All content related to individual
    investigations.  Each investigation with all its data in one single
    chunk on its own.
-4. One last chunk with all remaining stuff (RelatedDatafile,
-   DataCollection, Job).
+5. DataCollections.
+6. DataPublications.  All content related to individual data
+   publications, each one in one chunk on its own respectively.
+7. One last chunk with all remaining stuff (Study, RelatedDatafile,
+   Job).
 
 The functions defined in this module each return a list of queries
-needed to fetch all objects to be included in one of these chunkes.
+needed to fetch the objects to be included in one of these chunks.
+The queries are adapted to the ICAT server version the client is
+connected to.
 
+.. versionchanged:: 1.0.0
+    Review the partition to take the schema extensions in ICAT 5.0
+    into account and include the new entity types.
 
 .. autofunction:: icat.dump_queries.getAuthQueries
 
 .. autofunction:: icat.dump_queries.getStaticQueries
 
+.. autofunction:: icat.dump_queries.getFundingQueries
+
 .. autofunction:: icat.dump_queries.getInvestigationQueries
+
+.. autofunction:: icat.dump_queries.getDataCollectionQueries
+
+.. autofunction:: icat.dump_queries.getDataPublicationQueries
 
 .. autofunction:: icat.dump_queries.getOtherQueries

--- a/doc/src/entities.rst
+++ b/doc/src/entities.rst
@@ -21,7 +21,7 @@ Furthermore, custom methods are added to a few selected entity
 classes.
 
 .. versionchanged:: 0.17.0
-    Create the entity classes dynamically.
+    create the entity classes dynamically.
 
 .. autoclass:: icat.entities.GroupingMixin
     :members:

--- a/doc/src/entities.rst
+++ b/doc/src/entities.rst
@@ -5,9 +5,11 @@
 
 Provide the classes corresponding to the entities in the ICAT schema.
 
-Entity classes defined in this module are derived from the abstract
-base class :class:`icat.entity.Entity`.  They override the class
-attributes :attr:`icat.entity.Entity.BeanName`,
+The classes representing the entities in the ICAT schema are
+dynamically created based on the entity information queried from the
+ICAT server.  The classes are derived from the abstract base class
+:class:`icat.entity.Entity`.  They override the class attributes
+:attr:`icat.entity.Entity.BeanName`,
 :attr:`icat.entity.Entity.Constraint`,
 :attr:`icat.entity.Entity.InstAttr`,
 :attr:`icat.entity.Entity.InstRel`,
@@ -17,6 +19,9 @@ attributes :attr:`icat.entity.Entity.BeanName`,
 
 Furthermore, custom methods are added to a few selected entity
 classes.
+
+.. versionchanged:: 0.17.0
+    Create the entity classes dynamically.
 
 .. autoclass:: icat.entities.GroupingMixin
     :members:

--- a/doc/src/tutorial-config-advanced.rst
+++ b/doc/src/tutorial-config-advanced.rst
@@ -495,3 +495,10 @@ the `preset` keyword argument has a similar effect as setting a
 default for the respective configuration variable.  But it also allows
 to override the default for configuration variables that are
 predefined by :mod:`icat.config`.
+
+We can still override the preset configuration variable in the command
+line::
+
+  $ python config-preset.py -s myicat_nbour
+  Login to https://icat.example.com:8181 was successful.
+  User: db/nbour

--- a/doc/src/tutorial-config-advanced.rst
+++ b/doc/src/tutorial-config-advanced.rst
@@ -194,74 +194,118 @@ config file (``-s SECTION``) as well as the `entity` variable (``-e
   listing existing User objects...
   [(user){
      createId = "simple/root"
-     createTime = 2020-02-20 15:55:39+01:00
+     createTime = 2023-06-28 12:22:34+02:00
      id = 1
      modId = "simple/root"
-     modTime = 2020-02-20 15:55:39+01:00
+     modTime = 2023-06-28 12:22:34+02:00
+     affiliation = "University of Ravenna, Institute of Modern History"
+     email = "acord@example.org"
+     familyName = "Cordus"
      fullName = "Aelius Cordus"
+     givenName = "Aelius"
      name = "db/acord"
+     orcidId = "0000-0002-3262"
    }, (user){
      createId = "simple/root"
-     createTime = 2020-02-20 15:55:39+01:00
+     createTime = 2023-06-28 12:22:34+02:00
      id = 2
      modId = "simple/root"
-     modTime = 2020-02-20 15:55:39+01:00
+     modTime = 2023-06-28 12:22:34+02:00
+     affiliation = "Goethe University Frankfurt, Faculty of Philosophy and History"
+     email = "ahau@example.org"
+     familyName = "Hau"
      fullName = "Arnold Hau"
+     givenName = "Arnold"
      name = "db/ahau"
+     orcidId = "0000-0002-3263"
    }, (user){
      createId = "simple/root"
-     createTime = 2020-02-20 15:55:39+01:00
+     createTime = 2023-06-28 12:22:34+02:00
      id = 3
      modId = "simple/root"
-     modTime = 2020-02-20 15:55:39+01:00
+     modTime = 2023-06-28 12:22:34+02:00
+     affiliation = "Université Paul-Valéry Montpellier 3"
+     email = "jbotu@example.org"
+     familyName = "Botul"
      fullName = "Jean-Baptiste Botul"
+     givenName = "Jean-Baptiste"
      name = "db/jbotu"
+     orcidId = "0000-0002-3264"
    }, (user){
      createId = "simple/root"
-     createTime = 2020-02-20 15:55:39+01:00
+     createTime = 2023-06-28 12:22:34+02:00
      id = 4
      modId = "simple/root"
-     modTime = 2020-02-20 15:55:39+01:00
+     modTime = 2023-06-28 12:22:34+02:00
+     email = "jdoe@example.org"
+     familyName = "Doe"
      fullName = "John Doe"
+     givenName = "John"
      name = "db/jdoe"
    }, (user){
      createId = "simple/root"
-     createTime = 2020-02-20 15:55:39+01:00
+     createTime = 2023-06-28 12:22:34+02:00
      id = 5
      modId = "simple/root"
-     modTime = 2020-02-20 15:55:39+01:00
+     modTime = 2023-06-28 12:22:34+02:00
+     affiliation = "University of Nancago"
+     email = "nbour@example.org"
+     familyName = "Bourbaki"
      fullName = "Nicolas Bourbaki"
+     givenName = "Nicolas"
      name = "db/nbour"
+     orcidId = "0000-0002-3266"
    }, (user){
      createId = "simple/root"
-     createTime = 2020-02-20 15:55:39+01:00
+     createTime = 2023-06-28 12:22:34+02:00
      id = 6
      modId = "simple/root"
-     modTime = 2020-02-20 15:55:39+01:00
+     modTime = 2023-06-28 12:22:34+02:00
+     affiliation = "Kaiser-Wilhelms-Akademie für das militärärztliche Bildungswesen"
+     email = "rbeck@example.org"
+     familyName = "Beck-Dülmen"
      fullName = "Rudolph Beck-Dülmen"
+     givenName = "Rudolph"
      name = "db/rbeck"
+     orcidId = "0000-0002-3267"
    }, (user){
      createId = "simple/root"
-     createTime = 2020-02-20 15:55:39+01:00
+     createTime = 2023-06-28 12:22:34+02:00
      id = 7
      modId = "simple/root"
-     modTime = 2020-02-20 15:55:39+01:00
+     modTime = 2023-06-28 12:22:34+02:00
+     fullName = "Data Ingester"
+     name = "simple/dataingest"
+   }, (user){
+     createId = "simple/root"
+     createTime = 2023-06-28 12:22:34+02:00
+     id = 8
+     modId = "simple/root"
+     modTime = 2023-06-28 12:22:34+02:00
      fullName = "IDS reader"
      name = "simple/idsreader"
    }, (user){
      createId = "simple/root"
-     createTime = 2020-02-20 15:55:39+01:00
-     id = 8
+     createTime = 2023-06-28 12:22:34+02:00
+     id = 9
      modId = "simple/root"
-     modTime = 2020-02-20 15:55:39+01:00
+     modTime = 2023-06-28 12:22:34+02:00
+     fullName = "Pub reader"
+     name = "simple/pubreader"
+   }, (user){
+     createId = "simple/root"
+     createTime = 2023-06-28 12:22:34+02:00
+     id = 10
+     modId = "simple/root"
+     modTime = 2023-06-28 12:22:34+02:00
      fullName = "Root"
      name = "simple/root"
    }, (user){
      createId = "simple/root"
-     createTime = 2020-02-20 15:55:39+01:00
-     id = 9
+     createTime = 2023-06-28 12:22:34+02:00
+     id = 11
      modId = "simple/root"
-     modTime = 2020-02-20 15:55:39+01:00
+     modTime = 2023-06-28 12:22:34+02:00
      fullName = "User Office"
      name = "simple/useroffice"
    }]
@@ -296,82 +340,126 @@ with name "db/alice"::
   listing existing User objects...
   [(user){
      createId = "simple/root"
-     createTime = 2020-02-20 15:55:39+01:00
+     createTime = 2023-06-28 12:22:34+02:00
      id = 1
      modId = "simple/root"
-     modTime = 2020-02-20 15:55:39+01:00
+     modTime = 2023-06-28 12:22:34+02:00
+     affiliation = "University of Ravenna, Institute of Modern History"
+     email = "acord@example.org"
+     familyName = "Cordus"
      fullName = "Aelius Cordus"
+     givenName = "Aelius"
      name = "db/acord"
+     orcidId = "0000-0002-3262"
    }, (user){
      createId = "simple/root"
-     createTime = 2020-02-20 15:55:39+01:00
+     createTime = 2023-06-28 12:22:34+02:00
      id = 2
      modId = "simple/root"
-     modTime = 2020-02-20 15:55:39+01:00
+     modTime = 2023-06-28 12:22:34+02:00
+     affiliation = "Goethe University Frankfurt, Faculty of Philosophy and History"
+     email = "ahau@example.org"
+     familyName = "Hau"
      fullName = "Arnold Hau"
+     givenName = "Arnold"
      name = "db/ahau"
+     orcidId = "0000-0002-3263"
    }, (user){
      createId = "simple/root"
-     createTime = 2020-02-20 15:55:39+01:00
+     createTime = 2023-06-28 12:22:34+02:00
      id = 3
      modId = "simple/root"
-     modTime = 2020-02-20 15:55:39+01:00
+     modTime = 2023-06-28 12:22:34+02:00
+     affiliation = "Université Paul-Valéry Montpellier 3"
+     email = "jbotu@example.org"
+     familyName = "Botul"
      fullName = "Jean-Baptiste Botul"
+     givenName = "Jean-Baptiste"
      name = "db/jbotu"
+     orcidId = "0000-0002-3264"
    }, (user){
      createId = "simple/root"
-     createTime = 2020-02-20 15:55:39+01:00
+     createTime = 2023-06-28 12:22:34+02:00
      id = 4
      modId = "simple/root"
-     modTime = 2020-02-20 15:55:39+01:00
+     modTime = 2023-06-28 12:22:34+02:00
+     email = "jdoe@example.org"
+     familyName = "Doe"
      fullName = "John Doe"
+     givenName = "John"
      name = "db/jdoe"
    }, (user){
      createId = "simple/root"
-     createTime = 2020-02-20 15:55:39+01:00
+     createTime = 2023-06-28 12:22:34+02:00
      id = 5
      modId = "simple/root"
-     modTime = 2020-02-20 15:55:39+01:00
+     modTime = 2023-06-28 12:22:34+02:00
+     affiliation = "University of Nancago"
+     email = "nbour@example.org"
+     familyName = "Bourbaki"
      fullName = "Nicolas Bourbaki"
+     givenName = "Nicolas"
      name = "db/nbour"
+     orcidId = "0000-0002-3266"
    }, (user){
      createId = "simple/root"
-     createTime = 2020-02-20 15:55:39+01:00
+     createTime = 2023-06-28 12:22:34+02:00
      id = 6
      modId = "simple/root"
-     modTime = 2020-02-20 15:55:39+01:00
+     modTime = 2023-06-28 12:22:34+02:00
+     affiliation = "Kaiser-Wilhelms-Akademie für das militärärztliche Bildungswesen"
+     email = "rbeck@example.org"
+     familyName = "Beck-Dülmen"
      fullName = "Rudolph Beck-Dülmen"
+     givenName = "Rudolph"
      name = "db/rbeck"
+     orcidId = "0000-0002-3267"
    }, (user){
      createId = "simple/root"
-     createTime = 2020-02-20 15:55:39+01:00
+     createTime = 2023-06-28 12:22:34+02:00
      id = 7
      modId = "simple/root"
-     modTime = 2020-02-20 15:55:39+01:00
+     modTime = 2023-06-28 12:22:34+02:00
+     fullName = "Data Ingester"
+     name = "simple/dataingest"
+   }, (user){
+     createId = "simple/root"
+     createTime = 2023-06-28 12:22:34+02:00
+     id = 8
+     modId = "simple/root"
+     modTime = 2023-06-28 12:22:34+02:00
      fullName = "IDS reader"
      name = "simple/idsreader"
    }, (user){
      createId = "simple/root"
-     createTime = 2020-02-20 15:55:39+01:00
-     id = 8
+     createTime = 2023-06-28 12:22:34+02:00
+     id = 9
      modId = "simple/root"
-     modTime = 2020-02-20 15:55:39+01:00
+     modTime = 2023-06-28 12:22:34+02:00
+     fullName = "Pub reader"
+     name = "simple/pubreader"
+   }, (user){
+     createId = "simple/root"
+     createTime = 2023-06-28 12:22:34+02:00
+     id = 10
+     modId = "simple/root"
+     modTime = 2023-06-28 12:22:34+02:00
      fullName = "Root"
      name = "simple/root"
    }, (user){
      createId = "simple/root"
-     createTime = 2020-02-20 15:55:39+01:00
-     id = 9
+     createTime = 2023-06-28 12:22:34+02:00
+     id = 11
      modId = "simple/root"
-     modTime = 2020-02-20 15:55:39+01:00
+     modTime = 2023-06-28 12:22:34+02:00
      fullName = "User Office"
      name = "simple/useroffice"
    }, (user){
      createId = "simple/root"
-     createTime = 2020-02-21 18:34:29+01:00
-     id = 10
+     createTime = 2023-06-28 15:06:06+02:00
+     id = 12
      modId = "simple/root"
-     modTime = 2020-02-21 18:34:29+01:00
+     modTime = 2023-06-28 15:06:06+02:00
      name = "db/alice"
    }]
   done
@@ -379,10 +467,10 @@ with name "db/alice"::
 Finally, let's delete this new object using the `delete` sub-command.
 To do this, we must specify the sub-command-specific configuration
 variable `id` (``-i ID``).  In the above output, we can see that the
-object's ID is 10, so we write::
+object's ID is 12, so we write::
 
-  $ python config-sub-commands.py -s myicat_root -e User delete -i 10
-  deleting the User object with ID 10...
+  $ python config-sub-commands.py -s myicat_root -e User delete -i 12
+  deleting the User object with ID 12...
   done
 
 Preset configuration values in the program

--- a/doc/src/tutorial-config.rst
+++ b/doc/src/tutorial-config.rst
@@ -48,7 +48,7 @@ So there is a command line option ``-w URL``.  Let's try::
 
   $ python config.py -w 'https://icat.example.com:8181'
   Connect to https://icat.example.com:8181
-  ICAT version 4.10
+  ICAT version 5.0.1
 
 (Again, you may need to add the ``--no-check-certificate`` flag to the
 command line if your ICAT server does not have a trusted SSL
@@ -67,7 +67,7 @@ Now you can do the following::
 
   $ python config.py -s myicat
   Connect to https://icat.example.com:8181
-  ICAT version 4.10
+  ICAT version 5.0.1
 
 The command line option ``-s SECTION`` selects a section in the
 configuration file to read options from.
@@ -82,7 +82,7 @@ If you run this in the same way as above, you'll get::
 
   $ python config-with-ids.py -s myicat
   Connect to https://icat.example.com:8181
-  ICAT version 4.10
+  ICAT version 5.0.1
   No IDS configured
 
 But if you indicate the URL to IDS with the command line option
@@ -98,7 +98,7 @@ You'll get something like::
 
   $ python config-with-ids.py -s myicat
   Connect to https://icat.example.com:8181
-  ICAT version 4.10
+  ICAT version 5.0.1
   Connect to https://icat.example.com:8181
-  IDS version 1.10.1
+  IDS version 1.12.0
 

--- a/doc/src/tutorial-create.rst
+++ b/doc/src/tutorial-create.rst
@@ -39,10 +39,10 @@ The result can be verified by repeating the search from above::
   >>> client.search("SELECT f FROM Facility f")
   [(facility){
      createId = "simple/root"
-     createTime = 2019-11-26 12:39:18+01:00
+     createTime = 2023-06-28 10:39:26+02:00
      id = 1
      modId = "simple/root"
-     modTime = 2019-11-26 12:39:18+01:00
+     modTime = 2023-06-28 10:39:26+02:00
      fullName = "Facility 1"
      name = "Fac1"
    }]
@@ -62,18 +62,18 @@ To verify the result, we check again::
   >>> client.search("SELECT f FROM Facility f")
   [(facility){
      createId = "simple/root"
-     createTime = 2019-11-26 12:39:18+01:00
+     createTime = 2023-06-28 10:39:26+02:00
      id = 1
      modId = "simple/root"
-     modTime = 2019-11-26 12:39:18+01:00
+     modTime = 2023-06-28 10:39:26+02:00
      fullName = "Facility 1"
      name = "Fac1"
    }, (facility){
      createId = "simple/root"
-     createTime = 2019-11-26 12:40:02+01:00
+     createTime = 2023-06-28 10:41:08+02:00
      id = 2
      modId = "simple/root"
-     modTime = 2019-11-26 12:40:02+01:00
+     modTime = 2023-06-28 10:41:08+02:00
      fullName = "Facility 2"
      name = "Fac2"
    }]
@@ -136,10 +136,10 @@ We can verify this by searching for the newly created objects::
   >>> client.search(query)
   [(parameterType){
      createId = "simple/root"
-     createTime = 2019-11-26 12:40:54+01:00
+     createTime = 2023-06-28 10:43:06+02:00
      id = 1
      modId = "simple/root"
-     modTime = 2019-11-26 12:40:54+01:00
+     modTime = 2023-06-28 10:43:06+02:00
      applicableToDataCollection = False
      applicableToDatafile = False
      applicableToDataset = True
@@ -149,10 +149,10 @@ We can verify this by searching for the newly created objects::
      facility =
         (facility){
            createId = "simple/root"
-           createTime = 2019-11-26 12:39:18+01:00
+           createTime = 2023-06-28 10:39:26+02:00
            id = 1
            modId = "simple/root"
-           modTime = 2019-11-26 12:39:18+01:00
+           modTime = 2023-06-28 10:39:26+02:00
            fullName = "Facility 1"
            name = "Fac1"
         }
@@ -162,10 +162,10 @@ We can verify this by searching for the newly created objects::
      verified = False
    }, (parameterType){
      createId = "simple/root"
-     createTime = 2019-11-26 12:41:30+01:00
+     createTime = 2023-06-28 10:44:28+02:00
      id = 2
      modId = "simple/root"
-     modTime = 2019-11-26 12:41:30+01:00
+     modTime = 2023-06-28 10:44:28+02:00
      applicableToDataCollection = False
      applicableToDatafile = False
      applicableToDataset = True
@@ -175,10 +175,10 @@ We can verify this by searching for the newly created objects::
      facility =
         (facility){
            createId = "simple/root"
-           createTime = 2019-11-26 12:39:18+01:00
+           createTime = 2023-06-28 10:39:26+02:00
            id = 1
            modId = "simple/root"
-           modTime = 2019-11-26 12:39:18+01:00
+           modTime = 2023-06-28 10:39:26+02:00
            fullName = "Facility 1"
            name = "Fac1"
         }
@@ -186,27 +186,27 @@ We can verify this by searching for the newly created objects::
      permissibleStringValues[] =
         (permissibleStringValue){
            createId = "simple/root"
-           createTime = 2019-11-26 12:41:30+01:00
+           createTime = 2023-06-28 10:44:28+02:00
            id = 1
            modId = "simple/root"
-           modTime = 2019-11-26 12:41:30+01:00
+           modTime = 2023-06-28 10:44:28+02:00
+           value = "cattivo"
+        },
+        (permissibleStringValue){
+           createId = "simple/root"
+           createTime = 2023-06-28 10:44:28+02:00
+           id = 2
+           modId = "simple/root"
+           modTime = 2023-06-28 10:44:28+02:00
            value = "buono"
         },
         (permissibleStringValue){
            createId = "simple/root"
-           createTime = 2019-11-26 12:41:30+01:00
-           id = 2
-           modId = "simple/root"
-           modTime = 2019-11-26 12:41:30+01:00
-           value = "brutto"
-        },
-        (permissibleStringValue){
-           createId = "simple/root"
-           createTime = 2019-11-26 12:41:30+01:00
+           createTime = 2023-06-28 10:44:28+02:00
            id = 3
            modId = "simple/root"
-           modTime = 2019-11-26 12:41:30+01:00
-           value = "cattivo"
+           modTime = 2023-06-28 10:44:28+02:00
+           value = "brutto"
         },
      units = "N/A"
      valueType = "STRING"
@@ -272,10 +272,10 @@ If we now try again to search for the objects as normal user, we get::
   >>> client.search("SELECT pt FROM ParameterType pt INCLUDE pt.facility")
   [(parameterType){
      createId = "simple/root"
-     createTime = 2019-11-26 12:40:54+01:00
+     createTime = 2023-06-28 10:43:06+02:00
      id = 1
      modId = "simple/root"
-     modTime = 2019-11-26 12:40:54+01:00
+     modTime = 2023-06-28 10:43:06+02:00
      applicableToDataCollection = False
      applicableToDatafile = False
      applicableToDataset = True
@@ -285,10 +285,10 @@ If we now try again to search for the objects as normal user, we get::
      facility =
         (facility){
            createId = "simple/root"
-           createTime = 2019-11-26 12:39:18+01:00
+           createTime = 2023-06-28 10:39:26+02:00
            id = 1
            modId = "simple/root"
-           modTime = 2019-11-26 12:39:18+01:00
+           modTime = 2023-06-28 10:39:26+02:00
            fullName = "Facility 1"
            name = "Fac1"
         }
@@ -298,10 +298,10 @@ If we now try again to search for the objects as normal user, we get::
      verified = False
    }, (parameterType){
      createId = "simple/root"
-     createTime = 2019-11-26 12:41:30+01:00
+     createTime = 2023-06-28 10:44:28+02:00
      id = 2
      modId = "simple/root"
-     modTime = 2019-11-26 12:41:30+01:00
+     modTime = 2023-06-28 10:44:28+02:00
      applicableToDataCollection = False
      applicableToDatafile = False
      applicableToDataset = True
@@ -311,10 +311,10 @@ If we now try again to search for the objects as normal user, we get::
      facility =
         (facility){
            createId = "simple/root"
-           createTime = 2019-11-26 12:39:18+01:00
+           createTime = 2023-06-28 10:39:26+02:00
            id = 1
            modId = "simple/root"
-           modTime = 2019-11-26 12:39:18+01:00
+           modTime = 2023-06-28 10:39:26+02:00
            fullName = "Facility 1"
            name = "Fac1"
         }
@@ -323,4 +323,3 @@ If we now try again to search for the objects as normal user, we get::
      valueType = "STRING"
      verified = False
    }]
-

--- a/doc/src/tutorial-edit.rst
+++ b/doc/src/tutorial-edit.rst
@@ -10,18 +10,18 @@ objects::
   >>> client.search("SELECT f FROM Facility f")
   [(facility){
      createId = "simple/root"
-     createTime = 2019-11-26 12:39:18+01:00
+     createTime = 2023-06-28 10:39:26+02:00
      id = 1
      modId = "simple/root"
-     modTime = 2019-11-26 12:39:18+01:00
+     modTime = 2023-06-28 10:39:26+02:00
      fullName = "Facility 1"
      name = "Fac1"
    }, (facility){
      createId = "simple/root"
-     createTime = 2019-11-26 12:40:02+01:00
+     createTime = 2023-06-28 10:41:08+02:00
      id = 2
      modId = "simple/root"
-     modTime = 2019-11-26 12:40:02+01:00
+     modTime = 2023-06-28 10:41:08+02:00
      fullName = "Facility 2"
      name = "Fac2"
    }]
@@ -52,20 +52,20 @@ We can verify the changes by performing another search::
   >>> client.search("SELECT f FROM Facility f")
   [(facility){
      createId = "simple/root"
-     createTime = 2019-11-26 12:39:18+01:00
+     createTime = 2023-06-28 10:39:26+02:00
      id = 1
      modId = "simple/root"
-     modTime = 2019-11-26 12:48:46+01:00
+     modTime = 2023-06-28 11:25:27+02:00
      daysUntilRelease = 1826
      description = "An example facility"
      fullName = "Fac1 Facility"
      name = "Fac1"
    }, (facility){
      createId = "simple/root"
-     createTime = 2019-11-26 12:40:02+01:00
+     createTime = 2023-06-28 10:41:08+02:00
      id = 2
      modId = "simple/root"
-     modTime = 2019-11-26 12:48:46+01:00
+     modTime = 2023-06-28 11:25:27+02:00
      daysUntilRelease = 1826
      description = "An example facility"
      fullName = "Fac2 Facility"
@@ -73,7 +73,7 @@ We can verify the changes by performing another search::
    }]
 
 To remove a particular attribute value, we usually just have to assign
-:mod:`None` to it::
+:const:`None` to it::
 
   >>> for facility in client.search("SELECT f FROM Facility f"):
   ...     facility.description = None
@@ -85,19 +85,19 @@ If we search again now, the descriptions are gone::
   >>> client.search("SELECT f FROM Facility f")
   [(facility){
      createId = "simple/root"
-     createTime = 2019-11-26 12:39:18+01:00
+     createTime = 2023-06-28 10:39:26+02:00
      id = 1
      modId = "simple/root"
-     modTime = 2019-11-26 12:49:28+01:00
+     modTime = 2023-06-28 11:26:31+02:00
      daysUntilRelease = 1826
      fullName = "Fac1 Facility"
      name = "Fac1"
    }, (facility){
      createId = "simple/root"
-     createTime = 2019-11-26 12:40:02+01:00
+     createTime = 2023-06-28 10:41:08+02:00
      id = 2
      modId = "simple/root"
-     modTime = 2019-11-26 12:49:28+01:00
+     modTime = 2023-06-28 11:26:31+02:00
      daysUntilRelease = 1826
      fullName = "Fac2 Facility"
      name = "Fac2"
@@ -119,23 +119,23 @@ earlier, including its referenced ``ParameterType`` objects::
   >>> print(fac)
   (facility){
      createId = "simple/root"
-     createTime = 2019-11-26 12:39:18+01:00
+     createTime = 2023-06-28 10:39:26+02:00
      id = 1
      modId = "simple/root"
-     modTime = 2019-11-26 12:49:28+01:00
+     modTime = 2023-06-28 11:26:31+02:00
      daysUntilRelease = 1826
      fullName = "Fac1 Facility"
      name = "Fac1"
      parameterTypes[] =
         (parameterType){
            createId = "simple/root"
-           createTime = 2019-11-26 12:40:54+01:00
+           createTime = 2023-06-28 10:43:06+02:00
            id = 1
            modId = "simple/root"
-           modTime = 2019-11-26 12:40:54+01:00
+           modTime = 2023-06-28 10:43:06+02:00
            applicableToDataCollection = False
            applicableToDatafile = False
-           applicableToDataset = False
+           applicableToDataset = True
            applicableToInvestigation = False
            applicableToSample = False
            enforced = False
@@ -146,13 +146,13 @@ earlier, including its referenced ``ParameterType`` objects::
         },
         (parameterType){
            createId = "simple/root"
-           createTime = 2019-11-26 12:41:30+01:00
+           createTime = 2023-06-28 10:44:28+02:00
            id = 2
            modId = "simple/root"
-           modTime = 2019-11-26 12:41:30+01:00
+           modTime = 2023-06-28 10:44:28+02:00
            applicableToDataCollection = False
            applicableToDatafile = False
-           applicableToDataset = False
+           applicableToDataset = True
            applicableToInvestigation = False
            applicableToSample = False
            enforced = False
@@ -193,10 +193,10 @@ the object::
   >>> print(fac)
   (facility){
      createId = "simple/root"
-     createTime = 2019-11-26 12:39:18+01:00
+     createTime = 2023-06-28 10:39:26+02:00
      id = 1
      modId = "simple/root"
-     modTime = 2019-11-26 12:49:28+01:00
+     modTime = 2023-06-28 11:26:31+02:00
      daysUntilRelease = 1826
      fullName = "Fac1 Facility"
      name = "Fac1"
@@ -215,13 +215,13 @@ the object::
      parameterTypes[] =
         (parameterType){
            createId = "simple/root"
-           createTime = 2019-11-26 12:40:54+01:00
+           createTime = 2023-06-28 10:43:06+02:00
            id = 1
            modId = "simple/root"
-           modTime = 2019-11-26 12:40:54+01:00
+           modTime = 2023-06-28 10:43:06+02:00
            applicableToDataCollection = False
            applicableToDatafile = False
-           applicableToDataset = False
+           applicableToDataset = True
            applicableToInvestigation = False
            applicableToSample = False
            enforced = False
@@ -232,13 +232,13 @@ the object::
         },
         (parameterType){
            createId = "simple/root"
-           createTime = 2019-11-26 12:41:30+01:00
+           createTime = 2023-06-28 10:44:28+02:00
            id = 2
            modId = "simple/root"
-           modTime = 2019-11-26 12:41:30+01:00
+           modTime = 2023-06-28 10:44:28+02:00
            applicableToDataCollection = False
            applicableToDatafile = False
-           applicableToDataset = False
+           applicableToDataset = True
            applicableToInvestigation = False
            applicableToSample = False
            enforced = False
@@ -249,4 +249,3 @@ the object::
         },
      url = None
    }
-

--- a/doc/src/tutorial-hello.rst
+++ b/doc/src/tutorial-hello.rst
@@ -12,7 +12,7 @@ output::
 
   $ python hello.py
   Connect to https://icat.example.com:8181
-  ICAT version 4.10
+  ICAT version 5.0.1
 
 The constructor of :class:`icat.client.Client` takes the URL of the
 ICAT service as argument.  It contacts the ICAT server, queries the
@@ -27,7 +27,7 @@ get an error instead::
   $ python hello.py
   Traceback (most recent call last):
     ...
-  urllib.error.URLError: <urlopen error [SSL: CERTIFICATE_VERIFY_FAILED] certificate verify failed (_ssl.c:548)>
+  urllib.error.URLError: <urlopen error [SSL: CERTIFICATE_VERIFY_FAILED] certificate verify failed (_ssl.c:852)>
 
 In this case, you may either install a trusted certificate in your
 server now or modify your hello program and add a flag

--- a/doc/src/tutorial-ids.rst
+++ b/doc/src/tutorial-ids.rst
@@ -31,11 +31,11 @@ previous section.  This content can be set up with the following
 commands at the command line::
 
   $ wipeicat -s myicat_root
-  $ icatingest -s myicat_root -i icatdump-4.10.yaml
+  $ icatingest -s myicat_root -i icatdump-5.0.yaml
 
 If you already did that for the previous section, you don't need to
 repeat it.  Take notice of the hint on the content of the
-`icatdump-4.10.yaml` file and ICAT server versions from the previous
+`icatdump-5.0.yaml` file and ICAT server versions from the previous
 section.
 
 Upload files
@@ -72,41 +72,41 @@ For each of the files, we create a new datafile object and call the
   ...
   (datafile){
      createId = "db/nbour"
-     createTime = 2020-02-21 14:57:16+01:00
-     id = 11
+     createTime = 2023-06-28 14:14:26+02:00
+     id = 12
      modId = "db/nbour"
-     modTime = 2020-02-21 14:57:16+01:00
+     modTime = 2023-06-28 14:14:26+02:00
      checksum = "bef32c73"
-     datafileCreateTime = 2020-02-21 13:45:16+01:00
-     datafileModTime = 2020-02-21 13:45:16+01:00
+     datafileCreateTime = 2023-06-28 14:11:52+02:00
+     datafileModTime = 2023-06-28 14:11:52+02:00
      fileSize = 12
-     location = "3/9/f3b5c400-0a24-4915-b7a7-d4f976ec3e73"
+     location = "3/10/7f7800f4-c6cb-4a2c-889f-a6d88389f11e"
      name = "greet-jdoe.txt"
    }
   (datafile){
      createId = "db/nbour"
-     createTime = 2020-02-21 14:57:16+01:00
-     id = 12
+     createTime = 2023-06-28 14:14:26+02:00
+     id = 13
      modId = "db/nbour"
-     modTime = 2020-02-21 14:57:16+01:00
+     modTime = 2023-06-28 14:14:26+02:00
      checksum = "9012de77"
-     datafileCreateTime = 2020-02-21 13:45:16+01:00
-     datafileModTime = 2020-02-21 13:45:16+01:00
+     datafileCreateTime = 2023-06-28 14:11:52+02:00
+     datafileModTime = 2023-06-28 14:11:52+02:00
      fileSize = 15
-     location = "3/9/392d4c49-d9c4-40fa-b4cb-5bdcbb4414e6"
+     location = "3/10/2a76ca1c-9139-4842-a141-d4550d980d1a"
      name = "greet-nbour.txt"
    }
   (datafile){
      createId = "db/nbour"
-     createTime = 2020-02-21 14:57:16+01:00
-     id = 13
+     createTime = 2023-06-28 14:14:26+02:00
+     id = 14
      modId = "db/nbour"
-     modTime = 2020-02-21 14:57:16+01:00
+     modTime = 2023-06-28 14:14:26+02:00
      checksum = "cc830993"
-     datafileCreateTime = 2020-02-21 13:45:16+01:00
-     datafileModTime = 2020-02-21 13:45:16+01:00
+     datafileCreateTime = 2023-06-28 14:11:52+02:00
+     datafileModTime = 2023-06-28 14:11:52+02:00
      fileSize = 15
-     location = "3/9/dd4c6f7f-05f6-418d-8c1f-8a87ca727e5a"
+     location = "3/10/3481e96c-0842-446f-bb60-1796003d51d7"
      name = "greet-rbeck.txt"
    }
 

--- a/doc/src/tutorial-search.rst
+++ b/doc/src/tutorial-search.rst
@@ -11,10 +11,10 @@ and pass them to the :meth:`~icat.client.Client.search` method::
   >>> client.search("SELECT f FROM Facility f INCLUDE f.parameterTypes LIMIT 1,1")
   [(facility){
      createId = "simple/root"
-     createTime = 2019-11-26 12:40:02+01:00
+     createTime = 2023-06-28 10:41:08+02:00
      id = 2
      modId = "simple/root"
-     modTime = 2019-11-26 12:49:28+01:00
+     modTime = 2023-06-28 11:26:31+02:00
      daysUntilRelease = 1826
      fullName = "Fac2 Facility"
      name = "Fac2"
@@ -30,24 +30,24 @@ some well defined and rich content to search for.  Run the following
 commands at the command line::
 
   $ wipeicat -s myicat_root
-  $ icatingest -s myicat_root -i icatdump-4.10.yaml
+  $ icatingest -s myicat_root -i icatdump-5.0.yaml
 
 :ref:`wipeicat` and :ref:`icatingest` are two scripts that get
 installed with python-icat.  Depending on the situation, these scripts
 may be installed either with or without a trailing ``.py`` extension.
-The file `icatdump-4.10.yaml` can be found in the python-icat source
+The file `icatdump-5.0.yaml` can be found in the python-icat source
 distribution.  The first command deletes all content from the ICAT
 server that we may have created in the previous sections.  The second
-command reads the `icatdump-4.10.yaml` file and creates all objects
+command reads the `icatdump-5.0.yaml` file and creates all objects
 listed therein in the ICAT server.
 
 .. note::
-   As the name suggests, the content in `icatdump-4.10.yaml` requires
-   an ICAT server version 4.10 or newer.  If you are using an older
-   ICAT, you may just as well use the `icatdump-4.7.yaml` or
-   `icatdump-4.4.yaml` file instead, matching the respective older
-   versions.  For the sake of this tutorial, the difference does not
-   matter.
+   As the name suggests, the content in `icatdump-5.0.yaml` requires
+   an ICAT server version 5.0 or newer.  If you are using an older
+   ICAT, you may just as well use the `icatdump-4.10.yaml`,
+   `icatdump-4.7.yaml`, or `icatdump-4.4.yaml` file instead, matching
+   the respective older versions.  For the sake of this tutorial, the
+   difference does not matter.
 
 .. note::
    The search results in the following examples may depend on the user
@@ -76,32 +76,41 @@ that lists all investigations::
   >>> client.search(query)
   [(investigation){
      createId = "simple/root"
-     createTime = 2020-02-05 16:49:27+01:00
+     createTime = 2023-06-28 12:22:40+02:00
      id = 1
      modId = "simple/root"
-     modTime = 2020-02-05 16:49:27+01:00
+     modTime = 2023-06-28 12:22:40+02:00
+     doi = "DOI:00.0815/inv-00122"
+     fileCount = 1
+     fileSize = 368369
      name = "08100122-EF"
      startDate = 2008-03-13 11:39:42+01:00
      title = "Durol single crystal"
      visitId = "1.1-P"
    }, (investigation){
      createId = "simple/root"
-     createTime = 2020-02-05 16:49:28+01:00
+     createTime = 2023-06-28 12:22:40+02:00
      id = 2
      modId = "simple/root"
-     modTime = 2020-02-05 16:49:28+01:00
+     modTime = 2023-06-28 12:22:40+02:00
+     doi = "DOI:00.0815/inv-00601"
      endDate = 2010-10-12 17:00:00+02:00
+     fileCount = 4
+     fileSize = 127125
      name = "10100601-ST"
      startDate = 2010-09-30 12:27:24+02:00
      title = "Ni-Mn-Ga flat cone"
      visitId = "1.1-N"
    }, (investigation){
      createId = "simple/root"
-     createTime = 2020-02-05 16:49:33+01:00
+     createTime = 2023-06-28 12:22:42+02:00
      id = 3
      modId = "simple/root"
-     modTime = 2020-02-05 16:49:33+01:00
+     modTime = 2023-06-28 12:22:42+02:00
+     doi = "DOI:00.0815/inv-00409"
      endDate = 2012-08-06 03:10:08+02:00
+     fileCount = 6
+     fileSize = 757836
      name = "12100409-ST"
      startDate = 2012-07-26 17:44:24+02:00
      title = "NiO SC OF1 JUH HHL"
@@ -119,11 +128,14 @@ conditions on that attribute::
   >>> client.search(query)
   [(investigation){
      createId = "simple/root"
-     createTime = 2020-02-05 16:49:28+01:00
+     createTime = 2023-06-28 12:22:40+02:00
      id = 2
      modId = "simple/root"
-     modTime = 2020-02-05 16:49:28+01:00
+     modTime = 2023-06-28 12:22:40+02:00
+     doi = "DOI:00.0815/inv-00601"
      endDate = 2010-10-12 17:00:00+02:00
+     fileCount = 4
+     fileSize = 127125
      name = "10100601-ST"
      startDate = 2010-09-30 12:27:24+02:00
      title = "Ni-Mn-Ga flat cone"
@@ -138,45 +150,54 @@ We may also include related objects in the search results::
   >>> client.search(query)
   [(investigation){
      createId = "simple/root"
-     createTime = 2020-02-05 16:49:28+01:00
+     createTime = 2023-06-28 12:22:40+02:00
      id = 2
      modId = "simple/root"
-     modTime = 2020-02-05 16:49:28+01:00
+     modTime = 2023-06-28 12:22:40+02:00
      datasets[] =
         (dataset){
            createId = "simple/root"
-           createTime = 2020-02-05 16:49:29+01:00
+           createTime = 2023-06-28 12:22:41+02:00
            id = 3
            modId = "simple/root"
-           modTime = 2020-02-05 16:49:29+01:00
+           modTime = 2023-06-28 12:22:41+02:00
            complete = False
            endDate = 2010-10-01 08:17:48+02:00
+           fileCount = 2
+           fileSize = 73874
            name = "e208339"
            startDate = 2010-09-30 12:27:24+02:00
         },
         (dataset){
            createId = "simple/root"
-           createTime = 2020-02-05 16:49:32+01:00
+           createTime = 2023-06-28 12:22:41+02:00
            id = 4
            modId = "simple/root"
-           modTime = 2020-02-05 16:49:32+01:00
+           modTime = 2023-06-28 12:22:41+02:00
            complete = False
            endDate = 2010-10-05 10:32:21+02:00
+           fileCount = 2
+           fileSize = 53251
            name = "e208341"
            startDate = 2010-10-02 04:00:21+02:00
         },
         (dataset){
            createId = "simple/root"
-           createTime = 2020-02-05 16:49:32+01:00
+           createTime = 2023-06-28 12:22:41+02:00
            id = 5
            modId = "simple/root"
-           modTime = 2020-02-05 16:49:32+01:00
+           modTime = 2023-06-28 12:22:41+02:00
            complete = False
            endDate = 2010-10-12 17:00:00+02:00
+           fileCount = 0
+           fileSize = 0
            name = "e208342"
            startDate = 2010-10-09 07:00:00+02:00
         },
+     doi = "DOI:00.0815/inv-00601"
      endDate = 2010-10-12 17:00:00+02:00
+     fileCount = 4
+     fileSize = 127125
      name = "10100601-ST"
      startDate = 2010-09-30 12:27:24+02:00
      title = "Ni-Mn-Ga flat cone"
@@ -193,26 +214,30 @@ following query::
   >>> client.search(query)
   [(investigation){
      createId = "simple/root"
-     createTime = 2021-10-05 14:09:57+00:00
-     id = 430
+     createTime = 2023-06-28 12:22:40+02:00
+     id = 2
      modId = "simple/root"
-     modTime = 2021-10-05 14:09:57+00:00
+     modTime = 2023-06-28 12:22:40+02:00
      doi = "DOI:00.0815/inv-00601"
-     endDate = 2010-10-12 15:00:00+00:00
+     endDate = 2010-10-12 17:00:00+02:00
+     fileCount = 4
+     fileSize = 127125
      name = "10100601-ST"
-     startDate = 2010-09-30 10:27:24+00:00
+     startDate = 2010-09-30 12:27:24+02:00
      title = "Ni-Mn-Ga flat cone"
      visitId = "1.1-N"
    }, (investigation){
      createId = "simple/root"
-     createTime = 2021-10-05 14:09:58+00:00
-     id = 431
+     createTime = 2023-06-28 12:22:42+02:00
+     id = 3
      modId = "simple/root"
-     modTime = 2021-10-05 14:09:58+00:00
+     modTime = 2023-06-28 12:22:42+02:00
      doi = "DOI:00.0815/inv-00409"
-     endDate = 2012-08-06 01:10:08+00:00
+     endDate = 2012-08-06 03:10:08+02:00
+     fileCount = 6
+     fileSize = 757836
      name = "12100409-ST"
-     startDate = 2012-07-26 15:44:24+00:00
+     startDate = 2012-07-26 17:44:24+02:00
      title = "NiO SC OF1 JUH HHL"
      visitId = "1.1-P"
    }]
@@ -234,28 +259,30 @@ field larger then 5 Tesla and include its parameters in the result::
   >>> client.search(query)
   [(dataset){
      createId = "simple/root"
-     createTime = 2020-02-05 16:49:29+01:00
+     createTime = 2023-06-28 12:22:41+02:00
      id = 3
      modId = "simple/root"
-     modTime = 2020-02-05 16:49:29+01:00
+     modTime = 2023-06-28 12:22:41+02:00
      complete = False
      endDate = 2010-10-01 08:17:48+02:00
+     fileCount = 2
+     fileSize = 73874
      name = "e208339"
      parameters[] =
         (datasetParameter){
            createId = "simple/root"
-           createTime = 2020-02-05 16:49:29+01:00
-           id = 1
+           createTime = 2023-06-28 12:22:41+02:00
+           id = 2
            modId = "simple/root"
-           modTime = 2020-02-05 16:49:29+01:00
+           modTime = 2023-06-28 12:22:41+02:00
            numericValue = 7.3
            type =
               (parameterType){
                  createId = "simple/root"
-                 createTime = 2020-02-05 16:49:24+01:00
+                 createTime = 2023-06-28 12:22:39+02:00
                  id = 5
                  modId = "simple/root"
-                 modTime = 2020-02-05 16:49:24+01:00
+                 modTime = 2023-06-28 12:22:39+02:00
                  applicableToDataCollection = False
                  applicableToDatafile = False
                  applicableToDataset = True
@@ -271,18 +298,18 @@ field larger then 5 Tesla and include its parameters in the result::
         },
         (datasetParameter){
            createId = "simple/root"
-           createTime = 2020-02-05 16:49:29+01:00
-           id = 2
+           createTime = 2023-06-28 12:22:41+02:00
+           id = 1
            modId = "simple/root"
-           modTime = 2020-02-05 16:49:29+01:00
+           modTime = 2023-06-28 12:22:41+02:00
            numericValue = 5.0
            type =
               (parameterType){
                  createId = "simple/root"
-                 createTime = 2020-02-05 16:49:24+01:00
+                 createTime = 2023-06-28 12:22:39+02:00
                  id = 7
                  modId = "simple/root"
-                 modTime = 2020-02-05 16:49:24+01:00
+                 modTime = 2023-06-28 12:22:39+02:00
                  applicableToDataCollection = False
                  applicableToDatafile = False
                  applicableToDataset = True
@@ -315,10 +342,13 @@ of your Python program.  Consider::
   SELECT o FROM Investigation o WHERE o.name = '08100122-EF'
   (investigation){
      createId = "simple/root"
-     createTime = 2020-02-05 16:49:27+01:00
+     createTime = 2023-06-28 12:22:40+02:00
      id = 1
      modId = "simple/root"
-     modTime = 2020-02-05 16:49:27+01:00
+     modTime = 2023-06-28 12:22:40+02:00
+     doi = "DOI:00.0815/inv-00122"
+     fileCount = 1
+     fileSize = 368369
      name = "08100122-EF"
      startDate = 2008-03-13 11:39:42+01:00
      title = "Durol single crystal"
@@ -328,11 +358,14 @@ of your Python program.  Consider::
   SELECT o FROM Investigation o WHERE o.name = '12100409-ST' AND o.visitId = '1.1-P'
   (investigation){
      createId = "simple/root"
-     createTime = 2020-02-05 16:49:33+01:00
+     createTime = 2023-06-28 12:22:42+02:00
      id = 3
      modId = "simple/root"
-     modTime = 2020-02-05 16:49:33+01:00
+     modTime = 2023-06-28 12:22:42+02:00
+     doi = "DOI:00.0815/inv-00409"
      endDate = 2012-08-06 03:10:08+02:00
+     fileCount = 6
+     fileSize = 757836
      name = "12100409-ST"
      startDate = 2012-07-26 17:44:24+02:00
      title = "NiO SC OF1 JUH HHL"
@@ -357,20 +390,20 @@ on that attribute.  Search for all datafiles created in 2012::
   >>> client.search(query)
   [(datafile){
      createId = "simple/root"
-     createTime = 2020-02-05 16:49:34+01:00
+     createTime = 2023-06-28 12:22:42+02:00
      id = 7
      modId = "simple/root"
-     modTime = 2020-02-05 16:49:34+01:00
+     modTime = 2023-06-28 12:22:42+02:00
      datafileCreateTime = 2012-07-16 16:30:17+02:00
      datafileModTime = 2012-07-16 16:30:17+02:00
      fileSize = 28937
      name = "e208945-2.nxs"
    }, (datafile){
      createId = "simple/root"
-     createTime = 2020-02-05 16:49:34+01:00
+     createTime = 2023-06-28 12:22:42+02:00
      id = 8
      modId = "simple/root"
-     modTime = 2020-02-05 16:49:34+01:00
+     modTime = 2023-06-28 12:22:42+02:00
      checksum = "bd55affa"
      datafileCreateTime = 2012-07-30 03:10:08+02:00
      datafileModTime = 2012-07-30 03:10:08+02:00
@@ -378,14 +411,24 @@ on that attribute.  Search for all datafiles created in 2012::
      name = "e208945.dat"
    }, (datafile){
      createId = "simple/root"
-     createTime = 2020-02-05 16:49:34+01:00
+     createTime = 2023-06-28 12:22:42+02:00
      id = 10
      modId = "simple/root"
-     modTime = 2020-02-05 16:49:34+01:00
+     modTime = 2023-06-28 12:22:42+02:00
      datafileCreateTime = 2012-07-16 16:30:17+02:00
      datafileModTime = 2012-07-16 16:30:17+02:00
      fileSize = 14965
      name = "e208947.nxs"
+   }, (datafile){
+     createId = "simple/root"
+     createTime = 2023-06-28 12:22:42+02:00
+     id = 11
+     modId = "simple/root"
+     modTime = 2023-06-28 12:22:42+02:00
+     datafileCreateTime = 2012-08-01 00:52:23+02:00
+     datafileModTime = 2012-08-01 00:52:23+02:00
+     fileSize = 264188
+     name = "A000027.hdf5"
    }]
 
 Of course, that last example also works when adding the conditions
@@ -405,7 +448,8 @@ values of the matching objects.  Listing the names of all datasets::
   >>> print(query)
   SELECT o.name FROM Dataset o
   >>> client.search(query)
-  [e201215, e201216, e208339, e208341, e208342, e208945, e208946, e208947]
+  [e201215, e201216, e208339, e208341, e208342, e208945, e208946, e208947, pub-00027]
+
 
 As the name of that keyword argument suggests, we may also search for
 multiple attributes at once.  The result will be a tuple of attribute
@@ -416,7 +460,8 @@ This requires an ICAT server version 4.11 or newer though::
   >>> print(query)
   SELECT i.name, o.name, o.complete, t.name FROM Dataset o JOIN o.investigation AS i JOIN o.type AS t
   >>> client.search(query)
-  [(08100122-EF, e201215, False, raw), (08100122-EF, e201216, False, raw), (10100601-ST, e208339, False, raw), (10100601-ST, e208341, False, raw), (10100601-ST, e208342, False, raw), (12100409-ST, e208945, False, raw), (12100409-ST, e208946, False, raw), (12100409-ST, e208947, True, analyzed)]
+  [(08100122-EF, e201215, False, raw), (08100122-EF, e201216, False, raw), (10100601-ST, e208339, False, raw), (10100601-ST, e208341, False, raw), (10100601-ST, e208342, False, raw), (12100409-ST, e208945, False, raw), (12100409-ST, e208946, False, raw), (12100409-ST, e208947, True, analyzed), (12100409-ST, pub-00027, True, other)]
+
 
 There are also some aggregate functions that may be applied to search
 results.  Let's count all datasets::
@@ -425,7 +470,7 @@ results.  Let's count all datasets::
   >>> print(query)
   SELECT COUNT(o) FROM Dataset o
   >>> client.search(query)
-  [8]
+  [9]
 
 Using such aggregate functions in a query may result in a huge
 performance gain, because the counting is done directly in the
@@ -474,22 +519,28 @@ dataset with a magnetic field parameter set::
   >>> client.search(query)
   [(investigation){
      createId = "simple/root"
-     createTime = 2020-02-05 16:49:28+01:00
+     createTime = 2023-06-28 12:22:40+02:00
      id = 2
      modId = "simple/root"
-     modTime = 2020-02-05 16:49:28+01:00
+     modTime = 2023-06-28 12:22:40+02:00
+     doi = "DOI:00.0815/inv-00601"
      endDate = 2010-10-12 17:00:00+02:00
+     fileCount = 4
+     fileSize = 127125
      name = "10100601-ST"
      startDate = 2010-09-30 12:27:24+02:00
      title = "Ni-Mn-Ga flat cone"
      visitId = "1.1-N"
    }, (investigation){
      createId = "simple/root"
-     createTime = 2020-02-05 16:49:28+01:00
+     createTime = 2023-06-28 12:22:40+02:00
      id = 2
      modId = "simple/root"
-     modTime = 2020-02-05 16:49:28+01:00
+     modTime = 2023-06-28 12:22:40+02:00
+     doi = "DOI:00.0815/inv-00601"
      endDate = 2010-10-12 17:00:00+02:00
+     fileCount = 4
+     fileSize = 127125
      name = "10100601-ST"
      startDate = 2010-09-30 12:27:24+02:00
      title = "Ni-Mn-Ga flat cone"
@@ -506,11 +557,14 @@ respectively.  We may fix that by applying `DISTINCT`::
   >>> client.search(query)
   [(investigation){
      createId = "simple/root"
-     createTime = 2020-02-05 16:49:28+01:00
+     createTime = 2023-06-28 12:22:40+02:00
      id = 2
      modId = "simple/root"
-     modTime = 2020-02-05 16:49:28+01:00
+     modTime = 2023-06-28 12:22:40+02:00
+     doi = "DOI:00.0815/inv-00601"
      endDate = 2010-10-12 17:00:00+02:00
+     fileCount = 4
+     fileSize = 127125
      name = "10100601-ST"
      startDate = 2010-09-30 12:27:24+02:00
      title = "Ni-Mn-Ga flat cone"
@@ -546,18 +600,18 @@ dataset parameter, ordered by parameter type name (ascending), units
   >>> client.search(query)
   [(datasetParameter){
      createId = "simple/root"
-     createTime = 2020-02-05 16:49:29+01:00
-     id = 1
+     createTime = 2023-06-28 12:22:41+02:00
+     id = 2
      modId = "simple/root"
-     modTime = 2020-02-05 16:49:29+01:00
+     modTime = 2023-06-28 12:22:41+02:00
      numericValue = 7.3
      type =
         (parameterType){
            createId = "simple/root"
-           createTime = 2020-02-05 16:49:24+01:00
+           createTime = 2023-06-28 12:22:39+02:00
            id = 5
            modId = "simple/root"
-           modTime = 2020-02-05 16:49:24+01:00
+           modTime = 2023-06-28 12:22:39+02:00
            applicableToDataCollection = False
            applicableToDatafile = False
            applicableToDataset = True
@@ -572,18 +626,18 @@ dataset parameter, ordered by parameter type name (ascending), units
         }
    }, (datasetParameter){
      createId = "simple/root"
-     createTime = 2020-02-05 16:49:32+01:00
+     createTime = 2023-06-28 12:22:41+02:00
      id = 4
      modId = "simple/root"
-     modTime = 2020-02-05 16:49:32+01:00
+     modTime = 2023-06-28 12:22:41+02:00
      numericValue = 2.7
      type =
         (parameterType){
            createId = "simple/root"
-           createTime = 2020-02-05 16:49:24+01:00
+           createTime = 2023-06-28 12:22:39+02:00
            id = 5
            modId = "simple/root"
-           modTime = 2020-02-05 16:49:24+01:00
+           modTime = 2023-06-28 12:22:39+02:00
            applicableToDataCollection = False
            applicableToDatafile = False
            applicableToDataset = True
@@ -598,18 +652,44 @@ dataset parameter, ordered by parameter type name (ascending), units
         }
    }, (datasetParameter){
      createId = "simple/root"
-     createTime = 2020-02-05 16:49:32+01:00
+     createTime = 2023-06-28 12:22:41+02:00
+     id = 1
+     modId = "simple/root"
+     modTime = 2023-06-28 12:22:41+02:00
+     numericValue = 5.0
+     type =
+        (parameterType){
+           createId = "simple/root"
+           createTime = 2023-06-28 12:22:39+02:00
+           id = 7
+           modId = "simple/root"
+           modTime = 2023-06-28 12:22:39+02:00
+           applicableToDataCollection = False
+           applicableToDatafile = False
+           applicableToDataset = True
+           applicableToInvestigation = False
+           applicableToSample = False
+           enforced = False
+           name = "Reactor power"
+           units = "MW"
+           unitsFullName = "Megawatt"
+           valueType = "NUMERIC"
+           verified = False
+        }
+   }, (datasetParameter){
+     createId = "simple/root"
+     createTime = 2023-06-28 12:22:41+02:00
      id = 3
      modId = "simple/root"
-     modTime = 2020-02-05 16:49:32+01:00
+     modTime = 2023-06-28 12:22:41+02:00
      numericValue = 5.0
      type =
         (parameterType){
            createId = "simple/root"
-           createTime = 2020-02-05 16:49:24+01:00
+           createTime = 2023-06-28 12:22:39+02:00
            id = 7
            modId = "simple/root"
-           modTime = 2020-02-05 16:49:24+01:00
+           modTime = 2023-06-28 12:22:39+02:00
            applicableToDataCollection = False
            applicableToDatafile = False
            applicableToDataset = True
@@ -624,44 +704,18 @@ dataset parameter, ordered by parameter type name (ascending), units
         }
    }, (datasetParameter){
      createId = "simple/root"
-     createTime = 2020-02-05 16:49:29+01:00
-     id = 2
-     modId = "simple/root"
-     modTime = 2020-02-05 16:49:29+01:00
-     numericValue = 5.0
-     type =
-        (parameterType){
-           createId = "simple/root"
-           createTime = 2020-02-05 16:49:24+01:00
-           id = 7
-           modId = "simple/root"
-           modTime = 2020-02-05 16:49:24+01:00
-           applicableToDataCollection = False
-           applicableToDatafile = False
-           applicableToDataset = True
-           applicableToInvestigation = False
-           applicableToSample = False
-           enforced = False
-           name = "Reactor power"
-           units = "MW"
-           unitsFullName = "Megawatt"
-           valueType = "NUMERIC"
-           verified = False
-        }
-   }, (datasetParameter){
-     createId = "simple/root"
-     createTime = 2020-02-05 16:49:34+01:00
+     createTime = 2023-06-28 12:22:42+02:00
      id = 5
      modId = "simple/root"
-     modTime = 2020-02-05 16:49:34+01:00
+     modTime = 2023-06-28 12:22:42+02:00
      numericValue = 3.92
      type =
         (parameterType){
            createId = "simple/root"
-           createTime = 2020-02-05 16:49:25+01:00
+           createTime = 2023-06-28 12:22:39+02:00
            id = 9
            modId = "simple/root"
-           modTime = 2020-02-05 16:49:25+01:00
+           modTime = 2023-06-28 12:22:39+02:00
            applicableToDataCollection = False
            applicableToDatafile = False
            applicableToDataset = True
@@ -676,18 +730,18 @@ dataset parameter, ordered by parameter type name (ascending), units
         }
    }, (datasetParameter){
      createId = "simple/root"
-     createTime = 2020-02-05 16:49:34+01:00
+     createTime = 2023-06-28 12:22:42+02:00
      id = 6
      modId = "simple/root"
-     modTime = 2020-02-05 16:49:34+01:00
+     modTime = 2023-06-28 12:22:42+02:00
      numericValue = 277.07
      type =
         (parameterType){
            createId = "simple/root"
-           createTime = 2020-02-05 16:49:25+01:00
+           createTime = 2023-06-28 12:22:39+02:00
            id = 10
            modId = "simple/root"
-           modTime = 2020-02-05 16:49:25+01:00
+           modTime = 2023-06-28 12:22:39+02:00
            applicableToDataCollection = False
            applicableToDatafile = False
            applicableToDataset = True
@@ -717,27 +771,31 @@ shortest::
   19: Jean-Baptiste Botul
   16: Nicolas Bourbaki
   13: Aelius Cordus
+  13: Data Ingester
   11: User Office
   10: Arnold Hau
   10: IDS reader
+  10: Pub reader
   8: John Doe
   4: Root
 
-We may limit the number of returned items.  Search for the second to
+We may limit the number of returned items.  Search for the third to
 last dataset to have been finished::
 
-  >>> query = Query(client, "Dataset", order=[("endDate", "DESC")], limit=(1, 1))
+  >>> query = Query(client, "Dataset", order=[("endDate", "DESC")], limit=(2, 1))
   >>> print(query)
-  SELECT o FROM Dataset o ORDER BY o.endDate DESC LIMIT 1, 1
+  SELECT o FROM Dataset o ORDER BY o.endDate DESC LIMIT 2, 1
   >>> client.search(query)
   [(dataset){
      createId = "simple/root"
-     createTime = 2020-02-05 16:49:34+01:00
+     createTime = 2023-06-28 12:22:42+02:00
      id = 6
      modId = "simple/root"
-     modTime = 2020-02-05 16:49:34+01:00
+     modTime = 2023-06-28 12:22:42+02:00
      complete = False
      endDate = 2012-07-30 03:10:08+02:00
+     fileCount = 4
+     fileSize = 478683
      name = "e208945"
      startDate = 2012-07-26 17:44:24+02:00
    }]

--- a/doc/src/tutorial.rst
+++ b/doc/src/tutorial.rst
@@ -17,7 +17,7 @@ new empty folder for that purpose and change into that::
   $ cd python-icat-tutorial
 
 Some of the more advanced tutorial sections will require some example
-content in the ICAT server.  You'll need the file `icatdump-4.10.yaml`
+content in the ICAT server.  You'll need the file `icatdump-5.0.yaml`
 to set it up.  This file can be found in the `doc/examples` directory
 in the python-icat source distribution.
 

--- a/doc/src/tutorial.rst
+++ b/doc/src/tutorial.rst
@@ -37,3 +37,12 @@ the following sections:
    tutorial-ids
    tutorial-config-advanced
 
+.. note::
+   Throughout this tutorial, we assume the name of the Python
+   executable to be just ``python`` and the full path used in the
+   interpreter line of scripts to be ``/usr/bin/python``.  It is
+   likely that this assumption does not hold in your environment.
+   Quite often, a version number is appended to the executable name as
+   in ``python3`` or ``python3.11`` and the Python executable might
+   reside in another directory in your system.  You may need to adapt
+   accordingly.

--- a/icat/client.py
+++ b/icat/client.py
@@ -799,7 +799,7 @@ class Client(suds.client.Client):
         :rtype: :class:`icat.entity.Entity`
 
         .. versionchanged:: 1.0.0
-            The `infile` parameter also accepts a
+            the `infile` parameter also accepts a
             :class:`~pathlib.Path` object.
         """
 

--- a/icat/client.py
+++ b/icat/client.py
@@ -238,6 +238,10 @@ class Client(suds.client.Client):
         :rtype: :class:`icat.entity.Entity`
         :raise EntityTypeError: if obj is neither a valid instance
             object, nor a valid name of an entity type, nor None.
+
+        .. versionchanged:: 1.0.0
+            if the `obj` argument is a string, it is taken case
+            insensitive.
         """
 
         if isinstance(obj, suds.sudsobject.Object):
@@ -876,6 +880,9 @@ class Client(suds.client.Client):
         :type offset: :class:`int`
         :return: a file-like object as returned by
             :meth:`urllib.request.OpenerDirector.open`.
+
+        .. versionchanged:: 0.17.0
+            accept a prepared id in `objs`.
         """
         if not self.ids:
             raise RuntimeError("no IDS.")
@@ -913,6 +920,9 @@ class Client(suds.client.Client):
         :type outname: :class:`str`
         :return: the URL for the data at the IDS.
         :rtype: :class:`str`
+
+        .. versionchanged:: 0.17.0
+            accept a prepared id in `objs`.
         """
         if not self.ids:
             raise RuntimeError("no IDS.")

--- a/icat/config.py
+++ b/icat/config.py
@@ -665,6 +665,9 @@ class Config(BaseConfig):
         not set, the command line arguments will be taken from
         :data:`sys.argv`.
     :type args: :class:`list` of :class:`str`
+
+    .. versionchanged:: 1.0.0
+        add the `preset` argument.
     """
 
     def __init__(self, defaultvars=True, needlogin=True, ids="optional", 

--- a/icat/dump_queries.py
+++ b/icat/dump_queries.py
@@ -4,9 +4,8 @@
    This module is mostly intended as a helper for the icatdump script.
    Most users will not need to use it directly or even care about it.
 
-The data icatdump is written in chunks, see the documentation of
-icat.dumpfile for details why this is needed.  The partition used
-here is the following:
+ICAT data files are written in chunks.  The partition used here is the
+following:
 
 1. One chunk with all objects that define authorization (User, Group,
    Rule, PublicStep).
@@ -24,7 +23,13 @@ here is the following:
    Job).
 
 The functions defined in this module each return a list of queries
-needed to fetch all objects to be included in one of these chunks.
+needed to fetch the objects to be included in one of these chunks.
+The queries are adapted to the ICAT server version the client is
+connected to.
+
+.. versionchanged:: 1.0.0
+    Review the partition to take the schema extensions in ICAT 5.0
+    into account and include the new entity types.
 """
 
 import icat
@@ -49,9 +54,12 @@ def getAuthQueries(client):
 
 def getStaticQueries(client):
     """Return the queries to fetch all static objects.
+
+    .. versionchanged:: 1.0.0
+        Include queries for ``Technique`` and ``DataPublicationType``.
     """
     # Compatibility between ICAT versions:
-    # - ICAT 5.0.0 added Technique.
+    # - ICAT 5.0.0 added DataPublicationType and Technique.
     queries = [
         Query(client, "Facility", order=True),
         Query(client, "Instrument", order=True,
@@ -82,6 +90,8 @@ def getStaticQueries(client):
 
 def getFundingQueries(client):
     """Return the queries to fetch all FundingReferences.
+
+    .. versionadded:: 1.0.0
     """
     # Compatibility between ICAT versions:
     # - ICAT 5.0.0 added FundingReference.
@@ -92,6 +102,12 @@ def getFundingQueries(client):
 
 def getInvestigationQueries(client, invid):
     """Return the queries to fetch all objects related to an investigation.
+
+    .. versionchanged:: 1.0.0
+        Add include clauses for ``investigationFacilityCycles`` and
+        ``fundingReferences`` into query for ``Investigation``, add
+        include clauses for ``datasetInstruments`` and
+        ``datasetTechniques`` into query for ``Dataset``.
     """
     # Compatibility between ICAT versions:
     # - ICAT 4.4.0 added InvestigationGroups.
@@ -144,6 +160,8 @@ def getInvestigationQueries(client, invid):
 
 def getDataCollectionQueries(client):
     """Return the queries to fetch all DataCollections.
+
+    .. versionadded:: 1.0.0
     """
     # Compatibility between ICAT versions:
     # - ICAT 4.3.0 vs. ICAT 4.3.1 and later: name of the parameters
@@ -169,6 +187,8 @@ def getDataCollectionQueries(client):
 
 def getDataPublicationQueries(client, pubid):
     """Return the queries to fetch all objects related to a data publication.
+
+    .. versionadded:: 1.0.0
     """
     # Compatibility between ICAT versions:
     # - ICAT 5.0.0 added DataPublication and related classes.
@@ -187,6 +207,10 @@ def getDataPublicationQueries(client, pubid):
 def getOtherQueries(client):
     """Return the queries to fetch all other objects,
     e.g. not static and not directly related to an investigation.
+
+    .. versionchanged:: 1.0.0
+        Drop query for ``DataCollection``, now in a separate function
+        :func:`getDataCollectionQueries`.
     """
     return [
         Query(client, "Study", order=True,

--- a/icat/dump_queries.py
+++ b/icat/dump_queries.py
@@ -166,7 +166,7 @@ def getDataCollectionQueries(client):
     # Compatibility between ICAT versions:
     # - ICAT 4.3.0 vs. ICAT 4.3.1 and later: name of the parameters
     #   relation in DataCollection.
-    # - ICAT 5.0.0 added DatasetInstrument and DatasetTechnique.
+    # - ICAT 5.0.0 added DataCollectionInvestigation.
     dc_includes = {
         "dataCollectionDatasets.dataset.investigation.facility",
         "dataCollectionDatafiles.datafile.dataset.investigation.facility",

--- a/icat/dump_queries.py
+++ b/icat/dump_queries.py
@@ -28,7 +28,7 @@ The queries are adapted to the ICAT server version the client is
 connected to.
 
 .. versionchanged:: 1.0.0
-    Review the partition to take the schema extensions in ICAT 5.0
+    review the partition to take the schema extensions in ICAT 5.0
     into account and include the new entity types.
 """
 
@@ -56,7 +56,7 @@ def getStaticQueries(client):
     """Return the queries to fetch all static objects.
 
     .. versionchanged:: 1.0.0
-        Include queries for ``Technique`` and ``DataPublicationType``.
+        include queries for ``Technique`` and ``DataPublicationType``.
     """
     # Compatibility between ICAT versions:
     # - ICAT 5.0.0 added DataPublicationType and Technique.
@@ -104,7 +104,7 @@ def getInvestigationQueries(client, invid):
     """Return the queries to fetch all objects related to an investigation.
 
     .. versionchanged:: 1.0.0
-        Add include clauses for ``investigationFacilityCycles`` and
+        add include clauses for ``investigationFacilityCycles`` and
         ``fundingReferences`` into query for ``Investigation``, add
         include clauses for ``datasetInstruments`` and
         ``datasetTechniques`` into query for ``Dataset``.
@@ -209,7 +209,7 @@ def getOtherQueries(client):
     e.g. not static and not directly related to an investigation.
 
     .. versionchanged:: 1.0.0
-        Drop query for ``DataCollection``, now in a separate function
+        drop query for ``DataCollection``, now in a separate function
         :func:`getDataCollectionQueries`.
     """
     return [

--- a/icat/dumpfile.py
+++ b/icat/dumpfile.py
@@ -94,7 +94,7 @@ class DumpFileReader():
         file name.
 
     .. versionchanged:: 1.0.0
-        The `infile` parameter also accepts a :class:`~pathlib.Path`
+        the `infile` parameter also accepts a :class:`~pathlib.Path`
         object.
     """
 
@@ -194,7 +194,7 @@ class DumpFileWriter():
         :class:`~pathlib.Path` or a :class:`str` with a file name.
 
     .. versionchanged:: 1.0.0
-        The `outfile` parameter also accepts a :class:`~pathlib.Path`
+        the `outfile` parameter also accepts a :class:`~pathlib.Path`
         object.
     """
 

--- a/icat/entities.py
+++ b/icat/entities.py
@@ -13,7 +13,7 @@ ICAT server.  The classes are derived from the abstract base class
 :attr:`icat.entity.Entity.SortAttrs` as appropriate.
 
 .. versionchanged:: 0.17.0
-    Create the entity classes dynamically.
+    create the entity classes dynamically.
 """
 
 import itertools

--- a/icat/entities.py
+++ b/icat/entities.py
@@ -1,14 +1,19 @@
 """Provide the classes corresponding to the entities in the ICAT schema.
 
-Entity classes defined in this module are derived from the abstract
-base class :class:`icat.entity.Entity`.  They override the class
-attributes :attr:`icat.entity.Entity.BeanName`,
+The classes representing the entities in the ICAT schema are
+dynamically created based on the entity information queried from the
+ICAT server.  The classes are derived from the abstract base class
+:class:`icat.entity.Entity`.  They override the class attributes
+:attr:`icat.entity.Entity.BeanName`,
 :attr:`icat.entity.Entity.Constraint`,
 :attr:`icat.entity.Entity.InstAttr`,
 :attr:`icat.entity.Entity.InstRel`,
 :attr:`icat.entity.Entity.InstMRel`,
 :attr:`icat.entity.Entity.AttrAlias`, and
 :attr:`icat.entity.Entity.SortAttrs` as appropriate.
+
+.. versionchanged:: 0.17.0
+    Create the entity classes dynamically.
 """
 
 import itertools

--- a/icat/entity.py
+++ b/icat/entity.py
@@ -56,7 +56,10 @@ class Entity():
 
     @classmethod
     def getInstanceName(cls):
-        """Get the name of this class in the ICAT WSDL"""
+        """Get the name of this class in the ICAT WSDL.
+
+        .. versionadded:: 1.0.0
+        """
         if cls is Entity:
             return 'entityBaseBean'
         else:

--- a/icat/exception.py
+++ b/icat/exception.py
@@ -283,7 +283,7 @@ class QueryNullableOrderWarning(QueryWarning):
     """Warn about using a nullable many to one relation for ordering.
 
     .. versionchanged:: 0.19.0
-        Inherit from :exc:`QueryWarning`.
+        inherit from :exc:`QueryWarning`.
     """
     def __init__(self, attr):
         msg = ("ordering on a nullable many to one relation implicitly "
@@ -337,7 +337,7 @@ class EntityTypeError(_BaseException, TypeError):
     """An invalid entity type has been used.
 
     .. versionchanged:: 0.18.0
-        Inherit from :exc:`TypeError`.
+        inherit from :exc:`TypeError`.
     """
     pass
 

--- a/icat/helper.py
+++ b/icat/helper.py
@@ -62,6 +62,8 @@ class Version(packaging.version.Version):
     True
     >>> version == '5.0.0a1'
     True
+
+    .. versionadded:: 1.0.0
     """
     def __init__(self, version):
         super().__init__(re.sub(r'-SNAPSHOT$', 'a1', version))


### PR DESCRIPTION
Review the documentation and update some outdated parts:

- [x] [Module reference icat.dump_queries](https://python-icat.readthedocs.io/en/1.0.0/dump_queries.html) is completely out of date.
- [x] several ``versionadded`` and ``versionchanged`` hints are missing.
- [x] the tutorial is still based on data from ``icatdump-4.10.yaml``.
- [x] [Module reference icat.entities](https://python-icat.readthedocs.io/en/1.0.0/entities.html#module-icat.entities): should explain that the actual classes are auto-generated based on the entity info fetched from the ICAT server.

Close #126.