### PR TITLE
Return an empty list from getDataPublicationQueries() for old ICAT servers

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -27,6 +27,10 @@ Bug fixes and minor changes
 + `#115`_, `#116`_: Fix the test suite to work if either PyYAML or
   lxml is not available.
 
++ `#128`_: Return an empty list from
+  :func:`icat.dump_queries.getDataPublicationQueries` when talking to
+  an ICAT server older than 5.0.
+
 .. _#111: https://github.com/icatproject/python-icat/issues/111
 .. _#112: https://github.com/icatproject/python-icat/issues/112
 .. _#115: https://github.com/icatproject/python-icat/issues/115
@@ -36,6 +40,7 @@ Bug fixes and minor changes
 .. _#120: https://github.com/icatproject/python-icat/pull/120
 .. _#121: https://github.com/icatproject/python-icat/pull/121
 .. _#124: https://github.com/icatproject/python-icat/pull/124
+.. _#128: https://github.com/icatproject/python-icat/pull/128
 
 
 1.0.0 (2022-12-21)

--- a/icat/dump_queries.py
+++ b/icat/dump_queries.py
@@ -169,20 +169,26 @@ def getDataCollectionQueries(client):
 
 def getDataPublicationQueries(client, pubid):
     """Return the queries to fetch all objects related to a data publication.
+
+    .. versionchanged:: 1.1.0
+        return an empty list if the ICAT server is older than 5.0
+        rather than raising :exc:`~icat.exception.EntityTypeError`.
     """
     # Compatibility between ICAT versions:
     # - ICAT 5.0.0 added DataPublication and related classes.
-    # This is not tested here, we assume the caller to check this.
-    # Otherwise the pubid argument would make no sense.
-    return [
-        Query(client, "DataPublication", order=True,
-              conditions={"id": "= %d" % pubid},
-              includes={"facility", "content", "type.facility", "dates",
-                        "fundingReferences.funding", "relatedItems"}),
-        Query(client, "DataPublicationUser", order=True,
-              conditions={"publication.id": "= %d" % pubid},
-              includes={"publication", "user", "affiliations"}),
-    ]
+    if 'dataPublication' in client.typemap:
+        # ICAT >= 5.0.0
+        return [
+            Query(client, "DataPublication", order=True,
+                  conditions={"id": "= %d" % pubid},
+                  includes={"facility", "content", "type.facility", "dates",
+                            "fundingReferences.funding", "relatedItems"}),
+            Query(client, "DataPublicationUser", order=True,
+                  conditions={"publication.id": "= %d" % pubid},
+                  includes={"publication", "user", "affiliations"}),
+        ]
+    else:
+        return []
 
 def getOtherQueries(client):
     """Return the queries to fetch all other objects,


### PR DESCRIPTION
If talking to an ICAT server older than 5.0 that does not have `DataPublication`, return an empty list from `getDataPublicationQueries()` rather than raising `EntityTypeError`.

Strictly speaking, the previous behavior was not a bug, as it was as intended and documented. But in the meanwhile, I started to question these intentions.