### PR TITLE
Implemented referencing related objects by reference key in XML ICAT data file format

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -2,6 +2,19 @@ Changelog
 =========
 
 
+1.2.0 (not yet released)
+~~~~~~~~~~~~~~~~~~~~~~~~
+
+New features
+------------
+
++ `#122`_, `#133`_: Allow referencing related objects by reference key
+  in object references in XML ICAT data file format.
+
+.. _#122: https://github.com/icatproject/python-icat/issues/122
+.. _#133: https://github.com/icatproject/python-icat/pull/133
+
+
 1.1.0 (2023-06-30)
 ~~~~~~~~~~~~~~~~~~
 

--- a/doc/examples/icatdump-4.10.xml
+++ b/doc/examples/icatdump-4.10.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <icatdata>
 <head>
-  <date>2022-12-21T15:08:20+00:00</date>
+  <date>2023-10-16T14:48:15+00:00</date>
   <service>https://icat.example.com:8181/ICATService/ICAT?wsdl</service>
   <apiversion>4.10.0</apiversion>
   <generator>icatdump (python-icat 1.0.0)</generator>
@@ -431,226 +431,231 @@
     <grouping ref="Grouping_name-ingest"/>
   </rule>
   <rule id="Rule_00000066">
-    <crudFlags>R</crudFlags>
-    <what>Shift</what>
+    <crudFlags>CRU</crudFlags>
+    <what>Sample</what>
     <grouping ref="Grouping_name-ingest"/>
   </rule>
   <rule id="Rule_00000067">
     <crudFlags>R</crudFlags>
-    <what>DataCollection</what>
-    <grouping ref="Grouping_name-rall"/>
+    <what>Shift</what>
+    <grouping ref="Grouping_name-ingest"/>
   </rule>
   <rule id="Rule_00000068">
     <crudFlags>R</crudFlags>
-    <what>DataCollectionDatafile</what>
+    <what>DataCollection</what>
     <grouping ref="Grouping_name-rall"/>
   </rule>
   <rule id="Rule_00000069">
     <crudFlags>R</crudFlags>
-    <what>DataCollectionDataset</what>
+    <what>DataCollectionDatafile</what>
     <grouping ref="Grouping_name-rall"/>
   </rule>
   <rule id="Rule_00000070">
     <crudFlags>R</crudFlags>
-    <what>DataCollectionParameter</what>
+    <what>DataCollectionDataset</what>
     <grouping ref="Grouping_name-rall"/>
   </rule>
   <rule id="Rule_00000071">
     <crudFlags>R</crudFlags>
-    <what>Datafile</what>
+    <what>DataCollectionParameter</what>
     <grouping ref="Grouping_name-rall"/>
   </rule>
   <rule id="Rule_00000072">
     <crudFlags>R</crudFlags>
-    <what>DatafileParameter</what>
+    <what>Datafile</what>
     <grouping ref="Grouping_name-rall"/>
   </rule>
   <rule id="Rule_00000073">
     <crudFlags>R</crudFlags>
-    <what>Dataset</what>
+    <what>DatafileParameter</what>
     <grouping ref="Grouping_name-rall"/>
   </rule>
   <rule id="Rule_00000074">
     <crudFlags>R</crudFlags>
-    <what>DatasetParameter</what>
+    <what>Dataset</what>
     <grouping ref="Grouping_name-rall"/>
   </rule>
   <rule id="Rule_00000075">
     <crudFlags>R</crudFlags>
-    <what>Grouping</what>
+    <what>DatasetParameter</what>
     <grouping ref="Grouping_name-rall"/>
   </rule>
   <rule id="Rule_00000076">
     <crudFlags>R</crudFlags>
-    <what>InstrumentScientist</what>
+    <what>Grouping</what>
     <grouping ref="Grouping_name-rall"/>
   </rule>
   <rule id="Rule_00000077">
     <crudFlags>R</crudFlags>
-    <what>Investigation</what>
+    <what>InstrumentScientist</what>
     <grouping ref="Grouping_name-rall"/>
   </rule>
   <rule id="Rule_00000078">
     <crudFlags>R</crudFlags>
-    <what>InvestigationGroup</what>
+    <what>Investigation</what>
     <grouping ref="Grouping_name-rall"/>
   </rule>
   <rule id="Rule_00000079">
     <crudFlags>R</crudFlags>
-    <what>InvestigationInstrument</what>
+    <what>InvestigationGroup</what>
     <grouping ref="Grouping_name-rall"/>
   </rule>
   <rule id="Rule_00000080">
     <crudFlags>R</crudFlags>
-    <what>InvestigationParameter</what>
+    <what>InvestigationInstrument</what>
     <grouping ref="Grouping_name-rall"/>
   </rule>
   <rule id="Rule_00000081">
     <crudFlags>R</crudFlags>
-    <what>InvestigationUser</what>
+    <what>InvestigationParameter</what>
     <grouping ref="Grouping_name-rall"/>
   </rule>
   <rule id="Rule_00000082">
     <crudFlags>R</crudFlags>
-    <what>Job</what>
+    <what>InvestigationUser</what>
     <grouping ref="Grouping_name-rall"/>
   </rule>
   <rule id="Rule_00000083">
     <crudFlags>R</crudFlags>
-    <what>Keyword</what>
+    <what>Job</what>
     <grouping ref="Grouping_name-rall"/>
   </rule>
   <rule id="Rule_00000084">
     <crudFlags>R</crudFlags>
-    <what>PublicStep</what>
+    <what>Keyword</what>
     <grouping ref="Grouping_name-rall"/>
   </rule>
   <rule id="Rule_00000085">
     <crudFlags>R</crudFlags>
-    <what>Publication</what>
+    <what>PublicStep</what>
     <grouping ref="Grouping_name-rall"/>
   </rule>
   <rule id="Rule_00000086">
     <crudFlags>R</crudFlags>
-    <what>RelatedDatafile</what>
+    <what>Publication</what>
     <grouping ref="Grouping_name-rall"/>
   </rule>
   <rule id="Rule_00000087">
     <crudFlags>R</crudFlags>
-    <what>Rule</what>
+    <what>RelatedDatafile</what>
     <grouping ref="Grouping_name-rall"/>
   </rule>
   <rule id="Rule_00000088">
     <crudFlags>R</crudFlags>
-    <what>Sample</what>
+    <what>Rule</what>
     <grouping ref="Grouping_name-rall"/>
   </rule>
   <rule id="Rule_00000089">
     <crudFlags>R</crudFlags>
-    <what>SampleParameter</what>
+    <what>Sample</what>
     <grouping ref="Grouping_name-rall"/>
   </rule>
   <rule id="Rule_00000090">
     <crudFlags>R</crudFlags>
-    <what>Shift</what>
+    <what>SampleParameter</what>
     <grouping ref="Grouping_name-rall"/>
   </rule>
   <rule id="Rule_00000091">
     <crudFlags>R</crudFlags>
-    <what>Study</what>
+    <what>Shift</what>
     <grouping ref="Grouping_name-rall"/>
   </rule>
   <rule id="Rule_00000092">
     <crudFlags>R</crudFlags>
-    <what>StudyInvestigation</what>
+    <what>Study</what>
     <grouping ref="Grouping_name-rall"/>
   </rule>
   <rule id="Rule_00000093">
     <crudFlags>R</crudFlags>
-    <what>UserGroup</what>
+    <what>StudyInvestigation</what>
     <grouping ref="Grouping_name-rall"/>
   </rule>
   <rule id="Rule_00000094">
+    <crudFlags>R</crudFlags>
+    <what>UserGroup</what>
+    <grouping ref="Grouping_name-rall"/>
+  </rule>
+  <rule id="Rule_00000095">
     <crudFlags>RU</crudFlags>
     <what>Sample</what>
     <grouping ref="Grouping_name-scientific=5Fstaff"/>
   </rule>
-  <rule id="Rule_00000095">
+  <rule id="Rule_00000096">
     <crudFlags>UD</crudFlags>
     <what>SampleType</what>
     <grouping ref="Grouping_name-scientific=5Fstaff"/>
   </rule>
-  <rule id="Rule_00000096">
+  <rule id="Rule_00000097">
     <crudFlags>CRUD</crudFlags>
     <what>FacilityCycle</what>
     <grouping ref="Grouping_name-useroffice"/>
   </rule>
-  <rule id="Rule_00000097">
+  <rule id="Rule_00000098">
     <crudFlags>CRUD</crudFlags>
     <what>Grouping</what>
     <grouping ref="Grouping_name-useroffice"/>
   </rule>
-  <rule id="Rule_00000098">
+  <rule id="Rule_00000099">
     <crudFlags>CRUD</crudFlags>
     <what>InstrumentScientist</what>
     <grouping ref="Grouping_name-useroffice"/>
   </rule>
-  <rule id="Rule_00000099">
+  <rule id="Rule_00000100">
     <crudFlags>CRUD</crudFlags>
     <what>Investigation</what>
     <grouping ref="Grouping_name-useroffice"/>
   </rule>
-  <rule id="Rule_00000100">
+  <rule id="Rule_00000101">
     <crudFlags>CRUD</crudFlags>
     <what>InvestigationGroup</what>
     <grouping ref="Grouping_name-useroffice"/>
   </rule>
-  <rule id="Rule_00000101">
+  <rule id="Rule_00000102">
     <crudFlags>CRUD</crudFlags>
     <what>InvestigationInstrument</what>
     <grouping ref="Grouping_name-useroffice"/>
   </rule>
-  <rule id="Rule_00000102">
+  <rule id="Rule_00000103">
     <crudFlags>CRUD</crudFlags>
     <what>InvestigationParameter</what>
     <grouping ref="Grouping_name-useroffice"/>
   </rule>
-  <rule id="Rule_00000103">
+  <rule id="Rule_00000104">
     <crudFlags>CRUD</crudFlags>
     <what>InvestigationUser</what>
     <grouping ref="Grouping_name-useroffice"/>
   </rule>
-  <rule id="Rule_00000104">
+  <rule id="Rule_00000105">
     <crudFlags>CRUD</crudFlags>
     <what>Keyword</what>
     <grouping ref="Grouping_name-useroffice"/>
   </rule>
-  <rule id="Rule_00000105">
+  <rule id="Rule_00000106">
     <crudFlags>CRUD</crudFlags>
     <what>Publication</what>
     <grouping ref="Grouping_name-useroffice"/>
   </rule>
-  <rule id="Rule_00000106">
+  <rule id="Rule_00000107">
     <crudFlags>CRUD</crudFlags>
     <what>Shift</what>
     <grouping ref="Grouping_name-useroffice"/>
   </rule>
-  <rule id="Rule_00000107">
+  <rule id="Rule_00000108">
     <crudFlags>CRUD</crudFlags>
     <what>Study</what>
     <grouping ref="Grouping_name-useroffice"/>
   </rule>
-  <rule id="Rule_00000108">
+  <rule id="Rule_00000109">
     <crudFlags>CRUD</crudFlags>
     <what>StudyInvestigation</what>
     <grouping ref="Grouping_name-useroffice"/>
   </rule>
-  <rule id="Rule_00000109">
+  <rule id="Rule_00000110">
     <crudFlags>CRUD</crudFlags>
     <what>User</what>
     <grouping ref="Grouping_name-useroffice"/>
   </rule>
-  <rule id="Rule_00000110">
+  <rule id="Rule_00000111">
     <crudFlags>CRUD</crudFlags>
     <what>UserGroup</what>
     <grouping ref="Grouping_name-useroffice"/>

--- a/doc/examples/icatdump-4.10.yaml
+++ b/doc/examples/icatdump-4.10.yaml
@@ -1,5 +1,5 @@
 %YAML 1.1
-# Date: Wed, 21 Dec 2022 15:08:23 +0000
+# Date: Mon, 16 Oct 2023 14:48:11 +0000
 # Service: https://icat.example.com:8181/ICATService/ICAT?wsdl
 # ICAT-API: 4.10.0
 # Generator: icatdump (python-icat 1.0.0)
@@ -421,182 +421,186 @@ rule:
     grouping: Grouping_name-ingest
     what: Investigation
   Rule_00000066:
+    crudFlags: CRU
+    grouping: Grouping_name-ingest
+    what: Sample
+  Rule_00000067:
     crudFlags: R
     grouping: Grouping_name-ingest
     what: Shift
-  Rule_00000067:
-    crudFlags: R
-    grouping: Grouping_name-rall
-    what: DataCollection
   Rule_00000068:
     crudFlags: R
     grouping: Grouping_name-rall
-    what: DataCollectionDatafile
+    what: DataCollection
   Rule_00000069:
     crudFlags: R
     grouping: Grouping_name-rall
-    what: DataCollectionDataset
+    what: DataCollectionDatafile
   Rule_00000070:
     crudFlags: R
     grouping: Grouping_name-rall
-    what: DataCollectionParameter
+    what: DataCollectionDataset
   Rule_00000071:
     crudFlags: R
     grouping: Grouping_name-rall
-    what: Datafile
+    what: DataCollectionParameter
   Rule_00000072:
     crudFlags: R
     grouping: Grouping_name-rall
-    what: DatafileParameter
+    what: Datafile
   Rule_00000073:
     crudFlags: R
     grouping: Grouping_name-rall
-    what: Dataset
+    what: DatafileParameter
   Rule_00000074:
     crudFlags: R
     grouping: Grouping_name-rall
-    what: DatasetParameter
+    what: Dataset
   Rule_00000075:
     crudFlags: R
     grouping: Grouping_name-rall
-    what: Grouping
+    what: DatasetParameter
   Rule_00000076:
     crudFlags: R
     grouping: Grouping_name-rall
-    what: InstrumentScientist
+    what: Grouping
   Rule_00000077:
     crudFlags: R
     grouping: Grouping_name-rall
-    what: Investigation
+    what: InstrumentScientist
   Rule_00000078:
     crudFlags: R
     grouping: Grouping_name-rall
-    what: InvestigationGroup
+    what: Investigation
   Rule_00000079:
     crudFlags: R
     grouping: Grouping_name-rall
-    what: InvestigationInstrument
+    what: InvestigationGroup
   Rule_00000080:
     crudFlags: R
     grouping: Grouping_name-rall
-    what: InvestigationParameter
+    what: InvestigationInstrument
   Rule_00000081:
     crudFlags: R
     grouping: Grouping_name-rall
-    what: InvestigationUser
+    what: InvestigationParameter
   Rule_00000082:
     crudFlags: R
     grouping: Grouping_name-rall
-    what: Job
+    what: InvestigationUser
   Rule_00000083:
     crudFlags: R
     grouping: Grouping_name-rall
-    what: Keyword
+    what: Job
   Rule_00000084:
     crudFlags: R
     grouping: Grouping_name-rall
-    what: PublicStep
+    what: Keyword
   Rule_00000085:
     crudFlags: R
     grouping: Grouping_name-rall
-    what: Publication
+    what: PublicStep
   Rule_00000086:
     crudFlags: R
     grouping: Grouping_name-rall
-    what: RelatedDatafile
+    what: Publication
   Rule_00000087:
     crudFlags: R
     grouping: Grouping_name-rall
-    what: Rule
+    what: RelatedDatafile
   Rule_00000088:
     crudFlags: R
     grouping: Grouping_name-rall
-    what: Sample
+    what: Rule
   Rule_00000089:
     crudFlags: R
     grouping: Grouping_name-rall
-    what: SampleParameter
+    what: Sample
   Rule_00000090:
     crudFlags: R
     grouping: Grouping_name-rall
-    what: Shift
+    what: SampleParameter
   Rule_00000091:
     crudFlags: R
     grouping: Grouping_name-rall
-    what: Study
+    what: Shift
   Rule_00000092:
     crudFlags: R
     grouping: Grouping_name-rall
-    what: StudyInvestigation
+    what: Study
   Rule_00000093:
     crudFlags: R
     grouping: Grouping_name-rall
-    what: UserGroup
+    what: StudyInvestigation
   Rule_00000094:
+    crudFlags: R
+    grouping: Grouping_name-rall
+    what: UserGroup
+  Rule_00000095:
     crudFlags: RU
     grouping: Grouping_name-scientific=5Fstaff
     what: Sample
-  Rule_00000095:
+  Rule_00000096:
     crudFlags: UD
     grouping: Grouping_name-scientific=5Fstaff
     what: SampleType
-  Rule_00000096:
-    crudFlags: CRUD
-    grouping: Grouping_name-useroffice
-    what: FacilityCycle
   Rule_00000097:
     crudFlags: CRUD
     grouping: Grouping_name-useroffice
-    what: Grouping
+    what: FacilityCycle
   Rule_00000098:
     crudFlags: CRUD
     grouping: Grouping_name-useroffice
-    what: InstrumentScientist
+    what: Grouping
   Rule_00000099:
     crudFlags: CRUD
     grouping: Grouping_name-useroffice
-    what: Investigation
+    what: InstrumentScientist
   Rule_00000100:
     crudFlags: CRUD
     grouping: Grouping_name-useroffice
-    what: InvestigationGroup
+    what: Investigation
   Rule_00000101:
     crudFlags: CRUD
     grouping: Grouping_name-useroffice
-    what: InvestigationInstrument
+    what: InvestigationGroup
   Rule_00000102:
     crudFlags: CRUD
     grouping: Grouping_name-useroffice
-    what: InvestigationParameter
+    what: InvestigationInstrument
   Rule_00000103:
     crudFlags: CRUD
     grouping: Grouping_name-useroffice
-    what: InvestigationUser
+    what: InvestigationParameter
   Rule_00000104:
     crudFlags: CRUD
     grouping: Grouping_name-useroffice
-    what: Keyword
+    what: InvestigationUser
   Rule_00000105:
     crudFlags: CRUD
     grouping: Grouping_name-useroffice
-    what: Publication
+    what: Keyword
   Rule_00000106:
     crudFlags: CRUD
     grouping: Grouping_name-useroffice
-    what: Shift
+    what: Publication
   Rule_00000107:
     crudFlags: CRUD
     grouping: Grouping_name-useroffice
-    what: Study
+    what: Shift
   Rule_00000108:
     crudFlags: CRUD
     grouping: Grouping_name-useroffice
-    what: StudyInvestigation
+    what: Study
   Rule_00000109:
     crudFlags: CRUD
     grouping: Grouping_name-useroffice
-    what: User
+    what: StudyInvestigation
   Rule_00000110:
+    crudFlags: CRUD
+    grouping: Grouping_name-useroffice
+    what: User
+  Rule_00000111:
     crudFlags: CRUD
     grouping: Grouping_name-useroffice
     what: UserGroup

--- a/doc/examples/icatdump-4.4.xml
+++ b/doc/examples/icatdump-4.4.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <icatdata>
 <head>
-  <date>2022-12-21T14:56:55+00:00</date>
+  <date>2023-10-16T14:20:21+00:00</date>
   <service>https://icat.example.com:8181/ICATService/ICAT?wsdl</service>
   <apiversion>4.4.0</apiversion>
   <generator>icatdump (python-icat 1.0.0)</generator>
@@ -403,226 +403,231 @@
     <grouping ref="Grouping_name-ingest"/>
   </rule>
   <rule id="Rule_00000066">
-    <crudFlags>R</crudFlags>
-    <what>Shift</what>
+    <crudFlags>CRU</crudFlags>
+    <what>Sample</what>
     <grouping ref="Grouping_name-ingest"/>
   </rule>
   <rule id="Rule_00000067">
     <crudFlags>R</crudFlags>
-    <what>DataCollection</what>
-    <grouping ref="Grouping_name-rall"/>
+    <what>Shift</what>
+    <grouping ref="Grouping_name-ingest"/>
   </rule>
   <rule id="Rule_00000068">
     <crudFlags>R</crudFlags>
-    <what>DataCollectionDatafile</what>
+    <what>DataCollection</what>
     <grouping ref="Grouping_name-rall"/>
   </rule>
   <rule id="Rule_00000069">
     <crudFlags>R</crudFlags>
-    <what>DataCollectionDataset</what>
+    <what>DataCollectionDatafile</what>
     <grouping ref="Grouping_name-rall"/>
   </rule>
   <rule id="Rule_00000070">
     <crudFlags>R</crudFlags>
-    <what>DataCollectionParameter</what>
+    <what>DataCollectionDataset</what>
     <grouping ref="Grouping_name-rall"/>
   </rule>
   <rule id="Rule_00000071">
     <crudFlags>R</crudFlags>
-    <what>Datafile</what>
+    <what>DataCollectionParameter</what>
     <grouping ref="Grouping_name-rall"/>
   </rule>
   <rule id="Rule_00000072">
     <crudFlags>R</crudFlags>
-    <what>DatafileParameter</what>
+    <what>Datafile</what>
     <grouping ref="Grouping_name-rall"/>
   </rule>
   <rule id="Rule_00000073">
     <crudFlags>R</crudFlags>
-    <what>Dataset</what>
+    <what>DatafileParameter</what>
     <grouping ref="Grouping_name-rall"/>
   </rule>
   <rule id="Rule_00000074">
     <crudFlags>R</crudFlags>
-    <what>DatasetParameter</what>
+    <what>Dataset</what>
     <grouping ref="Grouping_name-rall"/>
   </rule>
   <rule id="Rule_00000075">
     <crudFlags>R</crudFlags>
-    <what>Grouping</what>
+    <what>DatasetParameter</what>
     <grouping ref="Grouping_name-rall"/>
   </rule>
   <rule id="Rule_00000076">
     <crudFlags>R</crudFlags>
-    <what>InstrumentScientist</what>
+    <what>Grouping</what>
     <grouping ref="Grouping_name-rall"/>
   </rule>
   <rule id="Rule_00000077">
     <crudFlags>R</crudFlags>
-    <what>Investigation</what>
+    <what>InstrumentScientist</what>
     <grouping ref="Grouping_name-rall"/>
   </rule>
   <rule id="Rule_00000078">
     <crudFlags>R</crudFlags>
-    <what>InvestigationGroup</what>
+    <what>Investigation</what>
     <grouping ref="Grouping_name-rall"/>
   </rule>
   <rule id="Rule_00000079">
     <crudFlags>R</crudFlags>
-    <what>InvestigationInstrument</what>
+    <what>InvestigationGroup</what>
     <grouping ref="Grouping_name-rall"/>
   </rule>
   <rule id="Rule_00000080">
     <crudFlags>R</crudFlags>
-    <what>InvestigationParameter</what>
+    <what>InvestigationInstrument</what>
     <grouping ref="Grouping_name-rall"/>
   </rule>
   <rule id="Rule_00000081">
     <crudFlags>R</crudFlags>
-    <what>InvestigationUser</what>
+    <what>InvestigationParameter</what>
     <grouping ref="Grouping_name-rall"/>
   </rule>
   <rule id="Rule_00000082">
     <crudFlags>R</crudFlags>
-    <what>Job</what>
+    <what>InvestigationUser</what>
     <grouping ref="Grouping_name-rall"/>
   </rule>
   <rule id="Rule_00000083">
     <crudFlags>R</crudFlags>
-    <what>Keyword</what>
+    <what>Job</what>
     <grouping ref="Grouping_name-rall"/>
   </rule>
   <rule id="Rule_00000084">
     <crudFlags>R</crudFlags>
-    <what>PublicStep</what>
+    <what>Keyword</what>
     <grouping ref="Grouping_name-rall"/>
   </rule>
   <rule id="Rule_00000085">
     <crudFlags>R</crudFlags>
-    <what>Publication</what>
+    <what>PublicStep</what>
     <grouping ref="Grouping_name-rall"/>
   </rule>
   <rule id="Rule_00000086">
     <crudFlags>R</crudFlags>
-    <what>RelatedDatafile</what>
+    <what>Publication</what>
     <grouping ref="Grouping_name-rall"/>
   </rule>
   <rule id="Rule_00000087">
     <crudFlags>R</crudFlags>
-    <what>Rule</what>
+    <what>RelatedDatafile</what>
     <grouping ref="Grouping_name-rall"/>
   </rule>
   <rule id="Rule_00000088">
     <crudFlags>R</crudFlags>
-    <what>Sample</what>
+    <what>Rule</what>
     <grouping ref="Grouping_name-rall"/>
   </rule>
   <rule id="Rule_00000089">
     <crudFlags>R</crudFlags>
-    <what>SampleParameter</what>
+    <what>Sample</what>
     <grouping ref="Grouping_name-rall"/>
   </rule>
   <rule id="Rule_00000090">
     <crudFlags>R</crudFlags>
-    <what>Shift</what>
+    <what>SampleParameter</what>
     <grouping ref="Grouping_name-rall"/>
   </rule>
   <rule id="Rule_00000091">
     <crudFlags>R</crudFlags>
-    <what>Study</what>
+    <what>Shift</what>
     <grouping ref="Grouping_name-rall"/>
   </rule>
   <rule id="Rule_00000092">
     <crudFlags>R</crudFlags>
-    <what>StudyInvestigation</what>
+    <what>Study</what>
     <grouping ref="Grouping_name-rall"/>
   </rule>
   <rule id="Rule_00000093">
     <crudFlags>R</crudFlags>
-    <what>UserGroup</what>
+    <what>StudyInvestigation</what>
     <grouping ref="Grouping_name-rall"/>
   </rule>
   <rule id="Rule_00000094">
+    <crudFlags>R</crudFlags>
+    <what>UserGroup</what>
+    <grouping ref="Grouping_name-rall"/>
+  </rule>
+  <rule id="Rule_00000095">
     <crudFlags>RU</crudFlags>
     <what>Sample</what>
     <grouping ref="Grouping_name-scientific=5Fstaff"/>
   </rule>
-  <rule id="Rule_00000095">
+  <rule id="Rule_00000096">
     <crudFlags>UD</crudFlags>
     <what>SampleType</what>
     <grouping ref="Grouping_name-scientific=5Fstaff"/>
   </rule>
-  <rule id="Rule_00000096">
+  <rule id="Rule_00000097">
     <crudFlags>CRUD</crudFlags>
     <what>FacilityCycle</what>
     <grouping ref="Grouping_name-useroffice"/>
   </rule>
-  <rule id="Rule_00000097">
+  <rule id="Rule_00000098">
     <crudFlags>CRUD</crudFlags>
     <what>Grouping</what>
     <grouping ref="Grouping_name-useroffice"/>
   </rule>
-  <rule id="Rule_00000098">
+  <rule id="Rule_00000099">
     <crudFlags>CRUD</crudFlags>
     <what>InstrumentScientist</what>
     <grouping ref="Grouping_name-useroffice"/>
   </rule>
-  <rule id="Rule_00000099">
+  <rule id="Rule_00000100">
     <crudFlags>CRUD</crudFlags>
     <what>Investigation</what>
     <grouping ref="Grouping_name-useroffice"/>
   </rule>
-  <rule id="Rule_00000100">
+  <rule id="Rule_00000101">
     <crudFlags>CRUD</crudFlags>
     <what>InvestigationGroup</what>
     <grouping ref="Grouping_name-useroffice"/>
   </rule>
-  <rule id="Rule_00000101">
+  <rule id="Rule_00000102">
     <crudFlags>CRUD</crudFlags>
     <what>InvestigationInstrument</what>
     <grouping ref="Grouping_name-useroffice"/>
   </rule>
-  <rule id="Rule_00000102">
+  <rule id="Rule_00000103">
     <crudFlags>CRUD</crudFlags>
     <what>InvestigationParameter</what>
     <grouping ref="Grouping_name-useroffice"/>
   </rule>
-  <rule id="Rule_00000103">
+  <rule id="Rule_00000104">
     <crudFlags>CRUD</crudFlags>
     <what>InvestigationUser</what>
     <grouping ref="Grouping_name-useroffice"/>
   </rule>
-  <rule id="Rule_00000104">
+  <rule id="Rule_00000105">
     <crudFlags>CRUD</crudFlags>
     <what>Keyword</what>
     <grouping ref="Grouping_name-useroffice"/>
   </rule>
-  <rule id="Rule_00000105">
+  <rule id="Rule_00000106">
     <crudFlags>CRUD</crudFlags>
     <what>Publication</what>
     <grouping ref="Grouping_name-useroffice"/>
   </rule>
-  <rule id="Rule_00000106">
+  <rule id="Rule_00000107">
     <crudFlags>CRUD</crudFlags>
     <what>Shift</what>
     <grouping ref="Grouping_name-useroffice"/>
   </rule>
-  <rule id="Rule_00000107">
+  <rule id="Rule_00000108">
     <crudFlags>CRUD</crudFlags>
     <what>Study</what>
     <grouping ref="Grouping_name-useroffice"/>
   </rule>
-  <rule id="Rule_00000108">
+  <rule id="Rule_00000109">
     <crudFlags>CRUD</crudFlags>
     <what>StudyInvestigation</what>
     <grouping ref="Grouping_name-useroffice"/>
   </rule>
-  <rule id="Rule_00000109">
+  <rule id="Rule_00000110">
     <crudFlags>CRUD</crudFlags>
     <what>User</what>
     <grouping ref="Grouping_name-useroffice"/>
   </rule>
-  <rule id="Rule_00000110">
+  <rule id="Rule_00000111">
     <crudFlags>CRUD</crudFlags>
     <what>UserGroup</what>
     <grouping ref="Grouping_name-useroffice"/>

--- a/doc/examples/icatdump-4.4.yaml
+++ b/doc/examples/icatdump-4.4.yaml
@@ -1,5 +1,5 @@
 %YAML 1.1
-# Date: Wed, 21 Dec 2022 14:57:08 +0000
+# Date: Mon, 16 Oct 2023 14:20:09 +0000
 # Service: https://icat.example.com:8181/ICATService/ICAT?wsdl
 # ICAT-API: 4.4.0
 # Generator: icatdump (python-icat 1.0.0)
@@ -421,182 +421,186 @@ rule:
     grouping: Grouping_name-ingest
     what: Investigation
   Rule_00000066:
+    crudFlags: CRU
+    grouping: Grouping_name-ingest
+    what: Sample
+  Rule_00000067:
     crudFlags: R
     grouping: Grouping_name-ingest
     what: Shift
-  Rule_00000067:
-    crudFlags: R
-    grouping: Grouping_name-rall
-    what: DataCollection
   Rule_00000068:
     crudFlags: R
     grouping: Grouping_name-rall
-    what: DataCollectionDatafile
+    what: DataCollection
   Rule_00000069:
     crudFlags: R
     grouping: Grouping_name-rall
-    what: DataCollectionDataset
+    what: DataCollectionDatafile
   Rule_00000070:
     crudFlags: R
     grouping: Grouping_name-rall
-    what: DataCollectionParameter
+    what: DataCollectionDataset
   Rule_00000071:
     crudFlags: R
     grouping: Grouping_name-rall
-    what: Datafile
+    what: DataCollectionParameter
   Rule_00000072:
     crudFlags: R
     grouping: Grouping_name-rall
-    what: DatafileParameter
+    what: Datafile
   Rule_00000073:
     crudFlags: R
     grouping: Grouping_name-rall
-    what: Dataset
+    what: DatafileParameter
   Rule_00000074:
     crudFlags: R
     grouping: Grouping_name-rall
-    what: DatasetParameter
+    what: Dataset
   Rule_00000075:
     crudFlags: R
     grouping: Grouping_name-rall
-    what: Grouping
+    what: DatasetParameter
   Rule_00000076:
     crudFlags: R
     grouping: Grouping_name-rall
-    what: InstrumentScientist
+    what: Grouping
   Rule_00000077:
     crudFlags: R
     grouping: Grouping_name-rall
-    what: Investigation
+    what: InstrumentScientist
   Rule_00000078:
     crudFlags: R
     grouping: Grouping_name-rall
-    what: InvestigationGroup
+    what: Investigation
   Rule_00000079:
     crudFlags: R
     grouping: Grouping_name-rall
-    what: InvestigationInstrument
+    what: InvestigationGroup
   Rule_00000080:
     crudFlags: R
     grouping: Grouping_name-rall
-    what: InvestigationParameter
+    what: InvestigationInstrument
   Rule_00000081:
     crudFlags: R
     grouping: Grouping_name-rall
-    what: InvestigationUser
+    what: InvestigationParameter
   Rule_00000082:
     crudFlags: R
     grouping: Grouping_name-rall
-    what: Job
+    what: InvestigationUser
   Rule_00000083:
     crudFlags: R
     grouping: Grouping_name-rall
-    what: Keyword
+    what: Job
   Rule_00000084:
     crudFlags: R
     grouping: Grouping_name-rall
-    what: PublicStep
+    what: Keyword
   Rule_00000085:
     crudFlags: R
     grouping: Grouping_name-rall
-    what: Publication
+    what: PublicStep
   Rule_00000086:
     crudFlags: R
     grouping: Grouping_name-rall
-    what: RelatedDatafile
+    what: Publication
   Rule_00000087:
     crudFlags: R
     grouping: Grouping_name-rall
-    what: Rule
+    what: RelatedDatafile
   Rule_00000088:
     crudFlags: R
     grouping: Grouping_name-rall
-    what: Sample
+    what: Rule
   Rule_00000089:
     crudFlags: R
     grouping: Grouping_name-rall
-    what: SampleParameter
+    what: Sample
   Rule_00000090:
     crudFlags: R
     grouping: Grouping_name-rall
-    what: Shift
+    what: SampleParameter
   Rule_00000091:
     crudFlags: R
     grouping: Grouping_name-rall
-    what: Study
+    what: Shift
   Rule_00000092:
     crudFlags: R
     grouping: Grouping_name-rall
-    what: StudyInvestigation
+    what: Study
   Rule_00000093:
     crudFlags: R
     grouping: Grouping_name-rall
-    what: UserGroup
+    what: StudyInvestigation
   Rule_00000094:
+    crudFlags: R
+    grouping: Grouping_name-rall
+    what: UserGroup
+  Rule_00000095:
     crudFlags: RU
     grouping: Grouping_name-scientific=5Fstaff
     what: Sample
-  Rule_00000095:
+  Rule_00000096:
     crudFlags: UD
     grouping: Grouping_name-scientific=5Fstaff
     what: SampleType
-  Rule_00000096:
-    crudFlags: CRUD
-    grouping: Grouping_name-useroffice
-    what: FacilityCycle
   Rule_00000097:
     crudFlags: CRUD
     grouping: Grouping_name-useroffice
-    what: Grouping
+    what: FacilityCycle
   Rule_00000098:
     crudFlags: CRUD
     grouping: Grouping_name-useroffice
-    what: InstrumentScientist
+    what: Grouping
   Rule_00000099:
     crudFlags: CRUD
     grouping: Grouping_name-useroffice
-    what: Investigation
+    what: InstrumentScientist
   Rule_00000100:
     crudFlags: CRUD
     grouping: Grouping_name-useroffice
-    what: InvestigationGroup
+    what: Investigation
   Rule_00000101:
     crudFlags: CRUD
     grouping: Grouping_name-useroffice
-    what: InvestigationInstrument
+    what: InvestigationGroup
   Rule_00000102:
     crudFlags: CRUD
     grouping: Grouping_name-useroffice
-    what: InvestigationParameter
+    what: InvestigationInstrument
   Rule_00000103:
     crudFlags: CRUD
     grouping: Grouping_name-useroffice
-    what: InvestigationUser
+    what: InvestigationParameter
   Rule_00000104:
     crudFlags: CRUD
     grouping: Grouping_name-useroffice
-    what: Keyword
+    what: InvestigationUser
   Rule_00000105:
     crudFlags: CRUD
     grouping: Grouping_name-useroffice
-    what: Publication
+    what: Keyword
   Rule_00000106:
     crudFlags: CRUD
     grouping: Grouping_name-useroffice
-    what: Shift
+    what: Publication
   Rule_00000107:
     crudFlags: CRUD
     grouping: Grouping_name-useroffice
-    what: Study
+    what: Shift
   Rule_00000108:
     crudFlags: CRUD
     grouping: Grouping_name-useroffice
-    what: StudyInvestigation
+    what: Study
   Rule_00000109:
     crudFlags: CRUD
     grouping: Grouping_name-useroffice
-    what: User
+    what: StudyInvestigation
   Rule_00000110:
+    crudFlags: CRUD
+    grouping: Grouping_name-useroffice
+    what: User
+  Rule_00000111:
     crudFlags: CRUD
     grouping: Grouping_name-useroffice
     what: UserGroup

--- a/doc/examples/icatdump-4.7.xml
+++ b/doc/examples/icatdump-4.7.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <icatdata>
 <head>
-  <date>2022-12-21T15:02:37+00:00</date>
+  <date>2023-10-16T14:34:50+00:00</date>
   <service>https://icat.example.com:8181/ICATService/ICAT?wsdl</service>
   <apiversion>4.7.0</apiversion>
   <generator>icatdump (python-icat 1.0.0)</generator>
@@ -414,226 +414,231 @@
     <grouping ref="Grouping_name-ingest"/>
   </rule>
   <rule id="Rule_00000066">
-    <crudFlags>R</crudFlags>
-    <what>Shift</what>
+    <crudFlags>CRU</crudFlags>
+    <what>Sample</what>
     <grouping ref="Grouping_name-ingest"/>
   </rule>
   <rule id="Rule_00000067">
     <crudFlags>R</crudFlags>
-    <what>DataCollection</what>
-    <grouping ref="Grouping_name-rall"/>
+    <what>Shift</what>
+    <grouping ref="Grouping_name-ingest"/>
   </rule>
   <rule id="Rule_00000068">
     <crudFlags>R</crudFlags>
-    <what>DataCollectionDatafile</what>
+    <what>DataCollection</what>
     <grouping ref="Grouping_name-rall"/>
   </rule>
   <rule id="Rule_00000069">
     <crudFlags>R</crudFlags>
-    <what>DataCollectionDataset</what>
+    <what>DataCollectionDatafile</what>
     <grouping ref="Grouping_name-rall"/>
   </rule>
   <rule id="Rule_00000070">
     <crudFlags>R</crudFlags>
-    <what>DataCollectionParameter</what>
+    <what>DataCollectionDataset</what>
     <grouping ref="Grouping_name-rall"/>
   </rule>
   <rule id="Rule_00000071">
     <crudFlags>R</crudFlags>
-    <what>Datafile</what>
+    <what>DataCollectionParameter</what>
     <grouping ref="Grouping_name-rall"/>
   </rule>
   <rule id="Rule_00000072">
     <crudFlags>R</crudFlags>
-    <what>DatafileParameter</what>
+    <what>Datafile</what>
     <grouping ref="Grouping_name-rall"/>
   </rule>
   <rule id="Rule_00000073">
     <crudFlags>R</crudFlags>
-    <what>Dataset</what>
+    <what>DatafileParameter</what>
     <grouping ref="Grouping_name-rall"/>
   </rule>
   <rule id="Rule_00000074">
     <crudFlags>R</crudFlags>
-    <what>DatasetParameter</what>
+    <what>Dataset</what>
     <grouping ref="Grouping_name-rall"/>
   </rule>
   <rule id="Rule_00000075">
     <crudFlags>R</crudFlags>
-    <what>Grouping</what>
+    <what>DatasetParameter</what>
     <grouping ref="Grouping_name-rall"/>
   </rule>
   <rule id="Rule_00000076">
     <crudFlags>R</crudFlags>
-    <what>InstrumentScientist</what>
+    <what>Grouping</what>
     <grouping ref="Grouping_name-rall"/>
   </rule>
   <rule id="Rule_00000077">
     <crudFlags>R</crudFlags>
-    <what>Investigation</what>
+    <what>InstrumentScientist</what>
     <grouping ref="Grouping_name-rall"/>
   </rule>
   <rule id="Rule_00000078">
     <crudFlags>R</crudFlags>
-    <what>InvestigationGroup</what>
+    <what>Investigation</what>
     <grouping ref="Grouping_name-rall"/>
   </rule>
   <rule id="Rule_00000079">
     <crudFlags>R</crudFlags>
-    <what>InvestigationInstrument</what>
+    <what>InvestigationGroup</what>
     <grouping ref="Grouping_name-rall"/>
   </rule>
   <rule id="Rule_00000080">
     <crudFlags>R</crudFlags>
-    <what>InvestigationParameter</what>
+    <what>InvestigationInstrument</what>
     <grouping ref="Grouping_name-rall"/>
   </rule>
   <rule id="Rule_00000081">
     <crudFlags>R</crudFlags>
-    <what>InvestigationUser</what>
+    <what>InvestigationParameter</what>
     <grouping ref="Grouping_name-rall"/>
   </rule>
   <rule id="Rule_00000082">
     <crudFlags>R</crudFlags>
-    <what>Job</what>
+    <what>InvestigationUser</what>
     <grouping ref="Grouping_name-rall"/>
   </rule>
   <rule id="Rule_00000083">
     <crudFlags>R</crudFlags>
-    <what>Keyword</what>
+    <what>Job</what>
     <grouping ref="Grouping_name-rall"/>
   </rule>
   <rule id="Rule_00000084">
     <crudFlags>R</crudFlags>
-    <what>PublicStep</what>
+    <what>Keyword</what>
     <grouping ref="Grouping_name-rall"/>
   </rule>
   <rule id="Rule_00000085">
     <crudFlags>R</crudFlags>
-    <what>Publication</what>
+    <what>PublicStep</what>
     <grouping ref="Grouping_name-rall"/>
   </rule>
   <rule id="Rule_00000086">
     <crudFlags>R</crudFlags>
-    <what>RelatedDatafile</what>
+    <what>Publication</what>
     <grouping ref="Grouping_name-rall"/>
   </rule>
   <rule id="Rule_00000087">
     <crudFlags>R</crudFlags>
-    <what>Rule</what>
+    <what>RelatedDatafile</what>
     <grouping ref="Grouping_name-rall"/>
   </rule>
   <rule id="Rule_00000088">
     <crudFlags>R</crudFlags>
-    <what>Sample</what>
+    <what>Rule</what>
     <grouping ref="Grouping_name-rall"/>
   </rule>
   <rule id="Rule_00000089">
     <crudFlags>R</crudFlags>
-    <what>SampleParameter</what>
+    <what>Sample</what>
     <grouping ref="Grouping_name-rall"/>
   </rule>
   <rule id="Rule_00000090">
     <crudFlags>R</crudFlags>
-    <what>Shift</what>
+    <what>SampleParameter</what>
     <grouping ref="Grouping_name-rall"/>
   </rule>
   <rule id="Rule_00000091">
     <crudFlags>R</crudFlags>
-    <what>Study</what>
+    <what>Shift</what>
     <grouping ref="Grouping_name-rall"/>
   </rule>
   <rule id="Rule_00000092">
     <crudFlags>R</crudFlags>
-    <what>StudyInvestigation</what>
+    <what>Study</what>
     <grouping ref="Grouping_name-rall"/>
   </rule>
   <rule id="Rule_00000093">
     <crudFlags>R</crudFlags>
-    <what>UserGroup</what>
+    <what>StudyInvestigation</what>
     <grouping ref="Grouping_name-rall"/>
   </rule>
   <rule id="Rule_00000094">
+    <crudFlags>R</crudFlags>
+    <what>UserGroup</what>
+    <grouping ref="Grouping_name-rall"/>
+  </rule>
+  <rule id="Rule_00000095">
     <crudFlags>RU</crudFlags>
     <what>Sample</what>
     <grouping ref="Grouping_name-scientific=5Fstaff"/>
   </rule>
-  <rule id="Rule_00000095">
+  <rule id="Rule_00000096">
     <crudFlags>UD</crudFlags>
     <what>SampleType</what>
     <grouping ref="Grouping_name-scientific=5Fstaff"/>
   </rule>
-  <rule id="Rule_00000096">
+  <rule id="Rule_00000097">
     <crudFlags>CRUD</crudFlags>
     <what>FacilityCycle</what>
     <grouping ref="Grouping_name-useroffice"/>
   </rule>
-  <rule id="Rule_00000097">
+  <rule id="Rule_00000098">
     <crudFlags>CRUD</crudFlags>
     <what>Grouping</what>
     <grouping ref="Grouping_name-useroffice"/>
   </rule>
-  <rule id="Rule_00000098">
+  <rule id="Rule_00000099">
     <crudFlags>CRUD</crudFlags>
     <what>InstrumentScientist</what>
     <grouping ref="Grouping_name-useroffice"/>
   </rule>
-  <rule id="Rule_00000099">
+  <rule id="Rule_00000100">
     <crudFlags>CRUD</crudFlags>
     <what>Investigation</what>
     <grouping ref="Grouping_name-useroffice"/>
   </rule>
-  <rule id="Rule_00000100">
+  <rule id="Rule_00000101">
     <crudFlags>CRUD</crudFlags>
     <what>InvestigationGroup</what>
     <grouping ref="Grouping_name-useroffice"/>
   </rule>
-  <rule id="Rule_00000101">
+  <rule id="Rule_00000102">
     <crudFlags>CRUD</crudFlags>
     <what>InvestigationInstrument</what>
     <grouping ref="Grouping_name-useroffice"/>
   </rule>
-  <rule id="Rule_00000102">
+  <rule id="Rule_00000103">
     <crudFlags>CRUD</crudFlags>
     <what>InvestigationParameter</what>
     <grouping ref="Grouping_name-useroffice"/>
   </rule>
-  <rule id="Rule_00000103">
+  <rule id="Rule_00000104">
     <crudFlags>CRUD</crudFlags>
     <what>InvestigationUser</what>
     <grouping ref="Grouping_name-useroffice"/>
   </rule>
-  <rule id="Rule_00000104">
+  <rule id="Rule_00000105">
     <crudFlags>CRUD</crudFlags>
     <what>Keyword</what>
     <grouping ref="Grouping_name-useroffice"/>
   </rule>
-  <rule id="Rule_00000105">
+  <rule id="Rule_00000106">
     <crudFlags>CRUD</crudFlags>
     <what>Publication</what>
     <grouping ref="Grouping_name-useroffice"/>
   </rule>
-  <rule id="Rule_00000106">
+  <rule id="Rule_00000107">
     <crudFlags>CRUD</crudFlags>
     <what>Shift</what>
     <grouping ref="Grouping_name-useroffice"/>
   </rule>
-  <rule id="Rule_00000107">
+  <rule id="Rule_00000108">
     <crudFlags>CRUD</crudFlags>
     <what>Study</what>
     <grouping ref="Grouping_name-useroffice"/>
   </rule>
-  <rule id="Rule_00000108">
+  <rule id="Rule_00000109">
     <crudFlags>CRUD</crudFlags>
     <what>StudyInvestigation</what>
     <grouping ref="Grouping_name-useroffice"/>
   </rule>
-  <rule id="Rule_00000109">
+  <rule id="Rule_00000110">
     <crudFlags>CRUD</crudFlags>
     <what>User</what>
     <grouping ref="Grouping_name-useroffice"/>
   </rule>
-  <rule id="Rule_00000110">
+  <rule id="Rule_00000111">
     <crudFlags>CRUD</crudFlags>
     <what>UserGroup</what>
     <grouping ref="Grouping_name-useroffice"/>

--- a/doc/examples/icatdump-4.7.yaml
+++ b/doc/examples/icatdump-4.7.yaml
@@ -1,5 +1,5 @@
 %YAML 1.1
-# Date: Wed, 21 Dec 2022 15:02:40 +0000
+# Date: Mon, 16 Oct 2023 14:34:39 +0000
 # Service: https://icat.example.com:8181/ICATService/ICAT?wsdl
 # ICAT-API: 4.7.0
 # Generator: icatdump (python-icat 1.0.0)
@@ -421,182 +421,186 @@ rule:
     grouping: Grouping_name-ingest
     what: Investigation
   Rule_00000066:
+    crudFlags: CRU
+    grouping: Grouping_name-ingest
+    what: Sample
+  Rule_00000067:
     crudFlags: R
     grouping: Grouping_name-ingest
     what: Shift
-  Rule_00000067:
-    crudFlags: R
-    grouping: Grouping_name-rall
-    what: DataCollection
   Rule_00000068:
     crudFlags: R
     grouping: Grouping_name-rall
-    what: DataCollectionDatafile
+    what: DataCollection
   Rule_00000069:
     crudFlags: R
     grouping: Grouping_name-rall
-    what: DataCollectionDataset
+    what: DataCollectionDatafile
   Rule_00000070:
     crudFlags: R
     grouping: Grouping_name-rall
-    what: DataCollectionParameter
+    what: DataCollectionDataset
   Rule_00000071:
     crudFlags: R
     grouping: Grouping_name-rall
-    what: Datafile
+    what: DataCollectionParameter
   Rule_00000072:
     crudFlags: R
     grouping: Grouping_name-rall
-    what: DatafileParameter
+    what: Datafile
   Rule_00000073:
     crudFlags: R
     grouping: Grouping_name-rall
-    what: Dataset
+    what: DatafileParameter
   Rule_00000074:
     crudFlags: R
     grouping: Grouping_name-rall
-    what: DatasetParameter
+    what: Dataset
   Rule_00000075:
     crudFlags: R
     grouping: Grouping_name-rall
-    what: Grouping
+    what: DatasetParameter
   Rule_00000076:
     crudFlags: R
     grouping: Grouping_name-rall
-    what: InstrumentScientist
+    what: Grouping
   Rule_00000077:
     crudFlags: R
     grouping: Grouping_name-rall
-    what: Investigation
+    what: InstrumentScientist
   Rule_00000078:
     crudFlags: R
     grouping: Grouping_name-rall
-    what: InvestigationGroup
+    what: Investigation
   Rule_00000079:
     crudFlags: R
     grouping: Grouping_name-rall
-    what: InvestigationInstrument
+    what: InvestigationGroup
   Rule_00000080:
     crudFlags: R
     grouping: Grouping_name-rall
-    what: InvestigationParameter
+    what: InvestigationInstrument
   Rule_00000081:
     crudFlags: R
     grouping: Grouping_name-rall
-    what: InvestigationUser
+    what: InvestigationParameter
   Rule_00000082:
     crudFlags: R
     grouping: Grouping_name-rall
-    what: Job
+    what: InvestigationUser
   Rule_00000083:
     crudFlags: R
     grouping: Grouping_name-rall
-    what: Keyword
+    what: Job
   Rule_00000084:
     crudFlags: R
     grouping: Grouping_name-rall
-    what: PublicStep
+    what: Keyword
   Rule_00000085:
     crudFlags: R
     grouping: Grouping_name-rall
-    what: Publication
+    what: PublicStep
   Rule_00000086:
     crudFlags: R
     grouping: Grouping_name-rall
-    what: RelatedDatafile
+    what: Publication
   Rule_00000087:
     crudFlags: R
     grouping: Grouping_name-rall
-    what: Rule
+    what: RelatedDatafile
   Rule_00000088:
     crudFlags: R
     grouping: Grouping_name-rall
-    what: Sample
+    what: Rule
   Rule_00000089:
     crudFlags: R
     grouping: Grouping_name-rall
-    what: SampleParameter
+    what: Sample
   Rule_00000090:
     crudFlags: R
     grouping: Grouping_name-rall
-    what: Shift
+    what: SampleParameter
   Rule_00000091:
     crudFlags: R
     grouping: Grouping_name-rall
-    what: Study
+    what: Shift
   Rule_00000092:
     crudFlags: R
     grouping: Grouping_name-rall
-    what: StudyInvestigation
+    what: Study
   Rule_00000093:
     crudFlags: R
     grouping: Grouping_name-rall
-    what: UserGroup
+    what: StudyInvestigation
   Rule_00000094:
+    crudFlags: R
+    grouping: Grouping_name-rall
+    what: UserGroup
+  Rule_00000095:
     crudFlags: RU
     grouping: Grouping_name-scientific=5Fstaff
     what: Sample
-  Rule_00000095:
+  Rule_00000096:
     crudFlags: UD
     grouping: Grouping_name-scientific=5Fstaff
     what: SampleType
-  Rule_00000096:
-    crudFlags: CRUD
-    grouping: Grouping_name-useroffice
-    what: FacilityCycle
   Rule_00000097:
     crudFlags: CRUD
     grouping: Grouping_name-useroffice
-    what: Grouping
+    what: FacilityCycle
   Rule_00000098:
     crudFlags: CRUD
     grouping: Grouping_name-useroffice
-    what: InstrumentScientist
+    what: Grouping
   Rule_00000099:
     crudFlags: CRUD
     grouping: Grouping_name-useroffice
-    what: Investigation
+    what: InstrumentScientist
   Rule_00000100:
     crudFlags: CRUD
     grouping: Grouping_name-useroffice
-    what: InvestigationGroup
+    what: Investigation
   Rule_00000101:
     crudFlags: CRUD
     grouping: Grouping_name-useroffice
-    what: InvestigationInstrument
+    what: InvestigationGroup
   Rule_00000102:
     crudFlags: CRUD
     grouping: Grouping_name-useroffice
-    what: InvestigationParameter
+    what: InvestigationInstrument
   Rule_00000103:
     crudFlags: CRUD
     grouping: Grouping_name-useroffice
-    what: InvestigationUser
+    what: InvestigationParameter
   Rule_00000104:
     crudFlags: CRUD
     grouping: Grouping_name-useroffice
-    what: Keyword
+    what: InvestigationUser
   Rule_00000105:
     crudFlags: CRUD
     grouping: Grouping_name-useroffice
-    what: Publication
+    what: Keyword
   Rule_00000106:
     crudFlags: CRUD
     grouping: Grouping_name-useroffice
-    what: Shift
+    what: Publication
   Rule_00000107:
     crudFlags: CRUD
     grouping: Grouping_name-useroffice
-    what: Study
+    what: Shift
   Rule_00000108:
     crudFlags: CRUD
     grouping: Grouping_name-useroffice
-    what: StudyInvestigation
+    what: Study
   Rule_00000109:
     crudFlags: CRUD
     grouping: Grouping_name-useroffice
-    what: User
+    what: StudyInvestigation
   Rule_00000110:
+    crudFlags: CRUD
+    grouping: Grouping_name-useroffice
+    what: User
+  Rule_00000111:
     crudFlags: CRUD
     grouping: Grouping_name-useroffice
     what: UserGroup

--- a/doc/examples/icatdump-5.0.xml
+++ b/doc/examples/icatdump-5.0.xml
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="utf-8"?>
 <icatdata>
 <head>
-  <date>2022-12-21T15:14:23+00:00</date>
+  <date>2023-10-16T15:00:34+00:00</date>
   <service>https://icat.example.com:8181/ICATService/ICAT?wsdl</service>
-  <apiversion>5.0.0</apiversion>
+  <apiversion>5.0.1</apiversion>
   <generator>icatdump (python-icat 1.0.0)</generator>
 </head>
 <data>
@@ -529,366 +529,371 @@
     <grouping ref="Grouping_name-ingest"/>
   </rule>
   <rule id="Rule_00000086">
+    <crudFlags>CRU</crudFlags>
+    <what>Sample</what>
+    <grouping ref="Grouping_name-ingest"/>
+  </rule>
+  <rule id="Rule_00000087">
     <crudFlags>R</crudFlags>
     <what>Shift</what>
     <grouping ref="Grouping_name-ingest"/>
   </rule>
-  <rule id="Rule_00000087">
-    <crudFlags>CRUD</crudFlags>
-    <what>Affiliation</what>
-    <grouping ref="Grouping_name-publisher"/>
-  </rule>
   <rule id="Rule_00000088">
     <crudFlags>CRUD</crudFlags>
-    <what>DataPublication</what>
+    <what>Affiliation</what>
     <grouping ref="Grouping_name-publisher"/>
   </rule>
   <rule id="Rule_00000089">
     <crudFlags>CRUD</crudFlags>
-    <what>DataPublicationDate</what>
+    <what>DataPublication</what>
     <grouping ref="Grouping_name-publisher"/>
   </rule>
   <rule id="Rule_00000090">
     <crudFlags>CRUD</crudFlags>
-    <what>DataPublicationFunding</what>
+    <what>DataPublicationDate</what>
     <grouping ref="Grouping_name-publisher"/>
   </rule>
   <rule id="Rule_00000091">
     <crudFlags>CRUD</crudFlags>
-    <what>DataPublicationUser</what>
+    <what>DataPublicationFunding</what>
     <grouping ref="Grouping_name-publisher"/>
   </rule>
   <rule id="Rule_00000092">
     <crudFlags>CRUD</crudFlags>
-    <what>FundingReference</what>
+    <what>DataPublicationUser</what>
     <grouping ref="Grouping_name-publisher"/>
   </rule>
   <rule id="Rule_00000093">
     <crudFlags>CRUD</crudFlags>
-    <what>RelatedItem</what>
+    <what>FundingReference</what>
     <grouping ref="Grouping_name-publisher"/>
   </rule>
   <rule id="Rule_00000094">
+    <crudFlags>CRUD</crudFlags>
+    <what>RelatedItem</what>
+    <grouping ref="Grouping_name-publisher"/>
+  </rule>
+  <rule id="Rule_00000095">
     <crudFlags>R</crudFlags>
     <what>SELECT o FROM DataPublication o</what>
     <grouping ref="Grouping_name-pubreader"/>
   </rule>
-  <rule id="Rule_00000095">
+  <rule id="Rule_00000096">
     <crudFlags>R</crudFlags>
     <what>SELECT o FROM Datafile o JOIN o.dataCollectionDatafiles AS s1 JOIN s1.dataCollection AS s2 JOIN s2.dataPublications AS s3 WHERE s3.id IS NOT NULL</what>
     <grouping ref="Grouping_name-pubreader"/>
   </rule>
-  <rule id="Rule_00000096">
+  <rule id="Rule_00000097">
     <crudFlags>R</crudFlags>
     <what>SELECT o FROM Datafile o JOIN o.dataset AS ds JOIN ds.dataCollectionDatasets AS s1 JOIN s1.dataCollection AS s2 JOIN s2.dataPublications AS s3 WHERE s3.id IS NOT NULL</what>
     <grouping ref="Grouping_name-pubreader"/>
   </rule>
-  <rule id="Rule_00000097">
+  <rule id="Rule_00000098">
     <crudFlags>R</crudFlags>
     <what>SELECT o FROM Datafile o JOIN o.dataset AS ds JOIN ds.investigation AS i JOIN i.dataCollectionInvestigations AS s1 JOIN s1.dataCollection AS s2 JOIN s2.dataPublications AS s3 WHERE s3.id IS NOT NULL</what>
     <grouping ref="Grouping_name-pubreader"/>
   </rule>
-  <rule id="Rule_00000098">
+  <rule id="Rule_00000099">
     <crudFlags>R</crudFlags>
     <what>SELECT o FROM Dataset o JOIN o.dataCollectionDatasets AS s1 JOIN s1.dataCollection AS s2 JOIN s2.dataPublications AS s3 WHERE s3.id IS NOT NULL</what>
     <grouping ref="Grouping_name-pubreader"/>
   </rule>
-  <rule id="Rule_00000099">
+  <rule id="Rule_00000100">
     <crudFlags>R</crudFlags>
     <what>SELECT o FROM Dataset o JOIN o.investigation AS i JOIN i.dataCollectionInvestigations AS s1 JOIN s1.dataCollection AS s2 JOIN s2.dataPublications AS s3 WHERE s3.id IS NOT NULL</what>
     <grouping ref="Grouping_name-pubreader"/>
   </rule>
-  <rule id="Rule_00000100">
+  <rule id="Rule_00000101">
     <crudFlags>R</crudFlags>
     <what>SELECT o FROM Investigation o JOIN o.dataCollectionInvestigations AS s1 JOIN s1.dataCollection AS s2 JOIN s2.dataPublications AS s3 WHERE s3.id IS NOT NULL</what>
     <grouping ref="Grouping_name-pubreader"/>
   </rule>
-  <rule id="Rule_00000101">
+  <rule id="Rule_00000102">
     <crudFlags>R</crudFlags>
     <what>Affiliation</what>
     <grouping ref="Grouping_name-rall"/>
   </rule>
-  <rule id="Rule_00000102">
+  <rule id="Rule_00000103">
     <crudFlags>R</crudFlags>
     <what>DataCollection</what>
     <grouping ref="Grouping_name-rall"/>
   </rule>
-  <rule id="Rule_00000103">
+  <rule id="Rule_00000104">
     <crudFlags>R</crudFlags>
     <what>DataCollectionDatafile</what>
     <grouping ref="Grouping_name-rall"/>
   </rule>
-  <rule id="Rule_00000104">
+  <rule id="Rule_00000105">
     <crudFlags>R</crudFlags>
     <what>DataCollectionDataset</what>
     <grouping ref="Grouping_name-rall"/>
   </rule>
-  <rule id="Rule_00000105">
+  <rule id="Rule_00000106">
     <crudFlags>R</crudFlags>
     <what>DataCollectionInvestigation</what>
     <grouping ref="Grouping_name-rall"/>
   </rule>
-  <rule id="Rule_00000106">
+  <rule id="Rule_00000107">
     <crudFlags>R</crudFlags>
     <what>DataCollectionParameter</what>
     <grouping ref="Grouping_name-rall"/>
   </rule>
-  <rule id="Rule_00000107">
+  <rule id="Rule_00000108">
     <crudFlags>R</crudFlags>
     <what>DataPublication</what>
     <grouping ref="Grouping_name-rall"/>
   </rule>
-  <rule id="Rule_00000108">
+  <rule id="Rule_00000109">
     <crudFlags>R</crudFlags>
     <what>DataPublicationDate</what>
     <grouping ref="Grouping_name-rall"/>
   </rule>
-  <rule id="Rule_00000109">
+  <rule id="Rule_00000110">
     <crudFlags>R</crudFlags>
     <what>DataPublicationFunding</what>
     <grouping ref="Grouping_name-rall"/>
   </rule>
-  <rule id="Rule_00000110">
+  <rule id="Rule_00000111">
     <crudFlags>R</crudFlags>
     <what>DataPublicationUser</what>
     <grouping ref="Grouping_name-rall"/>
   </rule>
-  <rule id="Rule_00000111">
+  <rule id="Rule_00000112">
     <crudFlags>R</crudFlags>
     <what>Datafile</what>
     <grouping ref="Grouping_name-rall"/>
   </rule>
-  <rule id="Rule_00000112">
+  <rule id="Rule_00000113">
     <crudFlags>R</crudFlags>
     <what>DatafileParameter</what>
     <grouping ref="Grouping_name-rall"/>
   </rule>
-  <rule id="Rule_00000113">
+  <rule id="Rule_00000114">
     <crudFlags>R</crudFlags>
     <what>Dataset</what>
     <grouping ref="Grouping_name-rall"/>
   </rule>
-  <rule id="Rule_00000114">
+  <rule id="Rule_00000115">
     <crudFlags>R</crudFlags>
     <what>DatasetInstrument</what>
     <grouping ref="Grouping_name-rall"/>
   </rule>
-  <rule id="Rule_00000115">
+  <rule id="Rule_00000116">
     <crudFlags>R</crudFlags>
     <what>DatasetParameter</what>
     <grouping ref="Grouping_name-rall"/>
   </rule>
-  <rule id="Rule_00000116">
+  <rule id="Rule_00000117">
     <crudFlags>R</crudFlags>
     <what>DatasetTechnique</what>
     <grouping ref="Grouping_name-rall"/>
   </rule>
-  <rule id="Rule_00000117">
-    <crudFlags>R</crudFlags>
-    <what>FundingReference</what>
-    <grouping ref="Grouping_name-rall"/>
-  </rule>
   <rule id="Rule_00000118">
     <crudFlags>R</crudFlags>
-    <what>Grouping</what>
+    <what>FundingReference</what>
     <grouping ref="Grouping_name-rall"/>
   </rule>
   <rule id="Rule_00000119">
     <crudFlags>R</crudFlags>
-    <what>InstrumentScientist</what>
+    <what>Grouping</what>
     <grouping ref="Grouping_name-rall"/>
   </rule>
   <rule id="Rule_00000120">
     <crudFlags>R</crudFlags>
-    <what>Investigation</what>
+    <what>InstrumentScientist</what>
     <grouping ref="Grouping_name-rall"/>
   </rule>
   <rule id="Rule_00000121">
     <crudFlags>R</crudFlags>
-    <what>InvestigationFacilityCycle</what>
+    <what>Investigation</what>
     <grouping ref="Grouping_name-rall"/>
   </rule>
   <rule id="Rule_00000122">
     <crudFlags>R</crudFlags>
-    <what>InvestigationFunding</what>
+    <what>InvestigationFacilityCycle</what>
     <grouping ref="Grouping_name-rall"/>
   </rule>
   <rule id="Rule_00000123">
     <crudFlags>R</crudFlags>
-    <what>InvestigationGroup</what>
+    <what>InvestigationFunding</what>
     <grouping ref="Grouping_name-rall"/>
   </rule>
   <rule id="Rule_00000124">
     <crudFlags>R</crudFlags>
-    <what>InvestigationInstrument</what>
+    <what>InvestigationGroup</what>
     <grouping ref="Grouping_name-rall"/>
   </rule>
   <rule id="Rule_00000125">
     <crudFlags>R</crudFlags>
-    <what>InvestigationParameter</what>
+    <what>InvestigationInstrument</what>
     <grouping ref="Grouping_name-rall"/>
   </rule>
   <rule id="Rule_00000126">
     <crudFlags>R</crudFlags>
-    <what>InvestigationUser</what>
+    <what>InvestigationParameter</what>
     <grouping ref="Grouping_name-rall"/>
   </rule>
   <rule id="Rule_00000127">
     <crudFlags>R</crudFlags>
-    <what>Job</what>
+    <what>InvestigationUser</what>
     <grouping ref="Grouping_name-rall"/>
   </rule>
   <rule id="Rule_00000128">
     <crudFlags>R</crudFlags>
-    <what>Keyword</what>
+    <what>Job</what>
     <grouping ref="Grouping_name-rall"/>
   </rule>
   <rule id="Rule_00000129">
     <crudFlags>R</crudFlags>
-    <what>PublicStep</what>
+    <what>Keyword</what>
     <grouping ref="Grouping_name-rall"/>
   </rule>
   <rule id="Rule_00000130">
     <crudFlags>R</crudFlags>
-    <what>Publication</what>
+    <what>PublicStep</what>
     <grouping ref="Grouping_name-rall"/>
   </rule>
   <rule id="Rule_00000131">
     <crudFlags>R</crudFlags>
-    <what>RelatedDatafile</what>
+    <what>Publication</what>
     <grouping ref="Grouping_name-rall"/>
   </rule>
   <rule id="Rule_00000132">
     <crudFlags>R</crudFlags>
-    <what>RelatedItem</what>
+    <what>RelatedDatafile</what>
     <grouping ref="Grouping_name-rall"/>
   </rule>
   <rule id="Rule_00000133">
     <crudFlags>R</crudFlags>
-    <what>Rule</what>
+    <what>RelatedItem</what>
     <grouping ref="Grouping_name-rall"/>
   </rule>
   <rule id="Rule_00000134">
     <crudFlags>R</crudFlags>
-    <what>Sample</what>
+    <what>Rule</what>
     <grouping ref="Grouping_name-rall"/>
   </rule>
   <rule id="Rule_00000135">
     <crudFlags>R</crudFlags>
-    <what>SampleParameter</what>
+    <what>Sample</what>
     <grouping ref="Grouping_name-rall"/>
   </rule>
   <rule id="Rule_00000136">
     <crudFlags>R</crudFlags>
-    <what>Shift</what>
+    <what>SampleParameter</what>
     <grouping ref="Grouping_name-rall"/>
   </rule>
   <rule id="Rule_00000137">
     <crudFlags>R</crudFlags>
-    <what>Study</what>
+    <what>Shift</what>
     <grouping ref="Grouping_name-rall"/>
   </rule>
   <rule id="Rule_00000138">
     <crudFlags>R</crudFlags>
-    <what>StudyInvestigation</what>
+    <what>Study</what>
     <grouping ref="Grouping_name-rall"/>
   </rule>
   <rule id="Rule_00000139">
     <crudFlags>R</crudFlags>
-    <what>UserGroup</what>
+    <what>StudyInvestigation</what>
     <grouping ref="Grouping_name-rall"/>
   </rule>
   <rule id="Rule_00000140">
+    <crudFlags>R</crudFlags>
+    <what>UserGroup</what>
+    <grouping ref="Grouping_name-rall"/>
+  </rule>
+  <rule id="Rule_00000141">
     <crudFlags>RU</crudFlags>
     <what>Sample</what>
     <grouping ref="Grouping_name-scientific=5Fstaff"/>
   </rule>
-  <rule id="Rule_00000141">
+  <rule id="Rule_00000142">
     <crudFlags>UD</crudFlags>
     <what>SampleType</what>
     <grouping ref="Grouping_name-scientific=5Fstaff"/>
   </rule>
-  <rule id="Rule_00000142">
+  <rule id="Rule_00000143">
     <crudFlags>CRUD</crudFlags>
     <what>FacilityCycle</what>
     <grouping ref="Grouping_name-useroffice"/>
   </rule>
-  <rule id="Rule_00000143">
+  <rule id="Rule_00000144">
     <crudFlags>CRUD</crudFlags>
     <what>FundingReference</what>
     <grouping ref="Grouping_name-useroffice"/>
   </rule>
-  <rule id="Rule_00000144">
+  <rule id="Rule_00000145">
     <crudFlags>CRUD</crudFlags>
     <what>Grouping</what>
     <grouping ref="Grouping_name-useroffice"/>
   </rule>
-  <rule id="Rule_00000145">
+  <rule id="Rule_00000146">
     <crudFlags>CRUD</crudFlags>
     <what>InstrumentScientist</what>
     <grouping ref="Grouping_name-useroffice"/>
   </rule>
-  <rule id="Rule_00000146">
+  <rule id="Rule_00000147">
     <crudFlags>CRUD</crudFlags>
     <what>Investigation</what>
     <grouping ref="Grouping_name-useroffice"/>
   </rule>
-  <rule id="Rule_00000147">
+  <rule id="Rule_00000148">
     <crudFlags>CRUD</crudFlags>
     <what>InvestigationFunding</what>
     <grouping ref="Grouping_name-useroffice"/>
   </rule>
-  <rule id="Rule_00000148">
+  <rule id="Rule_00000149">
     <crudFlags>CRUD</crudFlags>
     <what>InvestigationGroup</what>
     <grouping ref="Grouping_name-useroffice"/>
   </rule>
-  <rule id="Rule_00000149">
+  <rule id="Rule_00000150">
     <crudFlags>CRUD</crudFlags>
     <what>InvestigationInstrument</what>
     <grouping ref="Grouping_name-useroffice"/>
   </rule>
-  <rule id="Rule_00000150">
+  <rule id="Rule_00000151">
     <crudFlags>CRUD</crudFlags>
     <what>InvestigationParameter</what>
     <grouping ref="Grouping_name-useroffice"/>
   </rule>
-  <rule id="Rule_00000151">
+  <rule id="Rule_00000152">
     <crudFlags>CRUD</crudFlags>
     <what>InvestigationUser</what>
     <grouping ref="Grouping_name-useroffice"/>
   </rule>
-  <rule id="Rule_00000152">
+  <rule id="Rule_00000153">
     <crudFlags>CRUD</crudFlags>
     <what>Keyword</what>
     <grouping ref="Grouping_name-useroffice"/>
   </rule>
-  <rule id="Rule_00000153">
+  <rule id="Rule_00000154">
     <crudFlags>CRUD</crudFlags>
     <what>Publication</what>
     <grouping ref="Grouping_name-useroffice"/>
   </rule>
-  <rule id="Rule_00000154">
+  <rule id="Rule_00000155">
     <crudFlags>CRUD</crudFlags>
     <what>Shift</what>
     <grouping ref="Grouping_name-useroffice"/>
   </rule>
-  <rule id="Rule_00000155">
+  <rule id="Rule_00000156">
     <crudFlags>CRUD</crudFlags>
     <what>Study</what>
     <grouping ref="Grouping_name-useroffice"/>
   </rule>
-  <rule id="Rule_00000156">
+  <rule id="Rule_00000157">
     <crudFlags>CRUD</crudFlags>
     <what>StudyInvestigation</what>
     <grouping ref="Grouping_name-useroffice"/>
   </rule>
-  <rule id="Rule_00000157">
+  <rule id="Rule_00000158">
     <crudFlags>CRUD</crudFlags>
     <what>User</what>
     <grouping ref="Grouping_name-useroffice"/>
   </rule>
-  <rule id="Rule_00000158">
+  <rule id="Rule_00000159">
     <crudFlags>CRUD</crudFlags>
     <what>UserGroup</what>
     <grouping ref="Grouping_name-useroffice"/>

--- a/doc/examples/icatdump-5.0.yaml
+++ b/doc/examples/icatdump-5.0.yaml
@@ -1,7 +1,7 @@
 %YAML 1.1
-# Date: Wed, 21 Dec 2022 15:14:26 +0000
+# Date: Mon, 16 Oct 2023 15:00:30 +0000
 # Service: https://icat.example.com:8181/ICATService/ICAT?wsdl
-# ICAT-API: 5.0.0
+# ICAT-API: 5.0.1
 # Generator: icatdump (python-icat 1.0.0)
 ---
 grouping:
@@ -557,304 +557,308 @@ rule:
     grouping: Grouping_name-ingest
     what: Investigation
   Rule_00000086:
+    crudFlags: CRU
+    grouping: Grouping_name-ingest
+    what: Sample
+  Rule_00000087:
     crudFlags: R
     grouping: Grouping_name-ingest
     what: Shift
-  Rule_00000087:
-    crudFlags: CRUD
-    grouping: Grouping_name-publisher
-    what: Affiliation
   Rule_00000088:
     crudFlags: CRUD
     grouping: Grouping_name-publisher
-    what: DataPublication
+    what: Affiliation
   Rule_00000089:
     crudFlags: CRUD
     grouping: Grouping_name-publisher
-    what: DataPublicationDate
+    what: DataPublication
   Rule_00000090:
     crudFlags: CRUD
     grouping: Grouping_name-publisher
-    what: DataPublicationFunding
+    what: DataPublicationDate
   Rule_00000091:
     crudFlags: CRUD
     grouping: Grouping_name-publisher
-    what: DataPublicationUser
+    what: DataPublicationFunding
   Rule_00000092:
     crudFlags: CRUD
     grouping: Grouping_name-publisher
-    what: FundingReference
+    what: DataPublicationUser
   Rule_00000093:
     crudFlags: CRUD
     grouping: Grouping_name-publisher
-    what: RelatedItem
+    what: FundingReference
   Rule_00000094:
+    crudFlags: CRUD
+    grouping: Grouping_name-publisher
+    what: RelatedItem
+  Rule_00000095:
     crudFlags: R
     grouping: Grouping_name-pubreader
     what: SELECT o FROM DataPublication o
-  Rule_00000095:
+  Rule_00000096:
     crudFlags: R
     grouping: Grouping_name-pubreader
     what: SELECT o FROM Datafile o JOIN o.dataCollectionDatafiles AS s1 JOIN s1.dataCollection
       AS s2 JOIN s2.dataPublications AS s3 WHERE s3.id IS NOT NULL
-  Rule_00000096:
+  Rule_00000097:
     crudFlags: R
     grouping: Grouping_name-pubreader
     what: SELECT o FROM Datafile o JOIN o.dataset AS ds JOIN ds.dataCollectionDatasets
       AS s1 JOIN s1.dataCollection AS s2 JOIN s2.dataPublications AS s3 WHERE s3.id
       IS NOT NULL
-  Rule_00000097:
+  Rule_00000098:
     crudFlags: R
     grouping: Grouping_name-pubreader
     what: SELECT o FROM Datafile o JOIN o.dataset AS ds JOIN ds.investigation AS i
       JOIN i.dataCollectionInvestigations AS s1 JOIN s1.dataCollection AS s2 JOIN
       s2.dataPublications AS s3 WHERE s3.id IS NOT NULL
-  Rule_00000098:
+  Rule_00000099:
     crudFlags: R
     grouping: Grouping_name-pubreader
     what: SELECT o FROM Dataset o JOIN o.dataCollectionDatasets AS s1 JOIN s1.dataCollection
       AS s2 JOIN s2.dataPublications AS s3 WHERE s3.id IS NOT NULL
-  Rule_00000099:
+  Rule_00000100:
     crudFlags: R
     grouping: Grouping_name-pubreader
     what: SELECT o FROM Dataset o JOIN o.investigation AS i JOIN i.dataCollectionInvestigations
       AS s1 JOIN s1.dataCollection AS s2 JOIN s2.dataPublications AS s3 WHERE s3.id
       IS NOT NULL
-  Rule_00000100:
+  Rule_00000101:
     crudFlags: R
     grouping: Grouping_name-pubreader
     what: SELECT o FROM Investigation o JOIN o.dataCollectionInvestigations AS s1
       JOIN s1.dataCollection AS s2 JOIN s2.dataPublications AS s3 WHERE s3.id IS NOT
       NULL
-  Rule_00000101:
-    crudFlags: R
-    grouping: Grouping_name-rall
-    what: Affiliation
   Rule_00000102:
     crudFlags: R
     grouping: Grouping_name-rall
-    what: DataCollection
+    what: Affiliation
   Rule_00000103:
     crudFlags: R
     grouping: Grouping_name-rall
-    what: DataCollectionDatafile
+    what: DataCollection
   Rule_00000104:
     crudFlags: R
     grouping: Grouping_name-rall
-    what: DataCollectionDataset
+    what: DataCollectionDatafile
   Rule_00000105:
     crudFlags: R
     grouping: Grouping_name-rall
-    what: DataCollectionInvestigation
+    what: DataCollectionDataset
   Rule_00000106:
     crudFlags: R
     grouping: Grouping_name-rall
-    what: DataCollectionParameter
+    what: DataCollectionInvestigation
   Rule_00000107:
     crudFlags: R
     grouping: Grouping_name-rall
-    what: DataPublication
+    what: DataCollectionParameter
   Rule_00000108:
     crudFlags: R
     grouping: Grouping_name-rall
-    what: DataPublicationDate
+    what: DataPublication
   Rule_00000109:
     crudFlags: R
     grouping: Grouping_name-rall
-    what: DataPublicationFunding
+    what: DataPublicationDate
   Rule_00000110:
     crudFlags: R
     grouping: Grouping_name-rall
-    what: DataPublicationUser
+    what: DataPublicationFunding
   Rule_00000111:
     crudFlags: R
     grouping: Grouping_name-rall
-    what: Datafile
+    what: DataPublicationUser
   Rule_00000112:
     crudFlags: R
     grouping: Grouping_name-rall
-    what: DatafileParameter
+    what: Datafile
   Rule_00000113:
     crudFlags: R
     grouping: Grouping_name-rall
-    what: Dataset
+    what: DatafileParameter
   Rule_00000114:
     crudFlags: R
     grouping: Grouping_name-rall
-    what: DatasetInstrument
+    what: Dataset
   Rule_00000115:
     crudFlags: R
     grouping: Grouping_name-rall
-    what: DatasetParameter
+    what: DatasetInstrument
   Rule_00000116:
     crudFlags: R
     grouping: Grouping_name-rall
-    what: DatasetTechnique
+    what: DatasetParameter
   Rule_00000117:
     crudFlags: R
     grouping: Grouping_name-rall
-    what: FundingReference
+    what: DatasetTechnique
   Rule_00000118:
     crudFlags: R
     grouping: Grouping_name-rall
-    what: Grouping
+    what: FundingReference
   Rule_00000119:
     crudFlags: R
     grouping: Grouping_name-rall
-    what: InstrumentScientist
+    what: Grouping
   Rule_00000120:
     crudFlags: R
     grouping: Grouping_name-rall
-    what: Investigation
+    what: InstrumentScientist
   Rule_00000121:
     crudFlags: R
     grouping: Grouping_name-rall
-    what: InvestigationFacilityCycle
+    what: Investigation
   Rule_00000122:
     crudFlags: R
     grouping: Grouping_name-rall
-    what: InvestigationFunding
+    what: InvestigationFacilityCycle
   Rule_00000123:
     crudFlags: R
     grouping: Grouping_name-rall
-    what: InvestigationGroup
+    what: InvestigationFunding
   Rule_00000124:
     crudFlags: R
     grouping: Grouping_name-rall
-    what: InvestigationInstrument
+    what: InvestigationGroup
   Rule_00000125:
     crudFlags: R
     grouping: Grouping_name-rall
-    what: InvestigationParameter
+    what: InvestigationInstrument
   Rule_00000126:
     crudFlags: R
     grouping: Grouping_name-rall
-    what: InvestigationUser
+    what: InvestigationParameter
   Rule_00000127:
     crudFlags: R
     grouping: Grouping_name-rall
-    what: Job
+    what: InvestigationUser
   Rule_00000128:
     crudFlags: R
     grouping: Grouping_name-rall
-    what: Keyword
+    what: Job
   Rule_00000129:
     crudFlags: R
     grouping: Grouping_name-rall
-    what: PublicStep
+    what: Keyword
   Rule_00000130:
     crudFlags: R
     grouping: Grouping_name-rall
-    what: Publication
+    what: PublicStep
   Rule_00000131:
     crudFlags: R
     grouping: Grouping_name-rall
-    what: RelatedDatafile
+    what: Publication
   Rule_00000132:
     crudFlags: R
     grouping: Grouping_name-rall
-    what: RelatedItem
+    what: RelatedDatafile
   Rule_00000133:
     crudFlags: R
     grouping: Grouping_name-rall
-    what: Rule
+    what: RelatedItem
   Rule_00000134:
     crudFlags: R
     grouping: Grouping_name-rall
-    what: Sample
+    what: Rule
   Rule_00000135:
     crudFlags: R
     grouping: Grouping_name-rall
-    what: SampleParameter
+    what: Sample
   Rule_00000136:
     crudFlags: R
     grouping: Grouping_name-rall
-    what: Shift
+    what: SampleParameter
   Rule_00000137:
     crudFlags: R
     grouping: Grouping_name-rall
-    what: Study
+    what: Shift
   Rule_00000138:
     crudFlags: R
     grouping: Grouping_name-rall
-    what: StudyInvestigation
+    what: Study
   Rule_00000139:
     crudFlags: R
     grouping: Grouping_name-rall
-    what: UserGroup
+    what: StudyInvestigation
   Rule_00000140:
+    crudFlags: R
+    grouping: Grouping_name-rall
+    what: UserGroup
+  Rule_00000141:
     crudFlags: RU
     grouping: Grouping_name-scientific=5Fstaff
     what: Sample
-  Rule_00000141:
+  Rule_00000142:
     crudFlags: UD
     grouping: Grouping_name-scientific=5Fstaff
     what: SampleType
-  Rule_00000142:
-    crudFlags: CRUD
-    grouping: Grouping_name-useroffice
-    what: FacilityCycle
   Rule_00000143:
     crudFlags: CRUD
     grouping: Grouping_name-useroffice
-    what: FundingReference
+    what: FacilityCycle
   Rule_00000144:
     crudFlags: CRUD
     grouping: Grouping_name-useroffice
-    what: Grouping
+    what: FundingReference
   Rule_00000145:
     crudFlags: CRUD
     grouping: Grouping_name-useroffice
-    what: InstrumentScientist
+    what: Grouping
   Rule_00000146:
     crudFlags: CRUD
     grouping: Grouping_name-useroffice
-    what: Investigation
+    what: InstrumentScientist
   Rule_00000147:
     crudFlags: CRUD
     grouping: Grouping_name-useroffice
-    what: InvestigationFunding
+    what: Investigation
   Rule_00000148:
     crudFlags: CRUD
     grouping: Grouping_name-useroffice
-    what: InvestigationGroup
+    what: InvestigationFunding
   Rule_00000149:
     crudFlags: CRUD
     grouping: Grouping_name-useroffice
-    what: InvestigationInstrument
+    what: InvestigationGroup
   Rule_00000150:
     crudFlags: CRUD
     grouping: Grouping_name-useroffice
-    what: InvestigationParameter
+    what: InvestigationInstrument
   Rule_00000151:
     crudFlags: CRUD
     grouping: Grouping_name-useroffice
-    what: InvestigationUser
+    what: InvestigationParameter
   Rule_00000152:
     crudFlags: CRUD
     grouping: Grouping_name-useroffice
-    what: Keyword
+    what: InvestigationUser
   Rule_00000153:
     crudFlags: CRUD
     grouping: Grouping_name-useroffice
-    what: Publication
+    what: Keyword
   Rule_00000154:
     crudFlags: CRUD
     grouping: Grouping_name-useroffice
-    what: Shift
+    what: Publication
   Rule_00000155:
     crudFlags: CRUD
     grouping: Grouping_name-useroffice
-    what: Study
+    what: Shift
   Rule_00000156:
     crudFlags: CRUD
     grouping: Grouping_name-useroffice
-    what: StudyInvestigation
+    what: Study
   Rule_00000157:
     crudFlags: CRUD
     grouping: Grouping_name-useroffice
-    what: User
+    what: StudyInvestigation
   Rule_00000158:
+    crudFlags: CRUD
+    grouping: Grouping_name-useroffice
+    what: User
+  Rule_00000159:
     crudFlags: CRUD
     grouping: Grouping_name-useroffice
     what: UserGroup

--- a/doc/examples/ingest-sample-ds.xml
+++ b/doc/examples/ingest-sample-ds.xml
@@ -8,10 +8,8 @@
   </head>
   <data>
     <investigationRef id="inv_1" name="10100601-ST" visitId="1.1-N"/>
-    <sampleRef id="sample_1" name="ab3465"
-	       investigation.name="10100601-ST" investigation.visitId="1.1-N"/>
-    <sampleRef id="sample_2" name="ab3466"
-	       investigation.name="10100601-ST" investigation.visitId="1.1-N"/>
+    <sampleRef id="sample_1" name="ab3465" investigation.ref="inv_1"/>
+    <sampleRef id="sample_2" name="ab3466" investigation.ref="inv_1"/>
     <dataset>
       <complete>false</complete>
       <endDate>2012-07-30T01:10:08+00:00</endDate>

--- a/doc/examples/ingest-sample-ds.xml
+++ b/doc/examples/ingest-sample-ds.xml
@@ -1,0 +1,51 @@
+<?xml version="1.0" encoding="utf-8"?>
+<icatdata>
+  <!-- Example input to add some datasets that relate to existing
+       samples with icatingest.py. -->
+  <head>
+    <date>2023-10-17T07:33:36Z</date>
+    <generator>manual edit</generator>
+  </head>
+  <data>
+    <investigationRef id="inv_1" name="10100601-ST" visitId="1.1-N"/>
+    <sampleRef id="sample_1" name="ab3465"
+	       investigation.name="10100601-ST" investigation.visitId="1.1-N"/>
+    <sampleRef id="sample_2" name="ab3466"
+	       investigation.name="10100601-ST" investigation.visitId="1.1-N"/>
+    <dataset>
+      <complete>false</complete>
+      <endDate>2012-07-30T01:10:08+00:00</endDate>
+      <name>e209001</name>
+      <startDate>2012-07-26T15:44:24+00:00</startDate>
+      <investigation ref="inv_1"/>
+      <sample ref="sample_1"/>
+      <type name="raw"/>
+    </dataset>
+    <dataset>
+      <complete>false</complete>
+      <endDate>2012-08-06T01:10:08+00:00</endDate>
+      <name>e209002</name>
+      <startDate>2012-08-02T05:30:00+00:00</startDate>
+      <investigation ref="inv_1"/>
+      <sample ref="sample_1"/>
+      <type name="raw"/>
+    </dataset>
+    <dataset>
+      <complete>false</complete>
+      <endDate>2012-07-16T14:30:17+00:00</endDate>
+      <name>e209003</name>
+      <startDate>2012-07-16T11:42:05+00:00</startDate>
+      <investigation ref="inv_1"/>
+      <sample ref="sample_2"/>
+      <type name="raw"/>
+    </dataset>
+    <dataset>
+      <complete>false</complete>
+      <endDate>2012-07-31T22:52:23+00:00</endDate>
+      <name>e209004</name>
+      <startDate>2012-07-31T20:20:37+00:00</startDate>
+      <investigation ref="inv_1"/>
+      <type name="raw"/>
+    </dataset>
+  </data>
+</icatdata>

--- a/doc/examples/init-icat.py
+++ b/doc/examples/init-icat.py
@@ -131,7 +131,7 @@ client.createRules("CRUD", uotables, uogroup)
 ingest = client.createUser("simple/dataingest", fullName="Data Ingester")
 ingestgroup = client.createGroup("ingest", [ ingest ])
 client.createRules("R", [ "Investigation", "Shift" ], ingestgroup)
-ingest_cru_classes = [ "Dataset", "Datafile",
+ingest_cru_classes = [ "Sample", "Dataset", "Datafile",
                        "DatasetParameter", "DatafileParameter" ]
 if "datasetInstrument" in client.typemap:
     ingest_cru_classes.append("DatasetInstrument")

--- a/doc/icatdata-4.10.xsd
+++ b/doc/icatdata-4.10.xsd
@@ -169,13 +169,16 @@
      reference the target object in other reference objects.
 
      The target object may either be referenced by reference key or by
-     object attributes.  In the former case, the key is given in the
-     ref attribute and other attributes SHOULD NOT be present.  The
-     reference key may either have been defined earlier in the id
-     attribute of an other entity object or reference in the same data
-     element or it must the unique key as returned by the
-     getUniqueKey() method of the target object.  In the latter case,
-     the attribute values must uniquely define the target object.
+     object attributes.  The former case is implemeted by adding a
+     special attribute "ref" to hold the key.  In this case, other
+     attributes SHOULD NOT be present.  The reference key may either
+     have been defined earlier in the id attribute of another entity
+     object or reference in the same data element or it must the
+     unique key as returned by the getUniqueKey() method of the target
+     object.  When referencing the target object by attributes, the
+     attribute values must uniquely define the target object.  In this
+     case, related objects may in turn be referenced either by
+     reference or by attributes accordingly.
 
      Note that in the case of referencing the target object by
      attribute values, this schema is somewhat too restricted: in
@@ -200,6 +203,7 @@
 <xsd:complexType name="applicationRef">
   <xsd:complexContent>
     <xsd:extension base="entityReference">
+      <xsd:attribute name="facility.ref" type="xsd:string"/>
       <xsd:attribute name="facility.name" type="xsd:string"/>
       <xsd:attribute name="name" type="xsd:string"/>
       <xsd:attribute name="version" type="xsd:string"/>
@@ -218,6 +222,7 @@
 <xsd:complexType name="datafileRef">
   <xsd:complexContent>
     <xsd:extension base="entityReference">
+      <xsd:attribute name="dataset.ref" type="xsd:string"/>
       <xsd:attribute name="dataset.investigation.facility.name" 
 		     type="xsd:string"/>
       <xsd:attribute name="dataset.investigation.name" type="xsd:string"/>
@@ -232,6 +237,7 @@
 <xsd:complexType name="datafileFormatRef">
   <xsd:complexContent>
     <xsd:extension base="entityReference">
+      <xsd:attribute name="facility.ref" type="xsd:string"/>
       <xsd:attribute name="facility.name" type="xsd:string"/>
       <xsd:attribute name="name" type="xsd:string"/>
       <xsd:attribute name="version" type="xsd:string"/>
@@ -242,6 +248,7 @@
 <xsd:complexType name="datasetRef">
   <xsd:complexContent>
     <xsd:extension base="entityReference">
+      <xsd:attribute name="investigation.ref" type="xsd:string"/>
       <xsd:attribute name="investigation.facility.name" type="xsd:string"/>
       <xsd:attribute name="investigation.name" type="xsd:string"/>
       <xsd:attribute name="investigation.visitId" type="xsd:string"/>
@@ -254,6 +261,7 @@
 <xsd:complexType name="datasetTypeRef">
   <xsd:complexContent>
     <xsd:extension base="entityReference">
+      <xsd:attribute name="facility.ref" type="xsd:string"/>
       <xsd:attribute name="facility.name" type="xsd:string"/>
       <xsd:attribute name="name" type="xsd:string"/>
     </xsd:extension>
@@ -279,6 +287,7 @@
 <xsd:complexType name="instrumentRef">
   <xsd:complexContent>
     <xsd:extension base="entityReference">
+      <xsd:attribute name="facility.ref" type="xsd:string"/>
       <xsd:attribute name="facility.name" type="xsd:string"/>
       <xsd:attribute name="name" type="xsd:string"/>
       <xsd:attribute name="pid" type="xsd:string"/>
@@ -289,6 +298,7 @@
 <xsd:complexType name="investigationRef">
   <xsd:complexContent>
     <xsd:extension base="entityReference">
+      <xsd:attribute name="facility.ref" type="xsd:string"/>
       <xsd:attribute name="facility.name" type="xsd:string"/>
       <xsd:attribute name="name" type="xsd:string"/>
       <xsd:attribute name="visitId" type="xsd:string"/>
@@ -300,6 +310,7 @@
 <xsd:complexType name="investigationTypeRef">
   <xsd:complexContent>
     <xsd:extension base="entityReference">
+      <xsd:attribute name="facility.ref" type="xsd:string"/>
       <xsd:attribute name="facility.name" type="xsd:string"/>
       <xsd:attribute name="name" type="xsd:string"/>
     </xsd:extension>
@@ -309,6 +320,7 @@
 <xsd:complexType name="parameterTypeRef">
   <xsd:complexContent>
     <xsd:extension base="entityReference">
+      <xsd:attribute name="facility.ref" type="xsd:string"/>
       <xsd:attribute name="facility.name" type="xsd:string"/>
       <xsd:attribute name="name" type="xsd:string"/>
       <xsd:attribute name="units" type="xsd:string"/>
@@ -320,6 +332,7 @@
 <xsd:complexType name="sampleRef">
   <xsd:complexContent>
     <xsd:extension base="entityReference">
+      <xsd:attribute name="investigation.ref" type="xsd:string"/>
       <xsd:attribute name="investigation.facility.name" type="xsd:string"/>
       <xsd:attribute name="investigation.name" type="xsd:string"/>
       <xsd:attribute name="investigation.visitId" type="xsd:string"/>
@@ -332,6 +345,7 @@
 <xsd:complexType name="sampleTypeRef">
   <xsd:complexContent>
     <xsd:extension base="entityReference">
+      <xsd:attribute name="facility.ref" type="xsd:string"/>
       <xsd:attribute name="facility.name" type="xsd:string"/>
       <xsd:attribute name="name" type="xsd:string"/>
       <xsd:attribute name="molecularFormula" type="xsd:string"/>

--- a/doc/icatdata-4.3.xsd
+++ b/doc/icatdata-4.3.xsd
@@ -165,13 +165,16 @@
      reference the target object in other reference objects.
 
      The target object may either be referenced by reference key or by
-     object attributes.  In the former case, the key is given in the
-     ref attribute and other attributes SHOULD NOT be present.  The
-     reference key may either have been defined earlier in the id
-     attribute of an other entity object or reference in the same data
-     element or it must the unique key as returned by the
-     getUniqueKey() method of the target object.  In the latter case,
-     the attribute values must uniquely define the target object.
+     object attributes.  The former case is implemeted by adding a
+     special attribute "ref" to hold the key.  In this case, other
+     attributes SHOULD NOT be present.  The reference key may either
+     have been defined earlier in the id attribute of another entity
+     object or reference in the same data element or it must the
+     unique key as returned by the getUniqueKey() method of the target
+     object.  When referencing the target object by attributes, the
+     attribute values must uniquely define the target object.  In this
+     case, related objects may in turn be referenced either by
+     reference or by attributes accordingly.
 
      Note that in the case of referencing the target object by
      attribute values, this schema is somewhat too restricted: in
@@ -196,6 +199,7 @@
 <xsd:complexType name="applicationRef">
   <xsd:complexContent>
     <xsd:extension base="entityReference">
+      <xsd:attribute name="facility.ref" type="xsd:string"/>
       <xsd:attribute name="facility.name" type="xsd:string"/>
       <xsd:attribute name="name" type="xsd:string"/>
       <xsd:attribute name="version" type="xsd:string"/>
@@ -206,6 +210,7 @@
 <xsd:complexType name="datafileRef">
   <xsd:complexContent>
     <xsd:extension base="entityReference">
+      <xsd:attribute name="dataset.ref" type="xsd:string"/>
       <xsd:attribute name="dataset.investigation.facility.name" 
 		     type="xsd:string"/>
       <xsd:attribute name="dataset.investigation.name" type="xsd:string"/>
@@ -220,6 +225,7 @@
 <xsd:complexType name="datafileFormatRef">
   <xsd:complexContent>
     <xsd:extension base="entityReference">
+      <xsd:attribute name="facility.ref" type="xsd:string"/>
       <xsd:attribute name="facility.name" type="xsd:string"/>
       <xsd:attribute name="name" type="xsd:string"/>
       <xsd:attribute name="version" type="xsd:string"/>
@@ -230,6 +236,7 @@
 <xsd:complexType name="datasetRef">
   <xsd:complexContent>
     <xsd:extension base="entityReference">
+      <xsd:attribute name="investigation.ref" type="xsd:string"/>
       <xsd:attribute name="investigation.facility.name" type="xsd:string"/>
       <xsd:attribute name="investigation.name" type="xsd:string"/>
       <xsd:attribute name="investigation.visitId" type="xsd:string"/>
@@ -242,6 +249,7 @@
 <xsd:complexType name="datasetTypeRef">
   <xsd:complexContent>
     <xsd:extension base="entityReference">
+      <xsd:attribute name="facility.ref" type="xsd:string"/>
       <xsd:attribute name="facility.name" type="xsd:string"/>
       <xsd:attribute name="name" type="xsd:string"/>
     </xsd:extension>
@@ -267,6 +275,7 @@
 <xsd:complexType name="instrumentRef">
   <xsd:complexContent>
     <xsd:extension base="entityReference">
+      <xsd:attribute name="facility.ref" type="xsd:string"/>
       <xsd:attribute name="facility.name" type="xsd:string"/>
       <xsd:attribute name="name" type="xsd:string"/>
     </xsd:extension>
@@ -276,6 +285,7 @@
 <xsd:complexType name="investigationRef">
   <xsd:complexContent>
     <xsd:extension base="entityReference">
+      <xsd:attribute name="facility.ref" type="xsd:string"/>
       <xsd:attribute name="facility.name" type="xsd:string"/>
       <xsd:attribute name="name" type="xsd:string"/>
       <xsd:attribute name="visitId" type="xsd:string"/>
@@ -287,6 +297,7 @@
 <xsd:complexType name="investigationTypeRef">
   <xsd:complexContent>
     <xsd:extension base="entityReference">
+      <xsd:attribute name="facility.ref" type="xsd:string"/>
       <xsd:attribute name="facility.name" type="xsd:string"/>
       <xsd:attribute name="name" type="xsd:string"/>
     </xsd:extension>
@@ -296,6 +307,7 @@
 <xsd:complexType name="parameterTypeRef">
   <xsd:complexContent>
     <xsd:extension base="entityReference">
+      <xsd:attribute name="facility.ref" type="xsd:string"/>
       <xsd:attribute name="facility.name" type="xsd:string"/>
       <xsd:attribute name="name" type="xsd:string"/>
       <xsd:attribute name="units" type="xsd:string"/>
@@ -306,6 +318,7 @@
 <xsd:complexType name="sampleRef">
   <xsd:complexContent>
     <xsd:extension base="entityReference">
+      <xsd:attribute name="investigation.ref" type="xsd:string"/>
       <xsd:attribute name="investigation.facility.name" type="xsd:string"/>
       <xsd:attribute name="investigation.name" type="xsd:string"/>
       <xsd:attribute name="investigation.visitId" type="xsd:string"/>
@@ -317,6 +330,7 @@
 <xsd:complexType name="sampleTypeRef">
   <xsd:complexContent>
     <xsd:extension base="entityReference">
+      <xsd:attribute name="facility.ref" type="xsd:string"/>
       <xsd:attribute name="facility.name" type="xsd:string"/>
       <xsd:attribute name="name" type="xsd:string"/>
       <xsd:attribute name="molecularFormula" type="xsd:string"/>

--- a/doc/icatdata-4.4.xsd
+++ b/doc/icatdata-4.4.xsd
@@ -165,13 +165,16 @@
      reference the target object in other reference objects.
 
      The target object may either be referenced by reference key or by
-     object attributes.  In the former case, the key is given in the
-     ref attribute and other attributes SHOULD NOT be present.  The
-     reference key may either have been defined earlier in the id
-     attribute of an other entity object or reference in the same data
-     element or it must the unique key as returned by the
-     getUniqueKey() method of the target object.  In the latter case,
-     the attribute values must uniquely define the target object.
+     object attributes.  The former case is implemeted by adding a
+     special attribute "ref" to hold the key.  In this case, other
+     attributes SHOULD NOT be present.  The reference key may either
+     have been defined earlier in the id attribute of another entity
+     object or reference in the same data element or it must the
+     unique key as returned by the getUniqueKey() method of the target
+     object.  When referencing the target object by attributes, the
+     attribute values must uniquely define the target object.  In this
+     case, related objects may in turn be referenced either by
+     reference or by attributes accordingly.
 
      Note that in the case of referencing the target object by
      attribute values, this schema is somewhat too restricted: in
@@ -196,6 +199,7 @@
 <xsd:complexType name="applicationRef">
   <xsd:complexContent>
     <xsd:extension base="entityReference">
+      <xsd:attribute name="facility.ref" type="xsd:string"/>
       <xsd:attribute name="facility.name" type="xsd:string"/>
       <xsd:attribute name="name" type="xsd:string"/>
       <xsd:attribute name="version" type="xsd:string"/>
@@ -206,6 +210,7 @@
 <xsd:complexType name="datafileRef">
   <xsd:complexContent>
     <xsd:extension base="entityReference">
+      <xsd:attribute name="dataset.ref" type="xsd:string"/>
       <xsd:attribute name="dataset.investigation.facility.name" 
 		     type="xsd:string"/>
       <xsd:attribute name="dataset.investigation.name" type="xsd:string"/>
@@ -220,6 +225,7 @@
 <xsd:complexType name="datafileFormatRef">
   <xsd:complexContent>
     <xsd:extension base="entityReference">
+      <xsd:attribute name="facility.ref" type="xsd:string"/>
       <xsd:attribute name="facility.name" type="xsd:string"/>
       <xsd:attribute name="name" type="xsd:string"/>
       <xsd:attribute name="version" type="xsd:string"/>
@@ -230,6 +236,7 @@
 <xsd:complexType name="datasetRef">
   <xsd:complexContent>
     <xsd:extension base="entityReference">
+      <xsd:attribute name="investigation.ref" type="xsd:string"/>
       <xsd:attribute name="investigation.facility.name" type="xsd:string"/>
       <xsd:attribute name="investigation.name" type="xsd:string"/>
       <xsd:attribute name="investigation.visitId" type="xsd:string"/>
@@ -242,6 +249,7 @@
 <xsd:complexType name="datasetTypeRef">
   <xsd:complexContent>
     <xsd:extension base="entityReference">
+      <xsd:attribute name="facility.ref" type="xsd:string"/>
       <xsd:attribute name="facility.name" type="xsd:string"/>
       <xsd:attribute name="name" type="xsd:string"/>
     </xsd:extension>
@@ -267,6 +275,7 @@
 <xsd:complexType name="instrumentRef">
   <xsd:complexContent>
     <xsd:extension base="entityReference">
+      <xsd:attribute name="facility.ref" type="xsd:string"/>
       <xsd:attribute name="facility.name" type="xsd:string"/>
       <xsd:attribute name="name" type="xsd:string"/>
     </xsd:extension>
@@ -276,6 +285,7 @@
 <xsd:complexType name="investigationRef">
   <xsd:complexContent>
     <xsd:extension base="entityReference">
+      <xsd:attribute name="facility.ref" type="xsd:string"/>
       <xsd:attribute name="facility.name" type="xsd:string"/>
       <xsd:attribute name="name" type="xsd:string"/>
       <xsd:attribute name="visitId" type="xsd:string"/>
@@ -287,6 +297,7 @@
 <xsd:complexType name="investigationTypeRef">
   <xsd:complexContent>
     <xsd:extension base="entityReference">
+      <xsd:attribute name="facility.ref" type="xsd:string"/>
       <xsd:attribute name="facility.name" type="xsd:string"/>
       <xsd:attribute name="name" type="xsd:string"/>
     </xsd:extension>
@@ -296,6 +307,7 @@
 <xsd:complexType name="parameterTypeRef">
   <xsd:complexContent>
     <xsd:extension base="entityReference">
+      <xsd:attribute name="facility.ref" type="xsd:string"/>
       <xsd:attribute name="facility.name" type="xsd:string"/>
       <xsd:attribute name="name" type="xsd:string"/>
       <xsd:attribute name="units" type="xsd:string"/>
@@ -306,6 +318,7 @@
 <xsd:complexType name="sampleRef">
   <xsd:complexContent>
     <xsd:extension base="entityReference">
+      <xsd:attribute name="investigation.ref" type="xsd:string"/>
       <xsd:attribute name="investigation.facility.name" type="xsd:string"/>
       <xsd:attribute name="investigation.name" type="xsd:string"/>
       <xsd:attribute name="investigation.visitId" type="xsd:string"/>
@@ -317,6 +330,7 @@
 <xsd:complexType name="sampleTypeRef">
   <xsd:complexContent>
     <xsd:extension base="entityReference">
+      <xsd:attribute name="facility.ref" type="xsd:string"/>
       <xsd:attribute name="facility.name" type="xsd:string"/>
       <xsd:attribute name="name" type="xsd:string"/>
       <xsd:attribute name="molecularFormula" type="xsd:string"/>

--- a/doc/icatdata-4.7.xsd
+++ b/doc/icatdata-4.7.xsd
@@ -167,13 +167,16 @@
      reference the target object in other reference objects.
 
      The target object may either be referenced by reference key or by
-     object attributes.  In the former case, the key is given in the
-     ref attribute and other attributes SHOULD NOT be present.  The
-     reference key may either have been defined earlier in the id
-     attribute of an other entity object or reference in the same data
-     element or it must the unique key as returned by the
-     getUniqueKey() method of the target object.  In the latter case,
-     the attribute values must uniquely define the target object.
+     object attributes.  The former case is implemeted by adding a
+     special attribute "ref" to hold the key.  In this case, other
+     attributes SHOULD NOT be present.  The reference key may either
+     have been defined earlier in the id attribute of another entity
+     object or reference in the same data element or it must the
+     unique key as returned by the getUniqueKey() method of the target
+     object.  When referencing the target object by attributes, the
+     attribute values must uniquely define the target object.  In this
+     case, related objects may in turn be referenced either by
+     reference or by attributes accordingly.
 
      Note that in the case of referencing the target object by
      attribute values, this schema is somewhat too restricted: in
@@ -198,6 +201,7 @@
 <xsd:complexType name="applicationRef">
   <xsd:complexContent>
     <xsd:extension base="entityReference">
+      <xsd:attribute name="facility.ref" type="xsd:string"/>
       <xsd:attribute name="facility.name" type="xsd:string"/>
       <xsd:attribute name="name" type="xsd:string"/>
       <xsd:attribute name="version" type="xsd:string"/>
@@ -216,6 +220,7 @@
 <xsd:complexType name="datafileRef">
   <xsd:complexContent>
     <xsd:extension base="entityReference">
+      <xsd:attribute name="dataset.ref" type="xsd:string"/>
       <xsd:attribute name="dataset.investigation.facility.name" 
 		     type="xsd:string"/>
       <xsd:attribute name="dataset.investigation.name" type="xsd:string"/>
@@ -230,6 +235,7 @@
 <xsd:complexType name="datafileFormatRef">
   <xsd:complexContent>
     <xsd:extension base="entityReference">
+      <xsd:attribute name="facility.ref" type="xsd:string"/>
       <xsd:attribute name="facility.name" type="xsd:string"/>
       <xsd:attribute name="name" type="xsd:string"/>
       <xsd:attribute name="version" type="xsd:string"/>
@@ -240,6 +246,7 @@
 <xsd:complexType name="datasetRef">
   <xsd:complexContent>
     <xsd:extension base="entityReference">
+      <xsd:attribute name="investigation.ref" type="xsd:string"/>
       <xsd:attribute name="investigation.facility.name" type="xsd:string"/>
       <xsd:attribute name="investigation.name" type="xsd:string"/>
       <xsd:attribute name="investigation.visitId" type="xsd:string"/>
@@ -252,6 +259,7 @@
 <xsd:complexType name="datasetTypeRef">
   <xsd:complexContent>
     <xsd:extension base="entityReference">
+      <xsd:attribute name="facility.ref" type="xsd:string"/>
       <xsd:attribute name="facility.name" type="xsd:string"/>
       <xsd:attribute name="name" type="xsd:string"/>
     </xsd:extension>
@@ -277,6 +285,7 @@
 <xsd:complexType name="instrumentRef">
   <xsd:complexContent>
     <xsd:extension base="entityReference">
+      <xsd:attribute name="facility.ref" type="xsd:string"/>
       <xsd:attribute name="facility.name" type="xsd:string"/>
       <xsd:attribute name="name" type="xsd:string"/>
     </xsd:extension>
@@ -286,6 +295,7 @@
 <xsd:complexType name="investigationRef">
   <xsd:complexContent>
     <xsd:extension base="entityReference">
+      <xsd:attribute name="facility.ref" type="xsd:string"/>
       <xsd:attribute name="facility.name" type="xsd:string"/>
       <xsd:attribute name="name" type="xsd:string"/>
       <xsd:attribute name="visitId" type="xsd:string"/>
@@ -297,6 +307,7 @@
 <xsd:complexType name="investigationTypeRef">
   <xsd:complexContent>
     <xsd:extension base="entityReference">
+      <xsd:attribute name="facility.ref" type="xsd:string"/>
       <xsd:attribute name="facility.name" type="xsd:string"/>
       <xsd:attribute name="name" type="xsd:string"/>
     </xsd:extension>
@@ -306,6 +317,7 @@
 <xsd:complexType name="parameterTypeRef">
   <xsd:complexContent>
     <xsd:extension base="entityReference">
+      <xsd:attribute name="facility.ref" type="xsd:string"/>
       <xsd:attribute name="facility.name" type="xsd:string"/>
       <xsd:attribute name="name" type="xsd:string"/>
       <xsd:attribute name="units" type="xsd:string"/>
@@ -316,6 +328,7 @@
 <xsd:complexType name="sampleRef">
   <xsd:complexContent>
     <xsd:extension base="entityReference">
+      <xsd:attribute name="investigation.ref" type="xsd:string"/>
       <xsd:attribute name="investigation.facility.name" type="xsd:string"/>
       <xsd:attribute name="investigation.name" type="xsd:string"/>
       <xsd:attribute name="investigation.visitId" type="xsd:string"/>
@@ -327,6 +340,7 @@
 <xsd:complexType name="sampleTypeRef">
   <xsd:complexContent>
     <xsd:extension base="entityReference">
+      <xsd:attribute name="facility.ref" type="xsd:string"/>
       <xsd:attribute name="facility.name" type="xsd:string"/>
       <xsd:attribute name="name" type="xsd:string"/>
       <xsd:attribute name="molecularFormula" type="xsd:string"/>

--- a/doc/icatdata-5.0.xsd
+++ b/doc/icatdata-5.0.xsd
@@ -214,13 +214,16 @@
      reference the target object in other reference objects.
 
      The target object may either be referenced by reference key or by
-     object attributes.  In the former case, the key is given in the
-     ref attribute and other attributes SHOULD NOT be present.  The
-     reference key may either have been defined earlier in the id
-     attribute of an other entity object or reference in the same data
-     element or it must the unique key as returned by the
-     getUniqueKey() method of the target object.  In the latter case,
-     the attribute values must uniquely define the target object.
+     object attributes.  The former case is implemeted by adding a
+     special attribute "ref" to hold the key.  In this case, other
+     attributes SHOULD NOT be present.  The reference key may either
+     have been defined earlier in the id attribute of another entity
+     object or reference in the same data element or it must the
+     unique key as returned by the getUniqueKey() method of the target
+     object.  When referencing the target object by attributes, the
+     attribute values must uniquely define the target object.  In this
+     case, related objects may in turn be referenced either by
+     reference or by attributes accordingly.
 
      Note that in the case of referencing the target object by
      attribute values, this schema is somewhat too restricted: in
@@ -244,6 +247,7 @@
 <xsd:complexType name="applicationRef">
   <xsd:complexContent>
     <xsd:extension base="entityReference">
+      <xsd:attribute name="facility.ref" type="xsd:string"/>
       <xsd:attribute name="facility.name" type="xsd:string"/>
       <xsd:attribute name="name" type="xsd:string"/>
       <xsd:attribute name="version" type="xsd:string"/>
@@ -262,6 +266,7 @@
 <xsd:complexType name="dataPublicationRef">
   <xsd:complexContent>
     <xsd:extension base="entityReference">
+      <xsd:attribute name="facility.ref" type="xsd:string"/>
       <xsd:attribute name="facility.name" type="xsd:string"/>
       <xsd:attribute name="pid" type="xsd:string"/>
     </xsd:extension>
@@ -271,6 +276,7 @@
 <xsd:complexType name="dataPublicationTypeRef">
   <xsd:complexContent>
     <xsd:extension base="entityReference">
+      <xsd:attribute name="facility.ref" type="xsd:string"/>
       <xsd:attribute name="facility.name" type="xsd:string"/>
       <xsd:attribute name="name" type="xsd:string"/>
     </xsd:extension>
@@ -280,8 +286,10 @@
 <xsd:complexType name="dataPublicationUserRef">
   <xsd:complexContent>
     <xsd:extension base="entityReference">
+      <xsd:attribute name="publication.ref" type="xsd:string"/>
       <xsd:attribute name="publication.facility.name" type="xsd:string"/>
       <xsd:attribute name="publication.pid" type="xsd:string"/>
+      <xsd:attribute name="user.ref" type="xsd:string"/>
       <xsd:attribute name="user.name" type="xsd:string"/>
       <xsd:attribute name="contributorType" type="xsd:string"/>
     </xsd:extension>
@@ -291,6 +299,7 @@
 <xsd:complexType name="datafileRef">
   <xsd:complexContent>
     <xsd:extension base="entityReference">
+      <xsd:attribute name="dataset.ref" type="xsd:string"/>
       <xsd:attribute name="dataset.investigation.facility.name"
 		     type="xsd:string"/>
       <xsd:attribute name="dataset.investigation.name" type="xsd:string"/>
@@ -305,6 +314,7 @@
 <xsd:complexType name="datafileFormatRef">
   <xsd:complexContent>
     <xsd:extension base="entityReference">
+      <xsd:attribute name="facility.ref" type="xsd:string"/>
       <xsd:attribute name="facility.name" type="xsd:string"/>
       <xsd:attribute name="name" type="xsd:string"/>
       <xsd:attribute name="version" type="xsd:string"/>
@@ -315,6 +325,7 @@
 <xsd:complexType name="datasetRef">
   <xsd:complexContent>
     <xsd:extension base="entityReference">
+      <xsd:attribute name="investigation.ref" type="xsd:string"/>
       <xsd:attribute name="investigation.facility.name" type="xsd:string"/>
       <xsd:attribute name="investigation.name" type="xsd:string"/>
       <xsd:attribute name="investigation.visitId" type="xsd:string"/>
@@ -327,6 +338,7 @@
 <xsd:complexType name="datasetTypeRef">
   <xsd:complexContent>
     <xsd:extension base="entityReference">
+      <xsd:attribute name="facility.ref" type="xsd:string"/>
       <xsd:attribute name="facility.name" type="xsd:string"/>
       <xsd:attribute name="name" type="xsd:string"/>
     </xsd:extension>
@@ -344,6 +356,7 @@
 <xsd:complexType name="facilityCycleRef">
   <xsd:complexContent>
     <xsd:extension base="entityReference">
+      <xsd:attribute name="facility.ref" type="xsd:string"/>
       <xsd:attribute name="facility.name" type="xsd:string"/>
       <xsd:attribute name="name" type="xsd:string"/>
     </xsd:extension>
@@ -371,6 +384,7 @@
 <xsd:complexType name="instrumentRef">
   <xsd:complexContent>
     <xsd:extension base="entityReference">
+      <xsd:attribute name="facility.ref" type="xsd:string"/>
       <xsd:attribute name="facility.name" type="xsd:string"/>
       <xsd:attribute name="name" type="xsd:string"/>
       <xsd:attribute name="pid" type="xsd:string"/>
@@ -381,6 +395,7 @@
 <xsd:complexType name="investigationRef">
   <xsd:complexContent>
     <xsd:extension base="entityReference">
+      <xsd:attribute name="facility.ref" type="xsd:string"/>
       <xsd:attribute name="facility.name" type="xsd:string"/>
       <xsd:attribute name="name" type="xsd:string"/>
       <xsd:attribute name="visitId" type="xsd:string"/>
@@ -392,6 +407,7 @@
 <xsd:complexType name="investigationTypeRef">
   <xsd:complexContent>
     <xsd:extension base="entityReference">
+      <xsd:attribute name="facility.ref" type="xsd:string"/>
       <xsd:attribute name="facility.name" type="xsd:string"/>
       <xsd:attribute name="name" type="xsd:string"/>
     </xsd:extension>
@@ -401,6 +417,7 @@
 <xsd:complexType name="parameterTypeRef">
   <xsd:complexContent>
     <xsd:extension base="entityReference">
+      <xsd:attribute name="facility.ref" type="xsd:string"/>
       <xsd:attribute name="facility.name" type="xsd:string"/>
       <xsd:attribute name="name" type="xsd:string"/>
       <xsd:attribute name="units" type="xsd:string"/>
@@ -412,6 +429,7 @@
 <xsd:complexType name="sampleRef">
   <xsd:complexContent>
     <xsd:extension base="entityReference">
+      <xsd:attribute name="investigation.ref" type="xsd:string"/>
       <xsd:attribute name="investigation.facility.name" type="xsd:string"/>
       <xsd:attribute name="investigation.name" type="xsd:string"/>
       <xsd:attribute name="investigation.visitId" type="xsd:string"/>
@@ -424,6 +442,7 @@
 <xsd:complexType name="sampleTypeRef">
   <xsd:complexContent>
     <xsd:extension base="entityReference">
+      <xsd:attribute name="facility.ref" type="xsd:string"/>
       <xsd:attribute name="facility.name" type="xsd:string"/>
       <xsd:attribute name="name" type="xsd:string"/>
       <xsd:attribute name="molecularFormula" type="xsd:string"/>

--- a/icat/dumpfile_xml.py
+++ b/icat/dumpfile_xml.py
@@ -62,7 +62,15 @@ class XMLDumpFileReader(icat.dumpfile.DumpFileReader):
         else:
             # object is referenced by attributes.
             attrs = set(element.keys()) - {'id'}
-            conditions = { a: "= '%s'" % element.get(a) for a in attrs }
+            conditions = dict()
+            for attr in attrs:
+                if attr.endswith(".ref"):
+                    ref = element.get(attr)
+                    robj = self.client.searchUniqueKey(ref, objindex)
+                    attr = "%s.id" % attr[:-4]
+                    conditions[attr] = "= %d" % robj.id
+                else:
+                    conditions[attr] = "= '%s'" % element.get(attr)
             query = Query(self.client, objtype, conditions=conditions)
             return self.client.assertedSearch(query)[0]
 

--- a/setup.py
+++ b/setup.py
@@ -124,7 +124,8 @@ class build_test(setuptools.Command):
         files = []
         files += [ os.path.join("doc", "examples", f)
                    for f in ["example_data.yaml",
-                             "ingest-datafiles.xml", "ingest-ds-params.xml"] ]
+                             "ingest-datafiles.xml", "ingest-ds-params.xml",
+                             "ingest-sample-ds.xml"] ]
         files += [ os.path.join("doc", "examples",
                                 "icatdump-%s.%s" % (ver, ext))
                    for ver in ("4.4", "4.7", "4.10", "5.0")

--- a/tests/data/legacy-icatdump-4.10.xml
+++ b/tests/data/legacy-icatdump-4.10.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <icatdata>
 <head>
-  <date>2022-12-04T19:31:45+00:00</date>
+  <date>2023-10-16T14:48:15+00:00</date>
   <service>https://icat.example.com:8181/ICATService/ICAT?wsdl</service>
   <apiversion>4.10</apiversion>
   <generator>icatdump (python-icat 0.21.0)</generator>
@@ -431,226 +431,231 @@
     <grouping ref="Grouping_name-ingest"/>
   </rule>
   <rule id="Rule_00000066">
-    <crudFlags>R</crudFlags>
-    <what>Shift</what>
+    <crudFlags>CRU</crudFlags>
+    <what>Sample</what>
     <grouping ref="Grouping_name-ingest"/>
   </rule>
   <rule id="Rule_00000067">
     <crudFlags>R</crudFlags>
-    <what>DataCollection</what>
-    <grouping ref="Grouping_name-rall"/>
+    <what>Shift</what>
+    <grouping ref="Grouping_name-ingest"/>
   </rule>
   <rule id="Rule_00000068">
     <crudFlags>R</crudFlags>
-    <what>DataCollectionDatafile</what>
+    <what>DataCollection</what>
     <grouping ref="Grouping_name-rall"/>
   </rule>
   <rule id="Rule_00000069">
     <crudFlags>R</crudFlags>
-    <what>DataCollectionDataset</what>
+    <what>DataCollectionDatafile</what>
     <grouping ref="Grouping_name-rall"/>
   </rule>
   <rule id="Rule_00000070">
     <crudFlags>R</crudFlags>
-    <what>DataCollectionParameter</what>
+    <what>DataCollectionDataset</what>
     <grouping ref="Grouping_name-rall"/>
   </rule>
   <rule id="Rule_00000071">
     <crudFlags>R</crudFlags>
-    <what>Datafile</what>
+    <what>DataCollectionParameter</what>
     <grouping ref="Grouping_name-rall"/>
   </rule>
   <rule id="Rule_00000072">
     <crudFlags>R</crudFlags>
-    <what>DatafileParameter</what>
+    <what>Datafile</what>
     <grouping ref="Grouping_name-rall"/>
   </rule>
   <rule id="Rule_00000073">
     <crudFlags>R</crudFlags>
-    <what>Dataset</what>
+    <what>DatafileParameter</what>
     <grouping ref="Grouping_name-rall"/>
   </rule>
   <rule id="Rule_00000074">
     <crudFlags>R</crudFlags>
-    <what>DatasetParameter</what>
+    <what>Dataset</what>
     <grouping ref="Grouping_name-rall"/>
   </rule>
   <rule id="Rule_00000075">
     <crudFlags>R</crudFlags>
-    <what>Grouping</what>
+    <what>DatasetParameter</what>
     <grouping ref="Grouping_name-rall"/>
   </rule>
   <rule id="Rule_00000076">
     <crudFlags>R</crudFlags>
-    <what>InstrumentScientist</what>
+    <what>Grouping</what>
     <grouping ref="Grouping_name-rall"/>
   </rule>
   <rule id="Rule_00000077">
     <crudFlags>R</crudFlags>
-    <what>Investigation</what>
+    <what>InstrumentScientist</what>
     <grouping ref="Grouping_name-rall"/>
   </rule>
   <rule id="Rule_00000078">
     <crudFlags>R</crudFlags>
-    <what>InvestigationGroup</what>
+    <what>Investigation</what>
     <grouping ref="Grouping_name-rall"/>
   </rule>
   <rule id="Rule_00000079">
     <crudFlags>R</crudFlags>
-    <what>InvestigationInstrument</what>
+    <what>InvestigationGroup</what>
     <grouping ref="Grouping_name-rall"/>
   </rule>
   <rule id="Rule_00000080">
     <crudFlags>R</crudFlags>
-    <what>InvestigationParameter</what>
+    <what>InvestigationInstrument</what>
     <grouping ref="Grouping_name-rall"/>
   </rule>
   <rule id="Rule_00000081">
     <crudFlags>R</crudFlags>
-    <what>InvestigationUser</what>
+    <what>InvestigationParameter</what>
     <grouping ref="Grouping_name-rall"/>
   </rule>
   <rule id="Rule_00000082">
     <crudFlags>R</crudFlags>
-    <what>Job</what>
+    <what>InvestigationUser</what>
     <grouping ref="Grouping_name-rall"/>
   </rule>
   <rule id="Rule_00000083">
     <crudFlags>R</crudFlags>
-    <what>Keyword</what>
+    <what>Job</what>
     <grouping ref="Grouping_name-rall"/>
   </rule>
   <rule id="Rule_00000084">
     <crudFlags>R</crudFlags>
-    <what>PublicStep</what>
+    <what>Keyword</what>
     <grouping ref="Grouping_name-rall"/>
   </rule>
   <rule id="Rule_00000085">
     <crudFlags>R</crudFlags>
-    <what>Publication</what>
+    <what>PublicStep</what>
     <grouping ref="Grouping_name-rall"/>
   </rule>
   <rule id="Rule_00000086">
     <crudFlags>R</crudFlags>
-    <what>RelatedDatafile</what>
+    <what>Publication</what>
     <grouping ref="Grouping_name-rall"/>
   </rule>
   <rule id="Rule_00000087">
     <crudFlags>R</crudFlags>
-    <what>Rule</what>
+    <what>RelatedDatafile</what>
     <grouping ref="Grouping_name-rall"/>
   </rule>
   <rule id="Rule_00000088">
     <crudFlags>R</crudFlags>
-    <what>Sample</what>
+    <what>Rule</what>
     <grouping ref="Grouping_name-rall"/>
   </rule>
   <rule id="Rule_00000089">
     <crudFlags>R</crudFlags>
-    <what>SampleParameter</what>
+    <what>Sample</what>
     <grouping ref="Grouping_name-rall"/>
   </rule>
   <rule id="Rule_00000090">
     <crudFlags>R</crudFlags>
-    <what>Shift</what>
+    <what>SampleParameter</what>
     <grouping ref="Grouping_name-rall"/>
   </rule>
   <rule id="Rule_00000091">
     <crudFlags>R</crudFlags>
-    <what>Study</what>
+    <what>Shift</what>
     <grouping ref="Grouping_name-rall"/>
   </rule>
   <rule id="Rule_00000092">
     <crudFlags>R</crudFlags>
-    <what>StudyInvestigation</what>
+    <what>Study</what>
     <grouping ref="Grouping_name-rall"/>
   </rule>
   <rule id="Rule_00000093">
     <crudFlags>R</crudFlags>
-    <what>UserGroup</what>
+    <what>StudyInvestigation</what>
     <grouping ref="Grouping_name-rall"/>
   </rule>
   <rule id="Rule_00000094">
+    <crudFlags>R</crudFlags>
+    <what>UserGroup</what>
+    <grouping ref="Grouping_name-rall"/>
+  </rule>
+  <rule id="Rule_00000095">
     <crudFlags>RU</crudFlags>
     <what>Sample</what>
     <grouping ref="Grouping_name-scientific=5Fstaff"/>
   </rule>
-  <rule id="Rule_00000095">
+  <rule id="Rule_00000096">
     <crudFlags>UD</crudFlags>
     <what>SampleType</what>
     <grouping ref="Grouping_name-scientific=5Fstaff"/>
   </rule>
-  <rule id="Rule_00000096">
+  <rule id="Rule_00000097">
     <crudFlags>CRUD</crudFlags>
     <what>FacilityCycle</what>
     <grouping ref="Grouping_name-useroffice"/>
   </rule>
-  <rule id="Rule_00000097">
+  <rule id="Rule_00000098">
     <crudFlags>CRUD</crudFlags>
     <what>Grouping</what>
     <grouping ref="Grouping_name-useroffice"/>
   </rule>
-  <rule id="Rule_00000098">
+  <rule id="Rule_00000099">
     <crudFlags>CRUD</crudFlags>
     <what>InstrumentScientist</what>
     <grouping ref="Grouping_name-useroffice"/>
   </rule>
-  <rule id="Rule_00000099">
+  <rule id="Rule_00000100">
     <crudFlags>CRUD</crudFlags>
     <what>Investigation</what>
     <grouping ref="Grouping_name-useroffice"/>
   </rule>
-  <rule id="Rule_00000100">
+  <rule id="Rule_00000101">
     <crudFlags>CRUD</crudFlags>
     <what>InvestigationGroup</what>
     <grouping ref="Grouping_name-useroffice"/>
   </rule>
-  <rule id="Rule_00000101">
+  <rule id="Rule_00000102">
     <crudFlags>CRUD</crudFlags>
     <what>InvestigationInstrument</what>
     <grouping ref="Grouping_name-useroffice"/>
   </rule>
-  <rule id="Rule_00000102">
+  <rule id="Rule_00000103">
     <crudFlags>CRUD</crudFlags>
     <what>InvestigationParameter</what>
     <grouping ref="Grouping_name-useroffice"/>
   </rule>
-  <rule id="Rule_00000103">
+  <rule id="Rule_00000104">
     <crudFlags>CRUD</crudFlags>
     <what>InvestigationUser</what>
     <grouping ref="Grouping_name-useroffice"/>
   </rule>
-  <rule id="Rule_00000104">
+  <rule id="Rule_00000105">
     <crudFlags>CRUD</crudFlags>
     <what>Keyword</what>
     <grouping ref="Grouping_name-useroffice"/>
   </rule>
-  <rule id="Rule_00000105">
+  <rule id="Rule_00000106">
     <crudFlags>CRUD</crudFlags>
     <what>Publication</what>
     <grouping ref="Grouping_name-useroffice"/>
   </rule>
-  <rule id="Rule_00000106">
+  <rule id="Rule_00000107">
     <crudFlags>CRUD</crudFlags>
     <what>Shift</what>
     <grouping ref="Grouping_name-useroffice"/>
   </rule>
-  <rule id="Rule_00000107">
+  <rule id="Rule_00000108">
     <crudFlags>CRUD</crudFlags>
     <what>Study</what>
     <grouping ref="Grouping_name-useroffice"/>
   </rule>
-  <rule id="Rule_00000108">
+  <rule id="Rule_00000109">
     <crudFlags>CRUD</crudFlags>
     <what>StudyInvestigation</what>
     <grouping ref="Grouping_name-useroffice"/>
   </rule>
-  <rule id="Rule_00000109">
+  <rule id="Rule_00000110">
     <crudFlags>CRUD</crudFlags>
     <what>User</what>
     <grouping ref="Grouping_name-useroffice"/>
   </rule>
-  <rule id="Rule_00000110">
+  <rule id="Rule_00000111">
     <crudFlags>CRUD</crudFlags>
     <what>UserGroup</what>
     <grouping ref="Grouping_name-useroffice"/>

--- a/tests/data/legacy-icatdump-4.10.yaml
+++ b/tests/data/legacy-icatdump-4.10.yaml
@@ -1,5 +1,5 @@
 %YAML 1.1
-# Date: Sun, 04 Dec 2022 19:31:43 +0000
+# Date: Mon, 16 Oct 2023 14:48:11 +0000
 # Service: https://icat.example.com:8181/ICATService/ICAT?wsdl
 # ICAT-API: 4.10
 # Generator: icatdump (python-icat 0.21.0)
@@ -421,182 +421,186 @@ rule:
     grouping: Grouping_name-ingest
     what: Investigation
   Rule_00000066:
+    crudFlags: CRU
+    grouping: Grouping_name-ingest
+    what: Sample
+  Rule_00000067:
     crudFlags: R
     grouping: Grouping_name-ingest
     what: Shift
-  Rule_00000067:
-    crudFlags: R
-    grouping: Grouping_name-rall
-    what: DataCollection
   Rule_00000068:
     crudFlags: R
     grouping: Grouping_name-rall
-    what: DataCollectionDatafile
+    what: DataCollection
   Rule_00000069:
     crudFlags: R
     grouping: Grouping_name-rall
-    what: DataCollectionDataset
+    what: DataCollectionDatafile
   Rule_00000070:
     crudFlags: R
     grouping: Grouping_name-rall
-    what: DataCollectionParameter
+    what: DataCollectionDataset
   Rule_00000071:
     crudFlags: R
     grouping: Grouping_name-rall
-    what: Datafile
+    what: DataCollectionParameter
   Rule_00000072:
     crudFlags: R
     grouping: Grouping_name-rall
-    what: DatafileParameter
+    what: Datafile
   Rule_00000073:
     crudFlags: R
     grouping: Grouping_name-rall
-    what: Dataset
+    what: DatafileParameter
   Rule_00000074:
     crudFlags: R
     grouping: Grouping_name-rall
-    what: DatasetParameter
+    what: Dataset
   Rule_00000075:
     crudFlags: R
     grouping: Grouping_name-rall
-    what: Grouping
+    what: DatasetParameter
   Rule_00000076:
     crudFlags: R
     grouping: Grouping_name-rall
-    what: InstrumentScientist
+    what: Grouping
   Rule_00000077:
     crudFlags: R
     grouping: Grouping_name-rall
-    what: Investigation
+    what: InstrumentScientist
   Rule_00000078:
     crudFlags: R
     grouping: Grouping_name-rall
-    what: InvestigationGroup
+    what: Investigation
   Rule_00000079:
     crudFlags: R
     grouping: Grouping_name-rall
-    what: InvestigationInstrument
+    what: InvestigationGroup
   Rule_00000080:
     crudFlags: R
     grouping: Grouping_name-rall
-    what: InvestigationParameter
+    what: InvestigationInstrument
   Rule_00000081:
     crudFlags: R
     grouping: Grouping_name-rall
-    what: InvestigationUser
+    what: InvestigationParameter
   Rule_00000082:
     crudFlags: R
     grouping: Grouping_name-rall
-    what: Job
+    what: InvestigationUser
   Rule_00000083:
     crudFlags: R
     grouping: Grouping_name-rall
-    what: Keyword
+    what: Job
   Rule_00000084:
     crudFlags: R
     grouping: Grouping_name-rall
-    what: PublicStep
+    what: Keyword
   Rule_00000085:
     crudFlags: R
     grouping: Grouping_name-rall
-    what: Publication
+    what: PublicStep
   Rule_00000086:
     crudFlags: R
     grouping: Grouping_name-rall
-    what: RelatedDatafile
+    what: Publication
   Rule_00000087:
     crudFlags: R
     grouping: Grouping_name-rall
-    what: Rule
+    what: RelatedDatafile
   Rule_00000088:
     crudFlags: R
     grouping: Grouping_name-rall
-    what: Sample
+    what: Rule
   Rule_00000089:
     crudFlags: R
     grouping: Grouping_name-rall
-    what: SampleParameter
+    what: Sample
   Rule_00000090:
     crudFlags: R
     grouping: Grouping_name-rall
-    what: Shift
+    what: SampleParameter
   Rule_00000091:
     crudFlags: R
     grouping: Grouping_name-rall
-    what: Study
+    what: Shift
   Rule_00000092:
     crudFlags: R
     grouping: Grouping_name-rall
-    what: StudyInvestigation
+    what: Study
   Rule_00000093:
     crudFlags: R
     grouping: Grouping_name-rall
-    what: UserGroup
+    what: StudyInvestigation
   Rule_00000094:
+    crudFlags: R
+    grouping: Grouping_name-rall
+    what: UserGroup
+  Rule_00000095:
     crudFlags: RU
     grouping: Grouping_name-scientific=5Fstaff
     what: Sample
-  Rule_00000095:
+  Rule_00000096:
     crudFlags: UD
     grouping: Grouping_name-scientific=5Fstaff
     what: SampleType
-  Rule_00000096:
-    crudFlags: CRUD
-    grouping: Grouping_name-useroffice
-    what: FacilityCycle
   Rule_00000097:
     crudFlags: CRUD
     grouping: Grouping_name-useroffice
-    what: Grouping
+    what: FacilityCycle
   Rule_00000098:
     crudFlags: CRUD
     grouping: Grouping_name-useroffice
-    what: InstrumentScientist
+    what: Grouping
   Rule_00000099:
     crudFlags: CRUD
     grouping: Grouping_name-useroffice
-    what: Investigation
+    what: InstrumentScientist
   Rule_00000100:
     crudFlags: CRUD
     grouping: Grouping_name-useroffice
-    what: InvestigationGroup
+    what: Investigation
   Rule_00000101:
     crudFlags: CRUD
     grouping: Grouping_name-useroffice
-    what: InvestigationInstrument
+    what: InvestigationGroup
   Rule_00000102:
     crudFlags: CRUD
     grouping: Grouping_name-useroffice
-    what: InvestigationParameter
+    what: InvestigationInstrument
   Rule_00000103:
     crudFlags: CRUD
     grouping: Grouping_name-useroffice
-    what: InvestigationUser
+    what: InvestigationParameter
   Rule_00000104:
     crudFlags: CRUD
     grouping: Grouping_name-useroffice
-    what: Keyword
+    what: InvestigationUser
   Rule_00000105:
     crudFlags: CRUD
     grouping: Grouping_name-useroffice
-    what: Publication
+    what: Keyword
   Rule_00000106:
     crudFlags: CRUD
     grouping: Grouping_name-useroffice
-    what: Shift
+    what: Publication
   Rule_00000107:
     crudFlags: CRUD
     grouping: Grouping_name-useroffice
-    what: Study
+    what: Shift
   Rule_00000108:
     crudFlags: CRUD
     grouping: Grouping_name-useroffice
-    what: StudyInvestigation
+    what: Study
   Rule_00000109:
     crudFlags: CRUD
     grouping: Grouping_name-useroffice
-    what: User
+    what: StudyInvestigation
   Rule_00000110:
+    crudFlags: CRUD
+    grouping: Grouping_name-useroffice
+    what: User
+  Rule_00000111:
     crudFlags: CRUD
     grouping: Grouping_name-useroffice
     what: UserGroup

--- a/tests/data/legacy-icatdump-4.4.xml
+++ b/tests/data/legacy-icatdump-4.4.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <icatdata>
 <head>
-  <date>2022-12-04T19:02:46+00:00</date>
+  <date>2023-10-16T14:20:21+00:00</date>
   <service>https://icat.example.com:8181/ICATService/ICAT?wsdl</service>
   <apiversion>4.4</apiversion>
   <generator>icatdump (python-icat 0.21.0)</generator>
@@ -403,226 +403,231 @@
     <grouping ref="Grouping_name-ingest"/>
   </rule>
   <rule id="Rule_00000066">
-    <crudFlags>R</crudFlags>
-    <what>Shift</what>
+    <crudFlags>CRU</crudFlags>
+    <what>Sample</what>
     <grouping ref="Grouping_name-ingest"/>
   </rule>
   <rule id="Rule_00000067">
     <crudFlags>R</crudFlags>
-    <what>DataCollection</what>
-    <grouping ref="Grouping_name-rall"/>
+    <what>Shift</what>
+    <grouping ref="Grouping_name-ingest"/>
   </rule>
   <rule id="Rule_00000068">
     <crudFlags>R</crudFlags>
-    <what>DataCollectionDatafile</what>
+    <what>DataCollection</what>
     <grouping ref="Grouping_name-rall"/>
   </rule>
   <rule id="Rule_00000069">
     <crudFlags>R</crudFlags>
-    <what>DataCollectionDataset</what>
+    <what>DataCollectionDatafile</what>
     <grouping ref="Grouping_name-rall"/>
   </rule>
   <rule id="Rule_00000070">
     <crudFlags>R</crudFlags>
-    <what>DataCollectionParameter</what>
+    <what>DataCollectionDataset</what>
     <grouping ref="Grouping_name-rall"/>
   </rule>
   <rule id="Rule_00000071">
     <crudFlags>R</crudFlags>
-    <what>Datafile</what>
+    <what>DataCollectionParameter</what>
     <grouping ref="Grouping_name-rall"/>
   </rule>
   <rule id="Rule_00000072">
     <crudFlags>R</crudFlags>
-    <what>DatafileParameter</what>
+    <what>Datafile</what>
     <grouping ref="Grouping_name-rall"/>
   </rule>
   <rule id="Rule_00000073">
     <crudFlags>R</crudFlags>
-    <what>Dataset</what>
+    <what>DatafileParameter</what>
     <grouping ref="Grouping_name-rall"/>
   </rule>
   <rule id="Rule_00000074">
     <crudFlags>R</crudFlags>
-    <what>DatasetParameter</what>
+    <what>Dataset</what>
     <grouping ref="Grouping_name-rall"/>
   </rule>
   <rule id="Rule_00000075">
     <crudFlags>R</crudFlags>
-    <what>Grouping</what>
+    <what>DatasetParameter</what>
     <grouping ref="Grouping_name-rall"/>
   </rule>
   <rule id="Rule_00000076">
     <crudFlags>R</crudFlags>
-    <what>InstrumentScientist</what>
+    <what>Grouping</what>
     <grouping ref="Grouping_name-rall"/>
   </rule>
   <rule id="Rule_00000077">
     <crudFlags>R</crudFlags>
-    <what>Investigation</what>
+    <what>InstrumentScientist</what>
     <grouping ref="Grouping_name-rall"/>
   </rule>
   <rule id="Rule_00000078">
     <crudFlags>R</crudFlags>
-    <what>InvestigationGroup</what>
+    <what>Investigation</what>
     <grouping ref="Grouping_name-rall"/>
   </rule>
   <rule id="Rule_00000079">
     <crudFlags>R</crudFlags>
-    <what>InvestigationInstrument</what>
+    <what>InvestigationGroup</what>
     <grouping ref="Grouping_name-rall"/>
   </rule>
   <rule id="Rule_00000080">
     <crudFlags>R</crudFlags>
-    <what>InvestigationParameter</what>
+    <what>InvestigationInstrument</what>
     <grouping ref="Grouping_name-rall"/>
   </rule>
   <rule id="Rule_00000081">
     <crudFlags>R</crudFlags>
-    <what>InvestigationUser</what>
+    <what>InvestigationParameter</what>
     <grouping ref="Grouping_name-rall"/>
   </rule>
   <rule id="Rule_00000082">
     <crudFlags>R</crudFlags>
-    <what>Job</what>
+    <what>InvestigationUser</what>
     <grouping ref="Grouping_name-rall"/>
   </rule>
   <rule id="Rule_00000083">
     <crudFlags>R</crudFlags>
-    <what>Keyword</what>
+    <what>Job</what>
     <grouping ref="Grouping_name-rall"/>
   </rule>
   <rule id="Rule_00000084">
     <crudFlags>R</crudFlags>
-    <what>PublicStep</what>
+    <what>Keyword</what>
     <grouping ref="Grouping_name-rall"/>
   </rule>
   <rule id="Rule_00000085">
     <crudFlags>R</crudFlags>
-    <what>Publication</what>
+    <what>PublicStep</what>
     <grouping ref="Grouping_name-rall"/>
   </rule>
   <rule id="Rule_00000086">
     <crudFlags>R</crudFlags>
-    <what>RelatedDatafile</what>
+    <what>Publication</what>
     <grouping ref="Grouping_name-rall"/>
   </rule>
   <rule id="Rule_00000087">
     <crudFlags>R</crudFlags>
-    <what>Rule</what>
+    <what>RelatedDatafile</what>
     <grouping ref="Grouping_name-rall"/>
   </rule>
   <rule id="Rule_00000088">
     <crudFlags>R</crudFlags>
-    <what>Sample</what>
+    <what>Rule</what>
     <grouping ref="Grouping_name-rall"/>
   </rule>
   <rule id="Rule_00000089">
     <crudFlags>R</crudFlags>
-    <what>SampleParameter</what>
+    <what>Sample</what>
     <grouping ref="Grouping_name-rall"/>
   </rule>
   <rule id="Rule_00000090">
     <crudFlags>R</crudFlags>
-    <what>Shift</what>
+    <what>SampleParameter</what>
     <grouping ref="Grouping_name-rall"/>
   </rule>
   <rule id="Rule_00000091">
     <crudFlags>R</crudFlags>
-    <what>Study</what>
+    <what>Shift</what>
     <grouping ref="Grouping_name-rall"/>
   </rule>
   <rule id="Rule_00000092">
     <crudFlags>R</crudFlags>
-    <what>StudyInvestigation</what>
+    <what>Study</what>
     <grouping ref="Grouping_name-rall"/>
   </rule>
   <rule id="Rule_00000093">
     <crudFlags>R</crudFlags>
-    <what>UserGroup</what>
+    <what>StudyInvestigation</what>
     <grouping ref="Grouping_name-rall"/>
   </rule>
   <rule id="Rule_00000094">
+    <crudFlags>R</crudFlags>
+    <what>UserGroup</what>
+    <grouping ref="Grouping_name-rall"/>
+  </rule>
+  <rule id="Rule_00000095">
     <crudFlags>RU</crudFlags>
     <what>Sample</what>
     <grouping ref="Grouping_name-scientific=5Fstaff"/>
   </rule>
-  <rule id="Rule_00000095">
+  <rule id="Rule_00000096">
     <crudFlags>UD</crudFlags>
     <what>SampleType</what>
     <grouping ref="Grouping_name-scientific=5Fstaff"/>
   </rule>
-  <rule id="Rule_00000096">
+  <rule id="Rule_00000097">
     <crudFlags>CRUD</crudFlags>
     <what>FacilityCycle</what>
     <grouping ref="Grouping_name-useroffice"/>
   </rule>
-  <rule id="Rule_00000097">
+  <rule id="Rule_00000098">
     <crudFlags>CRUD</crudFlags>
     <what>Grouping</what>
     <grouping ref="Grouping_name-useroffice"/>
   </rule>
-  <rule id="Rule_00000098">
+  <rule id="Rule_00000099">
     <crudFlags>CRUD</crudFlags>
     <what>InstrumentScientist</what>
     <grouping ref="Grouping_name-useroffice"/>
   </rule>
-  <rule id="Rule_00000099">
+  <rule id="Rule_00000100">
     <crudFlags>CRUD</crudFlags>
     <what>Investigation</what>
     <grouping ref="Grouping_name-useroffice"/>
   </rule>
-  <rule id="Rule_00000100">
+  <rule id="Rule_00000101">
     <crudFlags>CRUD</crudFlags>
     <what>InvestigationGroup</what>
     <grouping ref="Grouping_name-useroffice"/>
   </rule>
-  <rule id="Rule_00000101">
+  <rule id="Rule_00000102">
     <crudFlags>CRUD</crudFlags>
     <what>InvestigationInstrument</what>
     <grouping ref="Grouping_name-useroffice"/>
   </rule>
-  <rule id="Rule_00000102">
+  <rule id="Rule_00000103">
     <crudFlags>CRUD</crudFlags>
     <what>InvestigationParameter</what>
     <grouping ref="Grouping_name-useroffice"/>
   </rule>
-  <rule id="Rule_00000103">
+  <rule id="Rule_00000104">
     <crudFlags>CRUD</crudFlags>
     <what>InvestigationUser</what>
     <grouping ref="Grouping_name-useroffice"/>
   </rule>
-  <rule id="Rule_00000104">
+  <rule id="Rule_00000105">
     <crudFlags>CRUD</crudFlags>
     <what>Keyword</what>
     <grouping ref="Grouping_name-useroffice"/>
   </rule>
-  <rule id="Rule_00000105">
+  <rule id="Rule_00000106">
     <crudFlags>CRUD</crudFlags>
     <what>Publication</what>
     <grouping ref="Grouping_name-useroffice"/>
   </rule>
-  <rule id="Rule_00000106">
+  <rule id="Rule_00000107">
     <crudFlags>CRUD</crudFlags>
     <what>Shift</what>
     <grouping ref="Grouping_name-useroffice"/>
   </rule>
-  <rule id="Rule_00000107">
+  <rule id="Rule_00000108">
     <crudFlags>CRUD</crudFlags>
     <what>Study</what>
     <grouping ref="Grouping_name-useroffice"/>
   </rule>
-  <rule id="Rule_00000108">
+  <rule id="Rule_00000109">
     <crudFlags>CRUD</crudFlags>
     <what>StudyInvestigation</what>
     <grouping ref="Grouping_name-useroffice"/>
   </rule>
-  <rule id="Rule_00000109">
+  <rule id="Rule_00000110">
     <crudFlags>CRUD</crudFlags>
     <what>User</what>
     <grouping ref="Grouping_name-useroffice"/>
   </rule>
-  <rule id="Rule_00000110">
+  <rule id="Rule_00000111">
     <crudFlags>CRUD</crudFlags>
     <what>UserGroup</what>
     <grouping ref="Grouping_name-useroffice"/>

--- a/tests/data/legacy-icatdump-4.4.yaml
+++ b/tests/data/legacy-icatdump-4.4.yaml
@@ -1,5 +1,5 @@
 %YAML 1.1
-# Date: Sun, 04 Dec 2022 19:02:35 +0000
+# Date: Mon, 16 Oct 2023 14:20:09 +0000
 # Service: https://icat.example.com:8181/ICATService/ICAT?wsdl
 # ICAT-API: 4.4
 # Generator: icatdump (python-icat 0.21.0)
@@ -421,182 +421,186 @@ rule:
     grouping: Grouping_name-ingest
     what: Investigation
   Rule_00000066:
+    crudFlags: CRU
+    grouping: Grouping_name-ingest
+    what: Sample
+  Rule_00000067:
     crudFlags: R
     grouping: Grouping_name-ingest
     what: Shift
-  Rule_00000067:
-    crudFlags: R
-    grouping: Grouping_name-rall
-    what: DataCollection
   Rule_00000068:
     crudFlags: R
     grouping: Grouping_name-rall
-    what: DataCollectionDatafile
+    what: DataCollection
   Rule_00000069:
     crudFlags: R
     grouping: Grouping_name-rall
-    what: DataCollectionDataset
+    what: DataCollectionDatafile
   Rule_00000070:
     crudFlags: R
     grouping: Grouping_name-rall
-    what: DataCollectionParameter
+    what: DataCollectionDataset
   Rule_00000071:
     crudFlags: R
     grouping: Grouping_name-rall
-    what: Datafile
+    what: DataCollectionParameter
   Rule_00000072:
     crudFlags: R
     grouping: Grouping_name-rall
-    what: DatafileParameter
+    what: Datafile
   Rule_00000073:
     crudFlags: R
     grouping: Grouping_name-rall
-    what: Dataset
+    what: DatafileParameter
   Rule_00000074:
     crudFlags: R
     grouping: Grouping_name-rall
-    what: DatasetParameter
+    what: Dataset
   Rule_00000075:
     crudFlags: R
     grouping: Grouping_name-rall
-    what: Grouping
+    what: DatasetParameter
   Rule_00000076:
     crudFlags: R
     grouping: Grouping_name-rall
-    what: InstrumentScientist
+    what: Grouping
   Rule_00000077:
     crudFlags: R
     grouping: Grouping_name-rall
-    what: Investigation
+    what: InstrumentScientist
   Rule_00000078:
     crudFlags: R
     grouping: Grouping_name-rall
-    what: InvestigationGroup
+    what: Investigation
   Rule_00000079:
     crudFlags: R
     grouping: Grouping_name-rall
-    what: InvestigationInstrument
+    what: InvestigationGroup
   Rule_00000080:
     crudFlags: R
     grouping: Grouping_name-rall
-    what: InvestigationParameter
+    what: InvestigationInstrument
   Rule_00000081:
     crudFlags: R
     grouping: Grouping_name-rall
-    what: InvestigationUser
+    what: InvestigationParameter
   Rule_00000082:
     crudFlags: R
     grouping: Grouping_name-rall
-    what: Job
+    what: InvestigationUser
   Rule_00000083:
     crudFlags: R
     grouping: Grouping_name-rall
-    what: Keyword
+    what: Job
   Rule_00000084:
     crudFlags: R
     grouping: Grouping_name-rall
-    what: PublicStep
+    what: Keyword
   Rule_00000085:
     crudFlags: R
     grouping: Grouping_name-rall
-    what: Publication
+    what: PublicStep
   Rule_00000086:
     crudFlags: R
     grouping: Grouping_name-rall
-    what: RelatedDatafile
+    what: Publication
   Rule_00000087:
     crudFlags: R
     grouping: Grouping_name-rall
-    what: Rule
+    what: RelatedDatafile
   Rule_00000088:
     crudFlags: R
     grouping: Grouping_name-rall
-    what: Sample
+    what: Rule
   Rule_00000089:
     crudFlags: R
     grouping: Grouping_name-rall
-    what: SampleParameter
+    what: Sample
   Rule_00000090:
     crudFlags: R
     grouping: Grouping_name-rall
-    what: Shift
+    what: SampleParameter
   Rule_00000091:
     crudFlags: R
     grouping: Grouping_name-rall
-    what: Study
+    what: Shift
   Rule_00000092:
     crudFlags: R
     grouping: Grouping_name-rall
-    what: StudyInvestigation
+    what: Study
   Rule_00000093:
     crudFlags: R
     grouping: Grouping_name-rall
-    what: UserGroup
+    what: StudyInvestigation
   Rule_00000094:
+    crudFlags: R
+    grouping: Grouping_name-rall
+    what: UserGroup
+  Rule_00000095:
     crudFlags: RU
     grouping: Grouping_name-scientific=5Fstaff
     what: Sample
-  Rule_00000095:
+  Rule_00000096:
     crudFlags: UD
     grouping: Grouping_name-scientific=5Fstaff
     what: SampleType
-  Rule_00000096:
-    crudFlags: CRUD
-    grouping: Grouping_name-useroffice
-    what: FacilityCycle
   Rule_00000097:
     crudFlags: CRUD
     grouping: Grouping_name-useroffice
-    what: Grouping
+    what: FacilityCycle
   Rule_00000098:
     crudFlags: CRUD
     grouping: Grouping_name-useroffice
-    what: InstrumentScientist
+    what: Grouping
   Rule_00000099:
     crudFlags: CRUD
     grouping: Grouping_name-useroffice
-    what: Investigation
+    what: InstrumentScientist
   Rule_00000100:
     crudFlags: CRUD
     grouping: Grouping_name-useroffice
-    what: InvestigationGroup
+    what: Investigation
   Rule_00000101:
     crudFlags: CRUD
     grouping: Grouping_name-useroffice
-    what: InvestigationInstrument
+    what: InvestigationGroup
   Rule_00000102:
     crudFlags: CRUD
     grouping: Grouping_name-useroffice
-    what: InvestigationParameter
+    what: InvestigationInstrument
   Rule_00000103:
     crudFlags: CRUD
     grouping: Grouping_name-useroffice
-    what: InvestigationUser
+    what: InvestigationParameter
   Rule_00000104:
     crudFlags: CRUD
     grouping: Grouping_name-useroffice
-    what: Keyword
+    what: InvestigationUser
   Rule_00000105:
     crudFlags: CRUD
     grouping: Grouping_name-useroffice
-    what: Publication
+    what: Keyword
   Rule_00000106:
     crudFlags: CRUD
     grouping: Grouping_name-useroffice
-    what: Shift
+    what: Publication
   Rule_00000107:
     crudFlags: CRUD
     grouping: Grouping_name-useroffice
-    what: Study
+    what: Shift
   Rule_00000108:
     crudFlags: CRUD
     grouping: Grouping_name-useroffice
-    what: StudyInvestigation
+    what: Study
   Rule_00000109:
     crudFlags: CRUD
     grouping: Grouping_name-useroffice
-    what: User
+    what: StudyInvestigation
   Rule_00000110:
+    crudFlags: CRUD
+    grouping: Grouping_name-useroffice
+    what: User
+  Rule_00000111:
     crudFlags: CRUD
     grouping: Grouping_name-useroffice
     what: UserGroup

--- a/tests/data/legacy-icatdump-4.7.xml
+++ b/tests/data/legacy-icatdump-4.7.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <icatdata>
 <head>
-  <date>2022-12-04T19:18:32+00:00</date>
+  <date>2023-10-16T14:34:50+00:00</date>
   <service>https://icat.example.com:8181/ICATService/ICAT?wsdl</service>
   <apiversion>4.7</apiversion>
   <generator>icatdump (python-icat 0.21.0)</generator>
@@ -414,226 +414,231 @@
     <grouping ref="Grouping_name-ingest"/>
   </rule>
   <rule id="Rule_00000066">
-    <crudFlags>R</crudFlags>
-    <what>Shift</what>
+    <crudFlags>CRU</crudFlags>
+    <what>Sample</what>
     <grouping ref="Grouping_name-ingest"/>
   </rule>
   <rule id="Rule_00000067">
     <crudFlags>R</crudFlags>
-    <what>DataCollection</what>
-    <grouping ref="Grouping_name-rall"/>
+    <what>Shift</what>
+    <grouping ref="Grouping_name-ingest"/>
   </rule>
   <rule id="Rule_00000068">
     <crudFlags>R</crudFlags>
-    <what>DataCollectionDatafile</what>
+    <what>DataCollection</what>
     <grouping ref="Grouping_name-rall"/>
   </rule>
   <rule id="Rule_00000069">
     <crudFlags>R</crudFlags>
-    <what>DataCollectionDataset</what>
+    <what>DataCollectionDatafile</what>
     <grouping ref="Grouping_name-rall"/>
   </rule>
   <rule id="Rule_00000070">
     <crudFlags>R</crudFlags>
-    <what>DataCollectionParameter</what>
+    <what>DataCollectionDataset</what>
     <grouping ref="Grouping_name-rall"/>
   </rule>
   <rule id="Rule_00000071">
     <crudFlags>R</crudFlags>
-    <what>Datafile</what>
+    <what>DataCollectionParameter</what>
     <grouping ref="Grouping_name-rall"/>
   </rule>
   <rule id="Rule_00000072">
     <crudFlags>R</crudFlags>
-    <what>DatafileParameter</what>
+    <what>Datafile</what>
     <grouping ref="Grouping_name-rall"/>
   </rule>
   <rule id="Rule_00000073">
     <crudFlags>R</crudFlags>
-    <what>Dataset</what>
+    <what>DatafileParameter</what>
     <grouping ref="Grouping_name-rall"/>
   </rule>
   <rule id="Rule_00000074">
     <crudFlags>R</crudFlags>
-    <what>DatasetParameter</what>
+    <what>Dataset</what>
     <grouping ref="Grouping_name-rall"/>
   </rule>
   <rule id="Rule_00000075">
     <crudFlags>R</crudFlags>
-    <what>Grouping</what>
+    <what>DatasetParameter</what>
     <grouping ref="Grouping_name-rall"/>
   </rule>
   <rule id="Rule_00000076">
     <crudFlags>R</crudFlags>
-    <what>InstrumentScientist</what>
+    <what>Grouping</what>
     <grouping ref="Grouping_name-rall"/>
   </rule>
   <rule id="Rule_00000077">
     <crudFlags>R</crudFlags>
-    <what>Investigation</what>
+    <what>InstrumentScientist</what>
     <grouping ref="Grouping_name-rall"/>
   </rule>
   <rule id="Rule_00000078">
     <crudFlags>R</crudFlags>
-    <what>InvestigationGroup</what>
+    <what>Investigation</what>
     <grouping ref="Grouping_name-rall"/>
   </rule>
   <rule id="Rule_00000079">
     <crudFlags>R</crudFlags>
-    <what>InvestigationInstrument</what>
+    <what>InvestigationGroup</what>
     <grouping ref="Grouping_name-rall"/>
   </rule>
   <rule id="Rule_00000080">
     <crudFlags>R</crudFlags>
-    <what>InvestigationParameter</what>
+    <what>InvestigationInstrument</what>
     <grouping ref="Grouping_name-rall"/>
   </rule>
   <rule id="Rule_00000081">
     <crudFlags>R</crudFlags>
-    <what>InvestigationUser</what>
+    <what>InvestigationParameter</what>
     <grouping ref="Grouping_name-rall"/>
   </rule>
   <rule id="Rule_00000082">
     <crudFlags>R</crudFlags>
-    <what>Job</what>
+    <what>InvestigationUser</what>
     <grouping ref="Grouping_name-rall"/>
   </rule>
   <rule id="Rule_00000083">
     <crudFlags>R</crudFlags>
-    <what>Keyword</what>
+    <what>Job</what>
     <grouping ref="Grouping_name-rall"/>
   </rule>
   <rule id="Rule_00000084">
     <crudFlags>R</crudFlags>
-    <what>PublicStep</what>
+    <what>Keyword</what>
     <grouping ref="Grouping_name-rall"/>
   </rule>
   <rule id="Rule_00000085">
     <crudFlags>R</crudFlags>
-    <what>Publication</what>
+    <what>PublicStep</what>
     <grouping ref="Grouping_name-rall"/>
   </rule>
   <rule id="Rule_00000086">
     <crudFlags>R</crudFlags>
-    <what>RelatedDatafile</what>
+    <what>Publication</what>
     <grouping ref="Grouping_name-rall"/>
   </rule>
   <rule id="Rule_00000087">
     <crudFlags>R</crudFlags>
-    <what>Rule</what>
+    <what>RelatedDatafile</what>
     <grouping ref="Grouping_name-rall"/>
   </rule>
   <rule id="Rule_00000088">
     <crudFlags>R</crudFlags>
-    <what>Sample</what>
+    <what>Rule</what>
     <grouping ref="Grouping_name-rall"/>
   </rule>
   <rule id="Rule_00000089">
     <crudFlags>R</crudFlags>
-    <what>SampleParameter</what>
+    <what>Sample</what>
     <grouping ref="Grouping_name-rall"/>
   </rule>
   <rule id="Rule_00000090">
     <crudFlags>R</crudFlags>
-    <what>Shift</what>
+    <what>SampleParameter</what>
     <grouping ref="Grouping_name-rall"/>
   </rule>
   <rule id="Rule_00000091">
     <crudFlags>R</crudFlags>
-    <what>Study</what>
+    <what>Shift</what>
     <grouping ref="Grouping_name-rall"/>
   </rule>
   <rule id="Rule_00000092">
     <crudFlags>R</crudFlags>
-    <what>StudyInvestigation</what>
+    <what>Study</what>
     <grouping ref="Grouping_name-rall"/>
   </rule>
   <rule id="Rule_00000093">
     <crudFlags>R</crudFlags>
-    <what>UserGroup</what>
+    <what>StudyInvestigation</what>
     <grouping ref="Grouping_name-rall"/>
   </rule>
   <rule id="Rule_00000094">
+    <crudFlags>R</crudFlags>
+    <what>UserGroup</what>
+    <grouping ref="Grouping_name-rall"/>
+  </rule>
+  <rule id="Rule_00000095">
     <crudFlags>RU</crudFlags>
     <what>Sample</what>
     <grouping ref="Grouping_name-scientific=5Fstaff"/>
   </rule>
-  <rule id="Rule_00000095">
+  <rule id="Rule_00000096">
     <crudFlags>UD</crudFlags>
     <what>SampleType</what>
     <grouping ref="Grouping_name-scientific=5Fstaff"/>
   </rule>
-  <rule id="Rule_00000096">
+  <rule id="Rule_00000097">
     <crudFlags>CRUD</crudFlags>
     <what>FacilityCycle</what>
     <grouping ref="Grouping_name-useroffice"/>
   </rule>
-  <rule id="Rule_00000097">
+  <rule id="Rule_00000098">
     <crudFlags>CRUD</crudFlags>
     <what>Grouping</what>
     <grouping ref="Grouping_name-useroffice"/>
   </rule>
-  <rule id="Rule_00000098">
+  <rule id="Rule_00000099">
     <crudFlags>CRUD</crudFlags>
     <what>InstrumentScientist</what>
     <grouping ref="Grouping_name-useroffice"/>
   </rule>
-  <rule id="Rule_00000099">
+  <rule id="Rule_00000100">
     <crudFlags>CRUD</crudFlags>
     <what>Investigation</what>
     <grouping ref="Grouping_name-useroffice"/>
   </rule>
-  <rule id="Rule_00000100">
+  <rule id="Rule_00000101">
     <crudFlags>CRUD</crudFlags>
     <what>InvestigationGroup</what>
     <grouping ref="Grouping_name-useroffice"/>
   </rule>
-  <rule id="Rule_00000101">
+  <rule id="Rule_00000102">
     <crudFlags>CRUD</crudFlags>
     <what>InvestigationInstrument</what>
     <grouping ref="Grouping_name-useroffice"/>
   </rule>
-  <rule id="Rule_00000102">
+  <rule id="Rule_00000103">
     <crudFlags>CRUD</crudFlags>
     <what>InvestigationParameter</what>
     <grouping ref="Grouping_name-useroffice"/>
   </rule>
-  <rule id="Rule_00000103">
+  <rule id="Rule_00000104">
     <crudFlags>CRUD</crudFlags>
     <what>InvestigationUser</what>
     <grouping ref="Grouping_name-useroffice"/>
   </rule>
-  <rule id="Rule_00000104">
+  <rule id="Rule_00000105">
     <crudFlags>CRUD</crudFlags>
     <what>Keyword</what>
     <grouping ref="Grouping_name-useroffice"/>
   </rule>
-  <rule id="Rule_00000105">
+  <rule id="Rule_00000106">
     <crudFlags>CRUD</crudFlags>
     <what>Publication</what>
     <grouping ref="Grouping_name-useroffice"/>
   </rule>
-  <rule id="Rule_00000106">
+  <rule id="Rule_00000107">
     <crudFlags>CRUD</crudFlags>
     <what>Shift</what>
     <grouping ref="Grouping_name-useroffice"/>
   </rule>
-  <rule id="Rule_00000107">
+  <rule id="Rule_00000108">
     <crudFlags>CRUD</crudFlags>
     <what>Study</what>
     <grouping ref="Grouping_name-useroffice"/>
   </rule>
-  <rule id="Rule_00000108">
+  <rule id="Rule_00000109">
     <crudFlags>CRUD</crudFlags>
     <what>StudyInvestigation</what>
     <grouping ref="Grouping_name-useroffice"/>
   </rule>
-  <rule id="Rule_00000109">
+  <rule id="Rule_00000110">
     <crudFlags>CRUD</crudFlags>
     <what>User</what>
     <grouping ref="Grouping_name-useroffice"/>
   </rule>
-  <rule id="Rule_00000110">
+  <rule id="Rule_00000111">
     <crudFlags>CRUD</crudFlags>
     <what>UserGroup</what>
     <grouping ref="Grouping_name-useroffice"/>

--- a/tests/data/legacy-icatdump-4.7.yaml
+++ b/tests/data/legacy-icatdump-4.7.yaml
@@ -1,5 +1,5 @@
 %YAML 1.1
-# Date: Sun, 04 Dec 2022 19:18:29 +0000
+# Date: Mon, 16 Oct 2023 14:34:39 +0000
 # Service: https://icat.example.com:8181/ICATService/ICAT?wsdl
 # ICAT-API: 4.7
 # Generator: icatdump (python-icat 0.21.0)
@@ -421,182 +421,186 @@ rule:
     grouping: Grouping_name-ingest
     what: Investigation
   Rule_00000066:
+    crudFlags: CRU
+    grouping: Grouping_name-ingest
+    what: Sample
+  Rule_00000067:
     crudFlags: R
     grouping: Grouping_name-ingest
     what: Shift
-  Rule_00000067:
-    crudFlags: R
-    grouping: Grouping_name-rall
-    what: DataCollection
   Rule_00000068:
     crudFlags: R
     grouping: Grouping_name-rall
-    what: DataCollectionDatafile
+    what: DataCollection
   Rule_00000069:
     crudFlags: R
     grouping: Grouping_name-rall
-    what: DataCollectionDataset
+    what: DataCollectionDatafile
   Rule_00000070:
     crudFlags: R
     grouping: Grouping_name-rall
-    what: DataCollectionParameter
+    what: DataCollectionDataset
   Rule_00000071:
     crudFlags: R
     grouping: Grouping_name-rall
-    what: Datafile
+    what: DataCollectionParameter
   Rule_00000072:
     crudFlags: R
     grouping: Grouping_name-rall
-    what: DatafileParameter
+    what: Datafile
   Rule_00000073:
     crudFlags: R
     grouping: Grouping_name-rall
-    what: Dataset
+    what: DatafileParameter
   Rule_00000074:
     crudFlags: R
     grouping: Grouping_name-rall
-    what: DatasetParameter
+    what: Dataset
   Rule_00000075:
     crudFlags: R
     grouping: Grouping_name-rall
-    what: Grouping
+    what: DatasetParameter
   Rule_00000076:
     crudFlags: R
     grouping: Grouping_name-rall
-    what: InstrumentScientist
+    what: Grouping
   Rule_00000077:
     crudFlags: R
     grouping: Grouping_name-rall
-    what: Investigation
+    what: InstrumentScientist
   Rule_00000078:
     crudFlags: R
     grouping: Grouping_name-rall
-    what: InvestigationGroup
+    what: Investigation
   Rule_00000079:
     crudFlags: R
     grouping: Grouping_name-rall
-    what: InvestigationInstrument
+    what: InvestigationGroup
   Rule_00000080:
     crudFlags: R
     grouping: Grouping_name-rall
-    what: InvestigationParameter
+    what: InvestigationInstrument
   Rule_00000081:
     crudFlags: R
     grouping: Grouping_name-rall
-    what: InvestigationUser
+    what: InvestigationParameter
   Rule_00000082:
     crudFlags: R
     grouping: Grouping_name-rall
-    what: Job
+    what: InvestigationUser
   Rule_00000083:
     crudFlags: R
     grouping: Grouping_name-rall
-    what: Keyword
+    what: Job
   Rule_00000084:
     crudFlags: R
     grouping: Grouping_name-rall
-    what: PublicStep
+    what: Keyword
   Rule_00000085:
     crudFlags: R
     grouping: Grouping_name-rall
-    what: Publication
+    what: PublicStep
   Rule_00000086:
     crudFlags: R
     grouping: Grouping_name-rall
-    what: RelatedDatafile
+    what: Publication
   Rule_00000087:
     crudFlags: R
     grouping: Grouping_name-rall
-    what: Rule
+    what: RelatedDatafile
   Rule_00000088:
     crudFlags: R
     grouping: Grouping_name-rall
-    what: Sample
+    what: Rule
   Rule_00000089:
     crudFlags: R
     grouping: Grouping_name-rall
-    what: SampleParameter
+    what: Sample
   Rule_00000090:
     crudFlags: R
     grouping: Grouping_name-rall
-    what: Shift
+    what: SampleParameter
   Rule_00000091:
     crudFlags: R
     grouping: Grouping_name-rall
-    what: Study
+    what: Shift
   Rule_00000092:
     crudFlags: R
     grouping: Grouping_name-rall
-    what: StudyInvestigation
+    what: Study
   Rule_00000093:
     crudFlags: R
     grouping: Grouping_name-rall
-    what: UserGroup
+    what: StudyInvestigation
   Rule_00000094:
+    crudFlags: R
+    grouping: Grouping_name-rall
+    what: UserGroup
+  Rule_00000095:
     crudFlags: RU
     grouping: Grouping_name-scientific=5Fstaff
     what: Sample
-  Rule_00000095:
+  Rule_00000096:
     crudFlags: UD
     grouping: Grouping_name-scientific=5Fstaff
     what: SampleType
-  Rule_00000096:
-    crudFlags: CRUD
-    grouping: Grouping_name-useroffice
-    what: FacilityCycle
   Rule_00000097:
     crudFlags: CRUD
     grouping: Grouping_name-useroffice
-    what: Grouping
+    what: FacilityCycle
   Rule_00000098:
     crudFlags: CRUD
     grouping: Grouping_name-useroffice
-    what: InstrumentScientist
+    what: Grouping
   Rule_00000099:
     crudFlags: CRUD
     grouping: Grouping_name-useroffice
-    what: Investigation
+    what: InstrumentScientist
   Rule_00000100:
     crudFlags: CRUD
     grouping: Grouping_name-useroffice
-    what: InvestigationGroup
+    what: Investigation
   Rule_00000101:
     crudFlags: CRUD
     grouping: Grouping_name-useroffice
-    what: InvestigationInstrument
+    what: InvestigationGroup
   Rule_00000102:
     crudFlags: CRUD
     grouping: Grouping_name-useroffice
-    what: InvestigationParameter
+    what: InvestigationInstrument
   Rule_00000103:
     crudFlags: CRUD
     grouping: Grouping_name-useroffice
-    what: InvestigationUser
+    what: InvestigationParameter
   Rule_00000104:
     crudFlags: CRUD
     grouping: Grouping_name-useroffice
-    what: Keyword
+    what: InvestigationUser
   Rule_00000105:
     crudFlags: CRUD
     grouping: Grouping_name-useroffice
-    what: Publication
+    what: Keyword
   Rule_00000106:
     crudFlags: CRUD
     grouping: Grouping_name-useroffice
-    what: Shift
+    what: Publication
   Rule_00000107:
     crudFlags: CRUD
     grouping: Grouping_name-useroffice
-    what: Study
+    what: Shift
   Rule_00000108:
     crudFlags: CRUD
     grouping: Grouping_name-useroffice
-    what: StudyInvestigation
+    what: Study
   Rule_00000109:
     crudFlags: CRUD
     grouping: Grouping_name-useroffice
-    what: User
+    what: StudyInvestigation
   Rule_00000110:
+    crudFlags: CRUD
+    grouping: Grouping_name-useroffice
+    what: User
+  Rule_00000111:
     crudFlags: CRUD
     grouping: Grouping_name-useroffice
     what: UserGroup

--- a/tests/data/ref-icatdump-5.0.xml
+++ b/tests/data/ref-icatdump-5.0.xml
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="utf-8"?>
 <icatdata>
 <head>
-  <date>2022-12-21T15:21:54+00:00</date>
+  <date>2023-10-16T15:00:34+00:00</date>
   <service>https://icat.example.com:8181/ICATService/ICAT?wsdl</service>
-  <apiversion>5.0.0</apiversion>
+  <apiversion>5.0.1</apiversion>
   <generator>icatdump (python-icat 1.0.0)</generator>
 </head>
 <data>
@@ -431,226 +431,231 @@
     <grouping ref="Grouping_name-ingest"/>
   </rule>
   <rule id="Rule_00000066">
-    <crudFlags>R</crudFlags>
-    <what>Shift</what>
+    <crudFlags>CRU</crudFlags>
+    <what>Sample</what>
     <grouping ref="Grouping_name-ingest"/>
   </rule>
   <rule id="Rule_00000067">
     <crudFlags>R</crudFlags>
-    <what>DataCollection</what>
-    <grouping ref="Grouping_name-rall"/>
+    <what>Shift</what>
+    <grouping ref="Grouping_name-ingest"/>
   </rule>
   <rule id="Rule_00000068">
     <crudFlags>R</crudFlags>
-    <what>DataCollectionDatafile</what>
+    <what>DataCollection</what>
     <grouping ref="Grouping_name-rall"/>
   </rule>
   <rule id="Rule_00000069">
     <crudFlags>R</crudFlags>
-    <what>DataCollectionDataset</what>
+    <what>DataCollectionDatafile</what>
     <grouping ref="Grouping_name-rall"/>
   </rule>
   <rule id="Rule_00000070">
     <crudFlags>R</crudFlags>
-    <what>DataCollectionParameter</what>
+    <what>DataCollectionDataset</what>
     <grouping ref="Grouping_name-rall"/>
   </rule>
   <rule id="Rule_00000071">
     <crudFlags>R</crudFlags>
-    <what>Datafile</what>
+    <what>DataCollectionParameter</what>
     <grouping ref="Grouping_name-rall"/>
   </rule>
   <rule id="Rule_00000072">
     <crudFlags>R</crudFlags>
-    <what>DatafileParameter</what>
+    <what>Datafile</what>
     <grouping ref="Grouping_name-rall"/>
   </rule>
   <rule id="Rule_00000073">
     <crudFlags>R</crudFlags>
-    <what>Dataset</what>
+    <what>DatafileParameter</what>
     <grouping ref="Grouping_name-rall"/>
   </rule>
   <rule id="Rule_00000074">
     <crudFlags>R</crudFlags>
-    <what>DatasetParameter</what>
+    <what>Dataset</what>
     <grouping ref="Grouping_name-rall"/>
   </rule>
   <rule id="Rule_00000075">
     <crudFlags>R</crudFlags>
-    <what>Grouping</what>
+    <what>DatasetParameter</what>
     <grouping ref="Grouping_name-rall"/>
   </rule>
   <rule id="Rule_00000076">
     <crudFlags>R</crudFlags>
-    <what>InstrumentScientist</what>
+    <what>Grouping</what>
     <grouping ref="Grouping_name-rall"/>
   </rule>
   <rule id="Rule_00000077">
     <crudFlags>R</crudFlags>
-    <what>Investigation</what>
+    <what>InstrumentScientist</what>
     <grouping ref="Grouping_name-rall"/>
   </rule>
   <rule id="Rule_00000078">
     <crudFlags>R</crudFlags>
-    <what>InvestigationGroup</what>
+    <what>Investigation</what>
     <grouping ref="Grouping_name-rall"/>
   </rule>
   <rule id="Rule_00000079">
     <crudFlags>R</crudFlags>
-    <what>InvestigationInstrument</what>
+    <what>InvestigationGroup</what>
     <grouping ref="Grouping_name-rall"/>
   </rule>
   <rule id="Rule_00000080">
     <crudFlags>R</crudFlags>
-    <what>InvestigationParameter</what>
+    <what>InvestigationInstrument</what>
     <grouping ref="Grouping_name-rall"/>
   </rule>
   <rule id="Rule_00000081">
     <crudFlags>R</crudFlags>
-    <what>InvestigationUser</what>
+    <what>InvestigationParameter</what>
     <grouping ref="Grouping_name-rall"/>
   </rule>
   <rule id="Rule_00000082">
     <crudFlags>R</crudFlags>
-    <what>Job</what>
+    <what>InvestigationUser</what>
     <grouping ref="Grouping_name-rall"/>
   </rule>
   <rule id="Rule_00000083">
     <crudFlags>R</crudFlags>
-    <what>Keyword</what>
+    <what>Job</what>
     <grouping ref="Grouping_name-rall"/>
   </rule>
   <rule id="Rule_00000084">
     <crudFlags>R</crudFlags>
-    <what>PublicStep</what>
+    <what>Keyword</what>
     <grouping ref="Grouping_name-rall"/>
   </rule>
   <rule id="Rule_00000085">
     <crudFlags>R</crudFlags>
-    <what>Publication</what>
+    <what>PublicStep</what>
     <grouping ref="Grouping_name-rall"/>
   </rule>
   <rule id="Rule_00000086">
     <crudFlags>R</crudFlags>
-    <what>RelatedDatafile</what>
+    <what>Publication</what>
     <grouping ref="Grouping_name-rall"/>
   </rule>
   <rule id="Rule_00000087">
     <crudFlags>R</crudFlags>
-    <what>Rule</what>
+    <what>RelatedDatafile</what>
     <grouping ref="Grouping_name-rall"/>
   </rule>
   <rule id="Rule_00000088">
     <crudFlags>R</crudFlags>
-    <what>Sample</what>
+    <what>Rule</what>
     <grouping ref="Grouping_name-rall"/>
   </rule>
   <rule id="Rule_00000089">
     <crudFlags>R</crudFlags>
-    <what>SampleParameter</what>
+    <what>Sample</what>
     <grouping ref="Grouping_name-rall"/>
   </rule>
   <rule id="Rule_00000090">
     <crudFlags>R</crudFlags>
-    <what>Shift</what>
+    <what>SampleParameter</what>
     <grouping ref="Grouping_name-rall"/>
   </rule>
   <rule id="Rule_00000091">
     <crudFlags>R</crudFlags>
-    <what>Study</what>
+    <what>Shift</what>
     <grouping ref="Grouping_name-rall"/>
   </rule>
   <rule id="Rule_00000092">
     <crudFlags>R</crudFlags>
-    <what>StudyInvestigation</what>
+    <what>Study</what>
     <grouping ref="Grouping_name-rall"/>
   </rule>
   <rule id="Rule_00000093">
     <crudFlags>R</crudFlags>
-    <what>UserGroup</what>
+    <what>StudyInvestigation</what>
     <grouping ref="Grouping_name-rall"/>
   </rule>
   <rule id="Rule_00000094">
+    <crudFlags>R</crudFlags>
+    <what>UserGroup</what>
+    <grouping ref="Grouping_name-rall"/>
+  </rule>
+  <rule id="Rule_00000095">
     <crudFlags>RU</crudFlags>
     <what>Sample</what>
     <grouping ref="Grouping_name-scientific=5Fstaff"/>
   </rule>
-  <rule id="Rule_00000095">
+  <rule id="Rule_00000096">
     <crudFlags>UD</crudFlags>
     <what>SampleType</what>
     <grouping ref="Grouping_name-scientific=5Fstaff"/>
   </rule>
-  <rule id="Rule_00000096">
+  <rule id="Rule_00000097">
     <crudFlags>CRUD</crudFlags>
     <what>FacilityCycle</what>
     <grouping ref="Grouping_name-useroffice"/>
   </rule>
-  <rule id="Rule_00000097">
+  <rule id="Rule_00000098">
     <crudFlags>CRUD</crudFlags>
     <what>Grouping</what>
     <grouping ref="Grouping_name-useroffice"/>
   </rule>
-  <rule id="Rule_00000098">
+  <rule id="Rule_00000099">
     <crudFlags>CRUD</crudFlags>
     <what>InstrumentScientist</what>
     <grouping ref="Grouping_name-useroffice"/>
   </rule>
-  <rule id="Rule_00000099">
+  <rule id="Rule_00000100">
     <crudFlags>CRUD</crudFlags>
     <what>Investigation</what>
     <grouping ref="Grouping_name-useroffice"/>
   </rule>
-  <rule id="Rule_00000100">
+  <rule id="Rule_00000101">
     <crudFlags>CRUD</crudFlags>
     <what>InvestigationGroup</what>
     <grouping ref="Grouping_name-useroffice"/>
   </rule>
-  <rule id="Rule_00000101">
+  <rule id="Rule_00000102">
     <crudFlags>CRUD</crudFlags>
     <what>InvestigationInstrument</what>
     <grouping ref="Grouping_name-useroffice"/>
   </rule>
-  <rule id="Rule_00000102">
+  <rule id="Rule_00000103">
     <crudFlags>CRUD</crudFlags>
     <what>InvestigationParameter</what>
     <grouping ref="Grouping_name-useroffice"/>
   </rule>
-  <rule id="Rule_00000103">
+  <rule id="Rule_00000104">
     <crudFlags>CRUD</crudFlags>
     <what>InvestigationUser</what>
     <grouping ref="Grouping_name-useroffice"/>
   </rule>
-  <rule id="Rule_00000104">
+  <rule id="Rule_00000105">
     <crudFlags>CRUD</crudFlags>
     <what>Keyword</what>
     <grouping ref="Grouping_name-useroffice"/>
   </rule>
-  <rule id="Rule_00000105">
+  <rule id="Rule_00000106">
     <crudFlags>CRUD</crudFlags>
     <what>Publication</what>
     <grouping ref="Grouping_name-useroffice"/>
   </rule>
-  <rule id="Rule_00000106">
+  <rule id="Rule_00000107">
     <crudFlags>CRUD</crudFlags>
     <what>Shift</what>
     <grouping ref="Grouping_name-useroffice"/>
   </rule>
-  <rule id="Rule_00000107">
+  <rule id="Rule_00000108">
     <crudFlags>CRUD</crudFlags>
     <what>Study</what>
     <grouping ref="Grouping_name-useroffice"/>
   </rule>
-  <rule id="Rule_00000108">
+  <rule id="Rule_00000109">
     <crudFlags>CRUD</crudFlags>
     <what>StudyInvestigation</what>
     <grouping ref="Grouping_name-useroffice"/>
   </rule>
-  <rule id="Rule_00000109">
+  <rule id="Rule_00000110">
     <crudFlags>CRUD</crudFlags>
     <what>User</what>
     <grouping ref="Grouping_name-useroffice"/>
   </rule>
-  <rule id="Rule_00000110">
+  <rule id="Rule_00000111">
     <crudFlags>CRUD</crudFlags>
     <what>UserGroup</what>
     <grouping ref="Grouping_name-useroffice"/>

--- a/tests/data/ref-icatdump-5.0.yaml
+++ b/tests/data/ref-icatdump-5.0.yaml
@@ -1,7 +1,7 @@
 %YAML 1.1
-# Date: Wed, 21 Dec 2022 15:22:05 +0000
+# Date: Mon, 16 Oct 2023 15:00:30 +0000
 # Service: https://icat.example.com:8181/ICATService/ICAT?wsdl
-# ICAT-API: 5.0.0
+# ICAT-API: 5.0.1
 # Generator: icatdump (python-icat 1.0.0)
 ---
 grouping:
@@ -421,182 +421,186 @@ rule:
     grouping: Grouping_name-ingest
     what: Investigation
   Rule_00000066:
+    crudFlags: CRU
+    grouping: Grouping_name-ingest
+    what: Sample
+  Rule_00000067:
     crudFlags: R
     grouping: Grouping_name-ingest
     what: Shift
-  Rule_00000067:
-    crudFlags: R
-    grouping: Grouping_name-rall
-    what: DataCollection
   Rule_00000068:
     crudFlags: R
     grouping: Grouping_name-rall
-    what: DataCollectionDatafile
+    what: DataCollection
   Rule_00000069:
     crudFlags: R
     grouping: Grouping_name-rall
-    what: DataCollectionDataset
+    what: DataCollectionDatafile
   Rule_00000070:
     crudFlags: R
     grouping: Grouping_name-rall
-    what: DataCollectionParameter
+    what: DataCollectionDataset
   Rule_00000071:
     crudFlags: R
     grouping: Grouping_name-rall
-    what: Datafile
+    what: DataCollectionParameter
   Rule_00000072:
     crudFlags: R
     grouping: Grouping_name-rall
-    what: DatafileParameter
+    what: Datafile
   Rule_00000073:
     crudFlags: R
     grouping: Grouping_name-rall
-    what: Dataset
+    what: DatafileParameter
   Rule_00000074:
     crudFlags: R
     grouping: Grouping_name-rall
-    what: DatasetParameter
+    what: Dataset
   Rule_00000075:
     crudFlags: R
     grouping: Grouping_name-rall
-    what: Grouping
+    what: DatasetParameter
   Rule_00000076:
     crudFlags: R
     grouping: Grouping_name-rall
-    what: InstrumentScientist
+    what: Grouping
   Rule_00000077:
     crudFlags: R
     grouping: Grouping_name-rall
-    what: Investigation
+    what: InstrumentScientist
   Rule_00000078:
     crudFlags: R
     grouping: Grouping_name-rall
-    what: InvestigationGroup
+    what: Investigation
   Rule_00000079:
     crudFlags: R
     grouping: Grouping_name-rall
-    what: InvestigationInstrument
+    what: InvestigationGroup
   Rule_00000080:
     crudFlags: R
     grouping: Grouping_name-rall
-    what: InvestigationParameter
+    what: InvestigationInstrument
   Rule_00000081:
     crudFlags: R
     grouping: Grouping_name-rall
-    what: InvestigationUser
+    what: InvestigationParameter
   Rule_00000082:
     crudFlags: R
     grouping: Grouping_name-rall
-    what: Job
+    what: InvestigationUser
   Rule_00000083:
     crudFlags: R
     grouping: Grouping_name-rall
-    what: Keyword
+    what: Job
   Rule_00000084:
     crudFlags: R
     grouping: Grouping_name-rall
-    what: PublicStep
+    what: Keyword
   Rule_00000085:
     crudFlags: R
     grouping: Grouping_name-rall
-    what: Publication
+    what: PublicStep
   Rule_00000086:
     crudFlags: R
     grouping: Grouping_name-rall
-    what: RelatedDatafile
+    what: Publication
   Rule_00000087:
     crudFlags: R
     grouping: Grouping_name-rall
-    what: Rule
+    what: RelatedDatafile
   Rule_00000088:
     crudFlags: R
     grouping: Grouping_name-rall
-    what: Sample
+    what: Rule
   Rule_00000089:
     crudFlags: R
     grouping: Grouping_name-rall
-    what: SampleParameter
+    what: Sample
   Rule_00000090:
     crudFlags: R
     grouping: Grouping_name-rall
-    what: Shift
+    what: SampleParameter
   Rule_00000091:
     crudFlags: R
     grouping: Grouping_name-rall
-    what: Study
+    what: Shift
   Rule_00000092:
     crudFlags: R
     grouping: Grouping_name-rall
-    what: StudyInvestigation
+    what: Study
   Rule_00000093:
     crudFlags: R
     grouping: Grouping_name-rall
-    what: UserGroup
+    what: StudyInvestigation
   Rule_00000094:
+    crudFlags: R
+    grouping: Grouping_name-rall
+    what: UserGroup
+  Rule_00000095:
     crudFlags: RU
     grouping: Grouping_name-scientific=5Fstaff
     what: Sample
-  Rule_00000095:
+  Rule_00000096:
     crudFlags: UD
     grouping: Grouping_name-scientific=5Fstaff
     what: SampleType
-  Rule_00000096:
-    crudFlags: CRUD
-    grouping: Grouping_name-useroffice
-    what: FacilityCycle
   Rule_00000097:
     crudFlags: CRUD
     grouping: Grouping_name-useroffice
-    what: Grouping
+    what: FacilityCycle
   Rule_00000098:
     crudFlags: CRUD
     grouping: Grouping_name-useroffice
-    what: InstrumentScientist
+    what: Grouping
   Rule_00000099:
     crudFlags: CRUD
     grouping: Grouping_name-useroffice
-    what: Investigation
+    what: InstrumentScientist
   Rule_00000100:
     crudFlags: CRUD
     grouping: Grouping_name-useroffice
-    what: InvestigationGroup
+    what: Investigation
   Rule_00000101:
     crudFlags: CRUD
     grouping: Grouping_name-useroffice
-    what: InvestigationInstrument
+    what: InvestigationGroup
   Rule_00000102:
     crudFlags: CRUD
     grouping: Grouping_name-useroffice
-    what: InvestigationParameter
+    what: InvestigationInstrument
   Rule_00000103:
     crudFlags: CRUD
     grouping: Grouping_name-useroffice
-    what: InvestigationUser
+    what: InvestigationParameter
   Rule_00000104:
     crudFlags: CRUD
     grouping: Grouping_name-useroffice
-    what: Keyword
+    what: InvestigationUser
   Rule_00000105:
     crudFlags: CRUD
     grouping: Grouping_name-useroffice
-    what: Publication
+    what: Keyword
   Rule_00000106:
     crudFlags: CRUD
     grouping: Grouping_name-useroffice
-    what: Shift
+    what: Publication
   Rule_00000107:
     crudFlags: CRUD
     grouping: Grouping_name-useroffice
-    what: Study
+    what: Shift
   Rule_00000108:
     crudFlags: CRUD
     grouping: Grouping_name-useroffice
-    what: StudyInvestigation
+    what: Study
   Rule_00000109:
     crudFlags: CRUD
     grouping: Grouping_name-useroffice
-    what: User
+    what: StudyInvestigation
   Rule_00000110:
+    crudFlags: CRUD
+    grouping: Grouping_name-useroffice
+    what: User
+  Rule_00000111:
     crudFlags: CRUD
     grouping: Grouping_name-useroffice
     what: UserGroup

--- a/tests/data/summary-4
+++ b/tests/data/summary-4
@@ -31,7 +31,7 @@ PermissibleStringValue   : 6
 PublicStep               : 24
 Publication              : 1
 RelatedDatafile          : 1
-Rule                     : 110
+Rule                     : 111
 Sample                   : 3
 SampleParameter          : 2
 SampleType               : 3

--- a/tests/data/summary-5
+++ b/tests/data/summary-5
@@ -44,7 +44,7 @@ PublicStep               : 37
 Publication              : 1
 RelatedDatafile          : 1
 RelatedItem              : 1
-Rule                     : 158
+Rule                     : 159
 Sample                   : 3
 SampleParameter          : 2
 SampleType               : 3

--- a/tests/test_06_icatingest.py
+++ b/tests/test_06_icatingest.py
@@ -360,6 +360,7 @@ def test_ingest_datafiles_upload(tmpdirsec, client, dataset, cmdargs):
             assert df.datafileModTime == f.mtime
 
 
+@pytest.mark.xfail(raises=CalledProcessError, reason="Issue #122")
 def test_ingest_dataset_samples(client, cleanup_list, cmdargs):
     """Ingest some datasets that are releated to samples.
     """

--- a/tests/test_06_icatingest.py
+++ b/tests/test_06_icatingest.py
@@ -360,7 +360,6 @@ def test_ingest_datafiles_upload(tmpdirsec, client, dataset, cmdargs):
             assert df.datafileModTime == f.mtime
 
 
-@pytest.mark.xfail(raises=CalledProcessError, reason="Issue #122")
 def test_ingest_dataset_samples(client, cleanup_list, cmdargs):
     """Ingest some datasets that are releated to samples.
     """

--- a/tests/test_06_query.py
+++ b/tests/test_06_query.py
@@ -35,8 +35,8 @@ tzinfo = UtcTimezone() if UtcTimezone else None
 # The the actual number of rules in the test data differs with the
 # ICAT version.
 have_icat_5 = 0 if icat_version < "5.0" else 1
-all_rules = 110 + 48*have_icat_5
-grp_rules = 50 + 30*have_icat_5
+all_rules = 111 + 48*have_icat_5
+grp_rules = 51 + 30*have_icat_5
 
 @pytest.mark.dependency(name='get_investigation')
 def test_query_simple(client):


### PR DESCRIPTION
Enhance the XML ICAT data file format that is read by the `icat.dumpfile_xml` to allow the use reference keys for related objects when referencing an object by attributes.

Close #122. (See that issue on what this is all about.)