### PR TITLE
Fix Read the Docs build

### DIFF
--- a/.rtd-require
+++ b/.rtd-require
@@ -4,5 +4,6 @@ packaging
 setuptools
 setuptools_scm
 suds
+jinja2<3.1
 sphinx>=2,<3
 sphinx-rtd-theme>=0.5,<1


### PR DESCRIPTION
Fix the documentation build at Read the Docs.

RTD was failing. Apparently this was because the RTD defaults made a version jump from Sphinx version 1.8.6 to 7.2.6, which included a version bump for Jinja2 from 3.0.3 to 3.1.2. In our RTD requirements file, we made an upgrade of Sphinx to version 2, which now, with the new defaults, means a downgrade. It seems that Jinja2 3.1.2 is incompatible with Sphinx 2.

For the time being, we fix that by downgrading Jinja2 to < 3.1. In the long run, we should consider upgrading Sphinx instead. But I'd like to do more testing before doing that.