### PR TITLE
Fix IDSClient.getApiVersion()

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -11,8 +11,16 @@ New features
 + `#122`_, `#133`_: Allow referencing related objects by reference key
   in object references in XML ICAT data file format.
 
+Bug fixes and minor changes
+---------------------------
+
++ `#131`_, `#135`_: Fix :meth:`icat.ids.IDSClient.getApiVersion` to
+  yield correct results for ids.server 2.0.0 and newer.
+
 .. _#122: https://github.com/icatproject/python-icat/issues/122
+.. _#131: https://github.com/icatproject/python-icat/issues/131
 .. _#133: https://github.com/icatproject/python-icat/pull/133
+.. _#135: https://github.com/icatproject/python-icat/pull/135
 
 
 1.1.0 (2023-06-30)

--- a/icat/ids.py
+++ b/icat/ids.py
@@ -218,17 +218,19 @@ class IDSClient():
         if result != "IdsOK": 
             raise IDSResponseError("unexpected response to ping: %s" % result)
 
-    def getApiVersion(self):
-        """Get the version of the IDS server.
+    def _get_legacy_version(self):
+        """Try to figure out the ids.server version in legacy cases.
 
-        Note: the `getApiVersion` call has been added in IDS server
-        version 1.3.0.  For older servers, try to guess the server
-        version from features visible in the API.  Obviously this
-        cannot always be accurate as we cannot distinguish server
-        version with no visible API changes.  In particular, versions
-        older then 1.2.0 will always reported as 1.0.0.  Nevertheless,
-        the result of the guess should be fair enough for most use
-        cases.
+        .. note::
+           This method will yield a **wrong** result for ids.server
+           2.0 and newer.  It should only be called when the ^version^
+           call is not available.
+
+
+        The `getApiVersion` call has been added in ids.server version
+        1.3.0.  In version 1.8.0 the newer `version` call has been
+        added, deprecating `getApiVersion` at the same time.  In
+        version 2.0.0 `getApiVersion` has definitely been removed.
         """
         try:
             req = IDSRequest(self.url + "getApiVersion")
@@ -252,14 +254,17 @@ class IDSClient():
         # No way to distinguish 1.1.0, 1.0.1, and 1.0.0, report as 1.0.0.
         return "1.0.0"
 
-    def version(self):
+    def getApiVersion(self):
         """Get the version of the IDS server.
 
-        Note: the `version` call has been added in IDS server version
-        1.8.0, deprecating `getApiVersion` at the same time.  For
-        older servers, we fall back to `getApiVersion` to emulate this
-        call.  Note furthermore that `version` returns a dict, while
-        `getApiVersion` returns the plain version number as a string.
+        The `getApiVersion` call used to be present ids.version from
+        version 1.3.0 to 1.12.*.  Emulate it using the newer
+        `version` call.
+        """
+        return self.version()["version"]
+
+    def version(self):
+        """Get the version of the IDS server.
         """
         try:
             req = IDSRequest(self.url + "version")
@@ -267,7 +272,7 @@ class IDSClient():
             return json.loads(result)
         except (HTTPError, IDSError) as err:
             try:
-                return {"version": self.getApiVersion()}
+                return {"version": self._get_legacy_version()}
             except:
                 raise err
 

--- a/tests/test_03_getversion.py
+++ b/tests/test_03_getversion.py
@@ -23,7 +23,6 @@ def test_get_icat_version():
     print("\nConnect to %s\nICAT version %s\n" % (conf.url, client.apiversion))
 
 
-@pytest.mark.xfail(conftest.ids_version > '1.99', reason="Issue #131")
 def test_ids_version_calls():
     """Test that client.ids.getApiVersion() and client.ids.version() yield
     coherent results.  Ref. #131.

--- a/tests/test_03_getversion.py
+++ b/tests/test_03_getversion.py
@@ -4,6 +4,7 @@
 import pytest
 import icat
 import icat.config
+import conftest
 from conftest import getConfig
 
 
@@ -20,6 +21,18 @@ def test_get_icat_version():
     # comparison with version strings.
     assert client.apiversion > '1.0.0'
     print("\nConnect to %s\nICAT version %s\n" % (conf.url, client.apiversion))
+
+
+@pytest.mark.xfail(conftest.ids_version > '1.99', reason="Issue #131")
+def test_ids_version_calls():
+    """Test that client.ids.getApiVersion() and client.ids.version() yield
+    coherent results.  Ref. #131.
+    """
+
+    client, conf = getConfig(needlogin=False, ids="mandatory")
+    ids_apiversion = client.ids.getApiVersion()
+    ids_verion = client.ids.version()
+    assert ids_apiversion == ids_verion["version"]
 
 
 def test_get_ids_version():


### PR DESCRIPTION
Review `IDSClient.getApiVersion()` and `IDSClient.version()` and make sure they will yield correct results also for `ids.server` 2.0 and newer. Fix #131.