### PR TITLE
Fix spurious AttributeError on cleanup

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -17,10 +17,15 @@ Bug fixes and minor changes
 + `#131`_, `#135`_: Fix :meth:`icat.ids.IDSClient.getApiVersion` to
   yield correct results for ids.server 2.0.0 and newer.
 
++ `#132`_, `#136`_: Fix a spurious :exc:`AttributeError` on cleanup
+  after connecting to an invalid url.
+
 .. _#122: https://github.com/icatproject/python-icat/issues/122
 .. _#131: https://github.com/icatproject/python-icat/issues/131
+.. _#132: https://github.com/icatproject/python-icat/issues/132
 .. _#133: https://github.com/icatproject/python-icat/pull/133
 .. _#135: https://github.com/icatproject/python-icat/pull/135
+.. _#136: https://github.com/icatproject/python-icat/pull/136
 
 
 1.1.0 (2023-06-30)

--- a/icat/client.py
+++ b/icat/client.py
@@ -134,8 +134,15 @@ class Client(suds.client.Client):
         self.kwargs['caPath'] = caPath
         self.kwargs['sslContext'] = sslContext
         self.kwargs['proxy'] = proxy
-
         idsurl = _complete_url(idsurl, default_path="/ids")
+
+        self.apiversion = None
+        self.entityInfoCache = {}
+        self.typemap = None
+        self.ids = None
+        self.sessionId = None
+        self.autoLogout = True
+        self._schedule_auto_refresh("never")
 
         if sslContext:
             self.sslContext = sslContext
@@ -151,15 +158,10 @@ class Client(suds.client.Client):
 
         if self.apiversion < '4.3.0':
             warn(ClientVersionWarning(self.apiversion, "too old"))
-        self.entityInfoCache = {}
         self.typemap = getTypeMap(self)
-        self.ids = None
-        self.sessionId = None
-        self.autoLogout = True
 
         if idsurl:
             self.add_ids(idsurl)
-        self._schedule_auto_refresh("never")
         self.Register[id(self)] = self
 
     def __del__(self):


### PR DESCRIPTION
In the constructor of class Client, set all object attributes to some value before doing anything that may fail, even to some bogus value that may need to be overwritten later on, in order to guarantee that at least the attribute is set.

Fix #132.