### PR TITLE
Review of test suite

### DIFF
--- a/tests/test_03_login.py
+++ b/tests/test_03_login.py
@@ -64,7 +64,7 @@ def test_login_ids_shorturl():
     # clients.
     client, conf = getConfig()
     if not client.ids:
-        pytest.skip("no IDS")
+        pytest.skip("no IDS configured")
     try:
         icatURL = client.ids.getIcatUrl()
     except icat.VersionMethodError:

--- a/tests/test_05_dump.py
+++ b/tests/test_05_dump.py
@@ -66,27 +66,42 @@ else:
 # to verify that object relations are kept intact after an icatdump /
 # icatingest cycle.
 queries = [
-    ("Datafile.name <-> Dataset <-> Investigation [name='10100601-ST']",
-     ['e208339.dat', 'e208339.nxs', 'e208341.dat', 'e208341.nxs']),
-    ("SELECT p.numericValue FROM DatasetParameter p "
-     "JOIN p.dataset AS ds JOIN ds.investigation AS i JOIN p.type AS t "
-     "WHERE i.name = '10100601-ST' AND ds.name = 'e208339' "
-     "AND t.name = 'Magnetic field'",
-     [7.3]),
-    ("SELECT ds.name FROM Dataset ds "
-     "JOIN ds.dataCollectionDatasets AS dcds "
-     "JOIN dcds.dataCollection AS dc JOIN dc.jobsAsOutput AS j "
-     "WHERE j.id IS NOT NULL",
-     ["e208947"]),
-    ("SELECT df.name FROM Datafile df "
-     "JOIN df.dataCollectionDatafiles AS dcdf "
-     "JOIN dcdf.dataCollection AS dc JOIN dc.jobsAsInput AS j "
-     "WHERE j.id IS NOT NULL",
-     ["e208945.nxs"]),
-    ("SELECT COUNT(dc) FROM DataCollection dc "
-     "JOIN dc.dataCollectionDatasets AS dcds JOIN dcds.dataset AS ds "
-     "WHERE ds.name = 'e201215'",
-     [1]),
+    pytest.param(
+        "Datafile.name <-> Dataset <-> Investigation [name='10100601-ST']",
+        ['e208339.dat', 'e208339.nxs', 'e208341.dat', 'e208341.nxs'],
+        id="df.name"
+    ),
+    pytest.param(
+        "SELECT p.numericValue FROM DatasetParameter p "
+        "JOIN p.dataset AS ds JOIN ds.investigation AS i JOIN p.type AS t "
+        "WHERE i.name = '10100601-ST' AND ds.name = 'e208339' "
+        "AND t.name = 'Magnetic field'",
+        [7.3],
+        id="param.name"
+    ),
+    pytest.param(
+        "SELECT ds.name FROM Dataset ds "
+        "JOIN ds.dataCollectionDatasets AS dcds "
+        "JOIN dcds.dataCollection AS dc JOIN dc.jobsAsOutput AS j "
+        "WHERE j.id IS NOT NULL",
+        ["e208947"],
+        id="jobout_ds.name"
+    ),
+    pytest.param(
+        "SELECT df.name FROM Datafile df "
+        "JOIN df.dataCollectionDatafiles AS dcdf "
+        "JOIN dcdf.dataCollection AS dc JOIN dc.jobsAsInput AS j "
+        "WHERE j.id IS NOT NULL",
+        ["e208945.nxs"],
+        id="jobin_df.name"
+    ),
+    pytest.param(
+        "SELECT COUNT(dc) FROM DataCollection dc "
+        "JOIN dc.dataCollectionDatasets AS dcds JOIN dcds.dataset AS ds "
+        "WHERE ds.name = 'e201215'",
+        [1],
+        id="dc.count"
+    ),
 ]
 
 @pytest.fixture(scope="module")

--- a/tests/test_05_dumpfile.py
+++ b/tests/test_05_dumpfile.py
@@ -55,27 +55,42 @@ ocases = cases
 # to verify that object relations are kept intact after an icatdump /
 # icatingest cycle.
 queries = [
-    ("Datafile.name <-> Dataset <-> Investigation [name='10100601-ST']",
-     ['e208339.dat', 'e208339.nxs', 'e208341.dat', 'e208341.nxs']),
-    ("SELECT p.numericValue FROM DatasetParameter p "
-     "JOIN p.dataset AS ds JOIN ds.investigation AS i JOIN p.type AS t "
-     "WHERE i.name = '10100601-ST' AND ds.name = 'e208339' "
-     "AND t.name = 'Magnetic field'",
-     [7.3]),
-    ("SELECT ds.name FROM Dataset ds "
-     "JOIN ds.dataCollectionDatasets AS dcds "
-     "JOIN dcds.dataCollection AS dc JOIN dc.jobsAsOutput AS j "
-     "WHERE j.id IS NOT NULL",
-     ["e208947"]),
-    ("SELECT df.name FROM Datafile df "
-     "JOIN df.dataCollectionDatafiles AS dcdf "
-     "JOIN dcdf.dataCollection AS dc JOIN dc.jobsAsInput AS j "
-     "WHERE j.id IS NOT NULL",
-     ["e208945.nxs"]),
-    ("SELECT COUNT(dc) FROM DataCollection dc "
-     "JOIN dc.dataCollectionDatasets AS dcds JOIN dcds.dataset AS ds "
-     "WHERE ds.name = 'e201215'",
-     [1]),
+    pytest.param(
+        "Datafile.name <-> Dataset <-> Investigation [name='10100601-ST']",
+        ['e208339.dat', 'e208339.nxs', 'e208341.dat', 'e208341.nxs'],
+        id="df.name"
+    ),
+    pytest.param(
+        "SELECT p.numericValue FROM DatasetParameter p "
+        "JOIN p.dataset AS ds JOIN ds.investigation AS i JOIN p.type AS t "
+        "WHERE i.name = '10100601-ST' AND ds.name = 'e208339' "
+        "AND t.name = 'Magnetic field'",
+        [7.3],
+        id="param.name"
+    ),
+    pytest.param(
+        "SELECT ds.name FROM Dataset ds "
+        "JOIN ds.dataCollectionDatasets AS dcds "
+        "JOIN dcds.dataCollection AS dc JOIN dc.jobsAsOutput AS j "
+        "WHERE j.id IS NOT NULL",
+        ["e208947"],
+        id="jobout_ds.name"
+    ),
+    pytest.param(
+        "SELECT df.name FROM Datafile df "
+        "JOIN df.dataCollectionDatafiles AS dcdf "
+        "JOIN dcdf.dataCollection AS dc JOIN dc.jobsAsInput AS j "
+        "WHERE j.id IS NOT NULL",
+        ["e208945.nxs"],
+        id="jobin_df.name"
+    ),
+    pytest.param(
+        "SELECT COUNT(dc) FROM DataCollection dc "
+        "JOIN dc.dataCollectionDatasets AS dcds JOIN dcds.dataset AS ds "
+        "WHERE ds.name = 'e201215'",
+        [1],
+        id="dc.count"
+    ),
 ]
 
 # ======== function equivalents to icatdump and icatingest ===========

--- a/tests/test_06_exception.py
+++ b/tests/test_06_exception.py
@@ -119,7 +119,7 @@ def test_ids_exception(client, errcond):
     """
     # Same comment as in test_icat_exception() applies.
     if not client.ids:
-        pytest.skip("No IDS configured.")
+        pytest.skip("no IDS configured")
     with pytest.raises(icat.IDSError) as einfo:
         errcond(client)
     err = einfo.value

--- a/tests/test_06_icatingest.py
+++ b/tests/test_06_icatingest.py
@@ -289,11 +289,11 @@ ingest_data_date = """<?xml version="1.0" encoding="utf-8"?>
 """
 
 @pytest.mark.parametrize("inputdata", [
-    ingest_data_string,
-    ingest_data_int,
-    ingest_data_boolean,
-    ingest_data_float,
-    ingest_data_date,
+    pytest.param(ingest_data_string, id="ingest_data_string"),
+    pytest.param(ingest_data_int, id="ingest_data_int"),
+    pytest.param(ingest_data_boolean, id="ingest_data_boolean"),
+    pytest.param(ingest_data_float, id="ingest_data_float"),
+    pytest.param(ingest_data_date, id="ingest_data_date"),
 ])
 def test_ingest_duplicate_check_types(tmpdirsec, dataset, cmdargs, inputdata):
     """Ingest with a collision of a duplicate object.

--- a/tests/test_06_ingest.py
+++ b/tests/test_06_ingest.py
@@ -19,19 +19,17 @@ def client(setupicat):
     return client
 
 @pytest.fixture(scope="function")
-def investigation(client):
+def investigation(client, cleanup_objs):
     query = Query(client, "Investigation", conditions={
         "name": "= '12100409-ST'",
     })
     inv = client.assertedSearch(query)[0]
     yield inv
-    rootclient, rootconf = getConfig(confSection="root", ids=False)
-    rootclient.login(rootconf.auth, rootconf.credentials)
-    query = Query(rootclient, "Dataset", conditions={
+    query = Query(client, "Dataset", conditions={
         "investigation.id": "= %d" % inv.id,
         "name": "LIKE 'testingest_%'",
     })
-    rootclient.deleteMany(client.search(query))
+    cleanup_objs.extend(client.search(query))
 
 @pytest.fixture(scope="function")
 def schemadir(monkeypatch):

--- a/tests/test_07_dataselection.py
+++ b/tests/test_07_dataselection.py
@@ -22,12 +22,24 @@ param_ids = [
     ([42], [47,11], [6,666,66]),
 ]
 param_queries = [
-    ("Investigation [name = '10100601-ST']"),
-    ("Dataset <-> Investigation [name = '10100601-ST']"),
-    ("Datafile <-> Dataset <-> Investigation [name = '10100601-ST']"),
-    ("SELECT dc FROM DataCollection dc "
-     "INCLUDE dc.dataCollectionDatafiles AS dcdf, dcdf.datafile, "
-     "dc.dataCollectionDatasets AS dcds, dcds.dataset"),
+    pytest.param(
+        "Investigation [name = '10100601-ST']",
+        id="investigations"
+    ),
+    pytest.param(
+        "Dataset <-> Investigation [name = '10100601-ST']",
+        id="datasets"
+    ),
+    pytest.param(
+        "Datafile <-> Dataset <-> Investigation [name = '10100601-ST']",
+        id="datafiles"
+    ),
+    pytest.param(
+        "SELECT dc FROM DataCollection dc "
+        "INCLUDE dc.dataCollectionDatafiles AS dcdf, dcdf.datafile, "
+        "dc.dataCollectionDatasets AS dcds, dcds.dataset",
+        id="dataCollections"
+    ),
 ]
 
 def get_obj_ids(objs):

--- a/tests/test_07_entity_validate.py
+++ b/tests/test_07_entity_validate.py
@@ -14,7 +14,7 @@ def client(setupicat):
     return client
 
 @pytest.fixture(scope="function")
-def dataset(client):
+def dataset(client, cleanup_objs):
     """Create a temporary Dataset for the tests.
     """
     inv = client.assertedSearch("Investigation [name='08100122-EF']")[0]
@@ -23,8 +23,8 @@ def dataset(client):
                          name="test_07_entity_validate", complete=False,
                          investigation=inv, type=dstype)
     dataset.create()
-    yield dataset
-    client.delete(dataset)
+    cleanup_objs.append(dataset)
+    return dataset
 
 
 def validate_param(self):


### PR DESCRIPTION
Some review of the test suite:

- `test_06_icatingest.py`: avoid needlessly skip tests if IDS is not available, only skip tests that actually need IDS. Close #130.
- Add a helper fixture `cleanup_objs` to `conftest.py`.
- Set meaningful pytest parameter ids for parametrized tests to avoid cluttering the pytest output in verbose mode with complicated parameter values.
- Misc minor changes.