### PR TITLE
Fix XSD and XSLT files used in icat.ingest to produce valid ICAT data files

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -11,6 +11,17 @@ New features
 + `#122`_, `#133`_: Allow referencing related objects by reference key
   in object references in XML ICAT data file format.
 
+Incompatible changes
+--------------------
+
++ `#138`_, `#139`_: Fix the input that :mod:`icat.ingest` generates on
+  the fly to be valid according to the ICAT data file schema.  This
+  also affects the input that the module accepts: the order of
+  subelements of `data` need to be changed such that
+  `datasetTechnique` comes before `datasetInstrument`.
+
+  Note that :mod:`icat.ingest` has been declared experimental for now.
+
 Bug fixes and minor changes
 ---------------------------
 
@@ -30,6 +41,8 @@ Bug fixes and minor changes
 .. _#135: https://github.com/icatproject/python-icat/pull/135
 .. _#136: https://github.com/icatproject/python-icat/pull/136
 .. _#137: https://github.com/icatproject/python-icat/pull/137
+.. _#138: https://github.com/icatproject/python-icat/issues/138
+.. _#139: https://github.com/icatproject/python-icat/pull/139
 
 
 1.1.0 (2023-06-30)

--- a/doc/examples/metadata-5.0-sep.xml
+++ b/doc/examples/metadata-5.0-sep.xml
@@ -17,14 +17,6 @@
       <startDate>2022-02-03T17:13:10+01:00</startDate>
       <endDate>2022-02-03T18:45:27+01:00</endDate>
     </dataset>
-    <datasetInstrument>
-      <dataset ref="Dataset_1"/>
-      <instrument pid="DOI:00.0815/inst-00001"/>
-    </datasetInstrument>
-    <datasetInstrument>
-      <dataset ref="Dataset_2"/>
-      <instrument pid="DOI:00.0815/inst-00001"/>
-    </datasetInstrument>
     <datasetTechnique>
       <dataset ref="Dataset_1"/>
       <technique pid="PaNET:PaNET01217"/>
@@ -33,6 +25,14 @@
       <dataset ref="Dataset_2"/>
       <technique pid="PaNET:PaNET01217"/>
     </datasetTechnique>
+    <datasetInstrument>
+      <dataset ref="Dataset_1"/>
+      <instrument pid="DOI:00.0815/inst-00001"/>
+    </datasetInstrument>
+    <datasetInstrument>
+      <dataset ref="Dataset_2"/>
+      <instrument pid="DOI:00.0815/inst-00001"/>
+    </datasetInstrument>
     <datasetParameter>
       <stringValue>neutron</stringValue>
       <dataset ref="Dataset_1"/>

--- a/doc/src/ingest.rst
+++ b/doc/src/ingest.rst
@@ -30,8 +30,8 @@ below.
 
 The input accepted by :class:`~icat.ingest.IngestReader` consists of
 one or more ``Dataset`` objects that all need to relate to the same
-``Investigation`` and any number of related ``DatasetInstrument``,
-``DatasetTechnique``, and ``DatasetParameter`` objects.  The
+``Investigation`` and any number of related ``DatasetTechnique``,
+``DatasetInstrument``, and ``DatasetParameter`` objects.  The
 ``Investigation`` must exist beforehand in ICAT.  The relation from
 the ``Dataset`` objects to the ``Investigation`` will be set by
 :class:`~icat.ingest.IngestReader` accordingly.  (Actually, the XSLT
@@ -44,7 +44,7 @@ and ``Datafile`` objects in ICAT at the same time.  But the attributes
 of the datasets will be read from the input file and set in the
 ``Dataset`` objects by :class:`~icat.ingest.IngestReader`.
 :class:`~icat.ingest.IngestReader` will also create the related
-``DatasetInstrument``, ``DatasetTechnique`` and ``DatasetParameter``
+``DatasetTechnique``, ``DatasetInstrument`` and ``DatasetParameter``
 objects read from the input file in ICAT.
 
 .. autoclass:: icat.ingest.IngestReader

--- a/etc/ingest-10.xsd
+++ b/etc/ingest-10.xsd
@@ -73,7 +73,7 @@
     <xsd:extension base="entityBase">
       <xsd:sequence>
 	<xsd:element name="dataset" type="entityReference" minOccurs="0"/>
-	<xsd:element name="instrument" type="instrumentRef"/>
+	<xsd:element name="instrument" type="nameRef"/>
       </xsd:sequence>
     </xsd:extension>
   </xsd:complexContent>
@@ -84,7 +84,7 @@
     <xsd:extension base="entityBase">
       <xsd:sequence>
 	<xsd:element name="dataset" type="entityReference" minOccurs="0"/>
-	<xsd:element name="technique" type="techniqueRef"/>
+	<xsd:element name="technique" type="nameRef"/>
       </xsd:sequence>
     </xsd:extension>
   </xsd:complexContent>
@@ -108,12 +108,7 @@
 </xsd:complexType>
 
 
-<xsd:complexType name="instrumentRef">
-  <xsd:attribute name="name" type="xsd:string"/>
-  <xsd:attribute name="pid" type="xsd:string"/>
-</xsd:complexType>
-
-<xsd:complexType name="techniqueRef">
+<xsd:complexType name="nameRef">
   <xsd:attribute name="name" type="xsd:string"/>
   <xsd:attribute name="pid" type="xsd:string"/>
 </xsd:complexType>

--- a/etc/ingest-10.xsd
+++ b/etc/ingest-10.xsd
@@ -30,9 +30,9 @@
   <xsd:sequence>
     <xsd:element name="dataset" type="dataset"
 		 minOccurs="0" maxOccurs="unbounded"/>
-    <xsd:element name="datasetInstrument" type="datasetInstrument"
-		 minOccurs="0" maxOccurs="unbounded"/>
     <xsd:element name="datasetTechnique" type="datasetTechnique"
+		 minOccurs="0" maxOccurs="unbounded"/>
+    <xsd:element name="datasetInstrument" type="datasetInstrument"
 		 minOccurs="0" maxOccurs="unbounded"/>
     <xsd:element name="datasetParameter" type="datasetParameter"
 		 minOccurs="0" maxOccurs="unbounded"/>
@@ -68,23 +68,23 @@
   </xsd:complexContent>
 </xsd:complexType>
 
-<xsd:complexType name="datasetInstrument">
-  <xsd:complexContent>
-    <xsd:extension base="entityBase">
-      <xsd:sequence>
-	<xsd:element name="dataset" type="entityReference" minOccurs="0"/>
-	<xsd:element name="instrument" type="nameRef"/>
-      </xsd:sequence>
-    </xsd:extension>
-  </xsd:complexContent>
-</xsd:complexType>
-
 <xsd:complexType name="datasetTechnique">
   <xsd:complexContent>
     <xsd:extension base="entityBase">
       <xsd:sequence>
 	<xsd:element name="dataset" type="entityReference" minOccurs="0"/>
 	<xsd:element name="technique" type="nameRef"/>
+      </xsd:sequence>
+    </xsd:extension>
+  </xsd:complexContent>
+</xsd:complexType>
+
+<xsd:complexType name="datasetInstrument">
+  <xsd:complexContent>
+    <xsd:extension base="entityBase">
+      <xsd:sequence>
+	<xsd:element name="dataset" type="entityReference" minOccurs="0"/>
+	<xsd:element name="instrument" type="nameRef"/>
       </xsd:sequence>
     </xsd:extension>
   </xsd:complexContent>

--- a/etc/ingest.xslt
+++ b/etc/ingest.xslt
@@ -21,12 +21,13 @@
     <xsl:template match="/icatingest/data/dataset">
 	<dataset>
 	    <xsl:copy-of select="@id"/>
-            <complete>false</complete>
+	    <complete>false</complete>
 	    <xsl:copy-of select="description"/>
 	    <xsl:copy-of select="endDate"/>
 	    <xsl:copy-of select="name"/>
 	    <xsl:copy-of select="startDate"/>
 	    <investigation ref="_Investigation"/>
+	    <type name="raw"/>
 	    <xsl:for-each select="datasetInstruments">
 		<xsl:copy-of select="."/>
 	    </xsl:for-each>
@@ -36,7 +37,6 @@
 	    <xsl:for-each select="parameters">
 		<xsl:copy-of select="."/>
 	    </xsl:for-each>
-            <type name="raw"/>
 	</dataset>
     </xsl:template>
 

--- a/setup.py
+++ b/setup.py
@@ -130,6 +130,7 @@ class build_test(setuptools.Command):
                                 "icatdump-%s.%s" % (ver, ext))
                    for ver in ("4.4", "4.7", "4.10", "5.0")
                    for ext in ("xml", "yaml") ]
+        files += glob(os.path.join("doc", "icatdata-*.xsd"))
         files += glob(os.path.join("doc", "examples", "metadata-*.xml"))
         files += [ os.path.join("etc", f)
                    for f in ["ingest-10.xsd", "ingest.xslt"] ]

--- a/tests/test_06_ingest.py
+++ b/tests/test_06_ingest.py
@@ -243,7 +243,6 @@ cases = [
     ),
 ]
 
-@pytest.mark.xfail(reason="Issue #138")
 @pytest.mark.parametrize("case", [
     pytest.param(c, id=c.metadata.name, marks=c.marks) for c in cases
 ])

--- a/tests/test_06_ingest.py
+++ b/tests/test_06_ingest.py
@@ -5,6 +5,7 @@ from collections import namedtuple
 import datetime
 import pytest
 pytest.importorskip("lxml")
+from lxml import etree
 import icat
 import icat.config
 from icat.ingest import IngestReader
@@ -38,13 +39,14 @@ def schemadir(monkeypatch):
 cet = datetime.timezone(datetime.timedelta(hours=1))
 cest = datetime.timezone(datetime.timedelta(hours=2))
 
-Case = namedtuple('Case', ['data', 'metadata', 'checks', 'marks'])
+Case = namedtuple('Case', ['data', 'metadata', 'schema', 'checks', 'marks'])
 
 # Try out different variants for the metadata input file
 cases = [
     Case(
         data = ["testingest_inl_1", "testingest_inl_2"],
         metadata = gettestdata("metadata-4.4-inl.xml"),
+        schema = gettestdata("icatdata-4.4.xsd"),
         checks = {
             "testingest_inl_1": [
                 ("SELECT ds.description FROM Dataset ds WHERE ds.id = %d",
@@ -84,6 +86,7 @@ cases = [
     Case(
         data = ["testingest_inl5_1", "testingest_inl5_2"],
         metadata = gettestdata("metadata-5.0-inl.xml"),
+        schema = gettestdata("icatdata-5.0.xsd"),
         checks = {
             "testingest_inl5_1": [
                 ("SELECT ds.description FROM Dataset ds WHERE ds.id = %d",
@@ -142,6 +145,7 @@ cases = [
     Case(
         data = ["testingest_sep_1", "testingest_sep_2"],
         metadata = gettestdata("metadata-4.4-sep.xml"),
+        schema = gettestdata("icatdata-4.4.xsd"),
         checks = {
             "testingest_sep_1": [
                 ("SELECT ds.description FROM Dataset ds WHERE ds.id = %d",
@@ -181,6 +185,7 @@ cases = [
     Case(
         data = ["testingest_sep5_1", "testingest_sep5_2"],
         metadata = gettestdata("metadata-5.0-sep.xml"),
+        schema = gettestdata("icatdata-5.0.xsd"),
         checks = {
             "testingest_sep5_1": [
                 ("SELECT ds.description FROM Dataset ds WHERE ds.id = %d",
@@ -237,6 +242,23 @@ cases = [
         ),
     ),
 ]
+
+@pytest.mark.xfail(reason="Issue #138")
+@pytest.mark.parametrize("case", [
+    pytest.param(c, id=c.metadata.name, marks=c.marks) for c in cases
+])
+def test_ingest_schema(client, investigation, schemadir, case):
+    """Check that the ingest data after transformation is valid according
+    to icatdata schema.
+    """
+    datasets = []
+    for name in case.data:
+        datasets.append(client.new("Dataset", name=name))
+    reader = IngestReader(client, case.metadata, investigation)
+    with case.schema.open("rb") as f:
+        schema = etree.XMLSchema(etree.parse(f))
+    assert schema.validate(reader.infile)
+
 @pytest.mark.parametrize("case", [
     pytest.param(c, id=c.metadata.name, marks=c.marks) for c in cases
 ])
@@ -263,6 +285,7 @@ badcases = [
     Case(
         data = ["e208339"],
         metadata = gettestdata("metadata-5.0-badref.xml"),
+        schema = gettestdata("icatdata-5.0.xsd"),
         checks = {},
         marks = (
             pytest.mark.skipif(icat_version < "5.0",


### PR DESCRIPTION
Fix `ingest-10.xsd` and `ingest.xslt` used by module `icat.ingest` so that the result of the transformation is valid according to the schema for ICAT data files.

Note that this constitutes an incompatible change regarding the input that `icat.ingest` accepts: the order of `datasetTechnique` and `datasetInstrument` subelements of `data` need to be changed.

Close #138.