### PR TITLE
Add support to link datasets with samples in icat.ingest

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -8,6 +8,9 @@ Changelog
 New features
 ------------
 
++ `#125`_, `#140`_: Add support to link datasets with samples in
+  :mod:`icat.ingest`.
+
 + `#122`_, `#133`_: Allow referencing related objects by reference key
   in object references in XML ICAT data file format.
 
@@ -34,6 +37,7 @@ Bug fixes and minor changes
 + `#130`_, `#137`_: Review test suite.
 
 .. _#122: https://github.com/icatproject/python-icat/issues/122
+.. _#125: https://github.com/icatproject/python-icat/issues/125
 .. _#130: https://github.com/icatproject/python-icat/issues/130
 .. _#131: https://github.com/icatproject/python-icat/issues/131
 .. _#132: https://github.com/icatproject/python-icat/issues/132
@@ -43,6 +47,7 @@ Bug fixes and minor changes
 .. _#137: https://github.com/icatproject/python-icat/pull/137
 .. _#138: https://github.com/icatproject/python-icat/issues/138
 .. _#139: https://github.com/icatproject/python-icat/pull/139
+.. _#140: https://github.com/icatproject/python-icat/pull/140
 
 
 1.1.0 (2023-06-30)

--- a/doc/examples/metadata-sample.xml
+++ b/doc/examples/metadata-sample.xml
@@ -1,0 +1,36 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<icatingest version="1.1">
+  <head>
+    <date>2023-10-20T12:15:26+02:00</date>
+    <generator>metadata-writer 0.28</generator>
+  </head>
+  <data>
+    <dataset id="Dataset_1">
+      <name>testingest_sample_1</name>
+      <description>ab3465 at 2.7 K</description>
+      <startDate>2020-09-30T18:02:17+02:00</startDate>
+      <endDate>2020-09-30T20:18:36+02:00</endDate>
+      <sample name="ab3465"/>
+    </dataset>
+    <dataset id="Dataset_2">
+      <name>testingest_sample_2</name>
+      <description>ab3465 at 5.1 K</description>
+      <startDate>2020-09-30T20:29:19+02:00</startDate>
+      <endDate>2020-09-30T21:23:49+02:00</endDate>
+      <sample name="ab3465"/>
+    </dataset>
+    <dataset id="Dataset_3">
+      <name>testingest_sample_3</name>
+      <description>ab3466 at 2.7 K</description>
+      <startDate>2020-09-30T21:35:16+02:00</startDate>
+      <endDate>2020-09-30T23:04:27+02:00</endDate>
+      <sample name="ab3466"/>
+    </dataset>
+    <dataset id="Dataset_4">
+      <name>testingest_sample_4</name>
+      <description>reference</description>
+      <startDate>2020-09-30T23:04:31+02:00</startDate>
+      <endDate>2020-10-01T01:26:07+02:00</endDate>
+    </dataset>
+  </data>
+</icatingest>

--- a/doc/src/ingest.rst
+++ b/doc/src/ingest.rst
@@ -47,6 +47,14 @@ of the datasets will be read from the input file and set in the
 ``DatasetTechnique``, ``DatasetInstrument`` and ``DatasetParameter``
 objects read from the input file in ICAT.
 
+Using ingest file format 1.1, ``Dataset`` objects may also include a
+reference to a ``Sample``.  That ``Sample`` objects needs to exist
+beforehand and needs to be related to the same ``Investigation`` as
+the ``Dataset``.
+
+.. versionchanged: 1.2.0
+   add version 1.1 of the ingest file format, including references to samples
+
 .. autoclass:: icat.ingest.IngestReader
     :members:
     :show-inheritance:

--- a/etc/ingest-10.xsd
+++ b/etc/ingest-10.xsd
@@ -73,7 +73,7 @@
     <xsd:extension base="entityBase">
       <xsd:sequence>
 	<xsd:element name="dataset" type="entityReference" minOccurs="0"/>
-	<xsd:element name="instrument" type="instrumentRef"/>
+	<xsd:element name="instrument" type="nameRef"/>
       </xsd:sequence>
     </xsd:extension>
   </xsd:complexContent>
@@ -84,7 +84,7 @@
     <xsd:extension base="entityBase">
       <xsd:sequence>
 	<xsd:element name="dataset" type="entityReference" minOccurs="0"/>
-	<xsd:element name="technique" type="techniqueRef"/>
+	<xsd:element name="technique" type="nameRef"/>
       </xsd:sequence>
     </xsd:extension>
   </xsd:complexContent>
@@ -108,12 +108,7 @@
 </xsd:complexType>
 
 
-<xsd:complexType name="instrumentRef">
-  <xsd:attribute name="name" type="xsd:string"/>
-  <xsd:attribute name="pid" type="xsd:string"/>
-</xsd:complexType>
-
-<xsd:complexType name="techniqueRef">
+<xsd:complexType name="nameRef">
   <xsd:attribute name="name" type="xsd:string"/>
   <xsd:attribute name="pid" type="xsd:string"/>
 </xsd:complexType>

--- a/etc/ingest-11.xsd
+++ b/etc/ingest-11.xsd
@@ -1,0 +1,137 @@
+<?xml version="1.0" encoding="utf-8"?>
+
+<xsd:schema xmlns:xsd="http://www.w3.org/2001/XMLSchema">
+
+<xsd:annotation>
+  <xsd:documentation>
+    Schema definition for ingest files to ICAT.
+    Version 1.1.
+  </xsd:documentation>
+</xsd:annotation>
+
+<xsd:element name="icatingest" type="icatingest"/>
+
+<xsd:complexType name="icatingest">
+  <xsd:sequence>
+    <xsd:element name="head" type="head" minOccurs="0"/>
+    <xsd:element name="data" type="data"/>
+  </xsd:sequence>
+  <xsd:attribute name="version" type="version_11" use="required"/>
+</xsd:complexType>
+
+<xsd:complexType name="head">
+  <xsd:sequence>
+    <xsd:element name="date" type="xsd:dateTime"/>
+    <xsd:element name="generator" type="xsd:string"/>
+  </xsd:sequence>
+</xsd:complexType>
+
+<xsd:complexType name="data">
+  <xsd:sequence>
+    <xsd:element name="dataset" type="dataset"
+		 minOccurs="0" maxOccurs="unbounded"/>
+    <xsd:element name="datasetInstrument" type="datasetInstrument"
+		 minOccurs="0" maxOccurs="unbounded"/>
+    <xsd:element name="datasetTechnique" type="datasetTechnique"
+		 minOccurs="0" maxOccurs="unbounded"/>
+    <xsd:element name="datasetParameter" type="datasetParameter"
+		 minOccurs="0" maxOccurs="unbounded"/>
+  </xsd:sequence>
+</xsd:complexType>
+
+
+<xsd:complexType name="entityBase">
+  <xsd:attribute name="id" type="identifier"/>
+</xsd:complexType>
+
+<xsd:complexType name="entityReference">
+  <xsd:attribute name="ref" type="identifier" use="required"/>
+</xsd:complexType>
+
+
+<xsd:complexType name="dataset">
+  <xsd:complexContent>
+    <xsd:extension base="entityBase">
+      <xsd:sequence>
+	<xsd:element name="name" type="xsd:string"/>
+	<xsd:element name="description" type="xsd:string" minOccurs="0"/>
+	<xsd:element name="startDate" type="xsd:dateTime" minOccurs="0"/>
+	<xsd:element name="endDate" type="xsd:dateTime" minOccurs="0"/>
+	<xsd:element name="sample" type="nameRef" minOccurs="0"/>
+	<xsd:element name="datasetInstruments" type="datasetInstrument"
+		     minOccurs="0" maxOccurs="unbounded"/>
+	<xsd:element name="datasetTechniques" type="datasetTechnique"
+		     minOccurs="0" maxOccurs="unbounded"/>
+	<xsd:element name="parameters" type="datasetParameter"
+		     minOccurs="0" maxOccurs="unbounded"/>
+      </xsd:sequence>
+    </xsd:extension>
+  </xsd:complexContent>
+</xsd:complexType>
+
+<xsd:complexType name="datasetInstrument">
+  <xsd:complexContent>
+    <xsd:extension base="entityBase">
+      <xsd:sequence>
+	<xsd:element name="dataset" type="entityReference" minOccurs="0"/>
+	<xsd:element name="instrument" type="nameRef"/>
+      </xsd:sequence>
+    </xsd:extension>
+  </xsd:complexContent>
+</xsd:complexType>
+
+<xsd:complexType name="datasetTechnique">
+  <xsd:complexContent>
+    <xsd:extension base="entityBase">
+      <xsd:sequence>
+	<xsd:element name="dataset" type="entityReference" minOccurs="0"/>
+	<xsd:element name="technique" type="nameRef"/>
+      </xsd:sequence>
+    </xsd:extension>
+  </xsd:complexContent>
+</xsd:complexType>
+
+<xsd:complexType name="datasetParameter">
+  <xsd:complexContent>
+    <xsd:extension base="entityBase">
+      <xsd:sequence>
+	<xsd:element name="dateTimeValue" type="xsd:dateTime" minOccurs="0"/>
+	<xsd:element name="error" type="xsd:double" minOccurs="0"/>
+	<xsd:element name="numericValue" type="xsd:double" minOccurs="0"/>
+	<xsd:element name="rangeBottom" type="xsd:double" minOccurs="0"/>
+	<xsd:element name="rangeTop" type="xsd:double" minOccurs="0"/>
+	<xsd:element name="stringValue" type="xsd:string" minOccurs="0"/>
+	<xsd:element name="dataset" type="entityReference" minOccurs="0"/>
+	<xsd:element name="type" type="parameterTypeRef"/>
+      </xsd:sequence>
+    </xsd:extension>
+  </xsd:complexContent>
+</xsd:complexType>
+
+
+<xsd:complexType name="nameRef">
+  <xsd:attribute name="name" type="xsd:string"/>
+  <xsd:attribute name="pid" type="xsd:string"/>
+</xsd:complexType>
+
+<xsd:complexType name="parameterTypeRef">
+  <xsd:attribute name="name" type="xsd:string"/>
+  <xsd:attribute name="units" type="xsd:string"/>
+  <xsd:attribute name="pid" type="xsd:string"/>
+</xsd:complexType>
+
+
+<xsd:simpleType name="identifier">
+  <xsd:restriction base="xsd:string">
+    <xsd:pattern value="[A-Za-z][A-Za-z0-9_]*"/>
+  </xsd:restriction>
+</xsd:simpleType>
+
+<xsd:simpleType name="version_11">
+  <xsd:restriction base="xsd:string">
+    <xsd:enumeration value="1.1"/>
+  </xsd:restriction>
+</xsd:simpleType>
+
+
+</xsd:schema>

--- a/etc/ingest.xslt
+++ b/etc/ingest.xslt
@@ -28,15 +28,9 @@
 	    <xsl:copy-of select="startDate"/>
 	    <investigation ref="_Investigation"/>
 	    <type name="raw"/>
-	    <xsl:for-each select="datasetInstruments">
-		<xsl:copy-of select="."/>
-	    </xsl:for-each>
-	    <xsl:for-each select="datasetTechniques">
-		<xsl:copy-of select="."/>
-	    </xsl:for-each>
-	    <xsl:for-each select="parameters">
-		<xsl:copy-of select="."/>
-	    </xsl:for-each>
+	    <xsl:copy-of select="datasetInstruments"/>
+	    <xsl:copy-of select="datasetTechniques"/>
+	    <xsl:copy-of select="parameters"/>
 	</dataset>
     </xsl:template>
 

--- a/etc/ingest.xslt
+++ b/etc/ingest.xslt
@@ -27,11 +27,19 @@
 	    <xsl:copy-of select="name"/>
 	    <xsl:copy-of select="startDate"/>
 	    <investigation ref="_Investigation"/>
+	    <xsl:apply-templates select="sample"/>
 	    <type name="raw"/>
 	    <xsl:copy-of select="datasetInstruments"/>
 	    <xsl:copy-of select="datasetTechniques"/>
 	    <xsl:copy-of select="parameters"/>
 	</dataset>
+    </xsl:template>
+
+    <xsl:template match="/icatingest/data/dataset/sample">
+	<xsl:copy>
+	    <xsl:attribute name="investigation.ref">_Investigation</xsl:attribute>
+	    <xsl:copy-of select="@*"/>
+	</xsl:copy>
     </xsl:template>
 
     <xsl:template match="*">

--- a/icat/ingest.py
+++ b/icat/ingest.py
@@ -43,6 +43,7 @@ class IngestReader(icat.dumpfile_xml.XMLDumpFileReader):
     """
     XSD_Map = {
         ('icatingest', '1.0'): "ingest-10.xsd",
+        ('icatingest', '1.1'): "ingest-11.xsd",
     }
     """A mapping to select the XSD file to use.  Keys are pairs of root
     element name and version attribute, the values are the

--- a/setup.py
+++ b/setup.py
@@ -132,7 +132,7 @@ class build_test(setuptools.Command):
                    for ext in ("xml", "yaml") ]
         files += glob(os.path.join("doc", "examples", "metadata-*.xml"))
         files += [ os.path.join("etc", f)
-                   for f in ["ingest-10.xsd", "ingest.xslt"] ]
+                   for f in ["ingest-10.xsd", "ingest-11.xsd", "ingest.xslt"] ]
         for f in files:
             dest = os.path.join(destdir, os.path.basename(f))
             self.copy_file(f, dest, preserve_mode=False)

--- a/tests/test_06_ingest.py
+++ b/tests/test_06_ingest.py
@@ -256,6 +256,69 @@ cases = [
                                reason="Need ICAT schema 5.0 or newer"),
         ),
     ),
+    Case(
+        data = [ "testingest_sample_1", "testingest_sample_2",
+                 "testingest_sample_3", "testingest_sample_4" ],
+        metadata = gettestdata("metadata-sample.xml"),
+        checks = {
+            "testingest_sample_1": [
+                ("SELECT ds.description FROM Dataset ds WHERE ds.id = %d",
+                 "ab3465 at 2.7 K"),
+                ("SELECT ds.startDate FROM Dataset ds WHERE ds.id = %d",
+                 datetime.datetime(2020, 9, 30, 18, 2, 17, tzinfo=cest)),
+                ("SELECT ds.endDate FROM Dataset ds WHERE ds.id = %d",
+                 datetime.datetime(2020, 9, 30, 20, 18, 36, tzinfo=cest)),
+                (("SELECT COUNT(s) FROM Sample s JOIN s.datasets AS ds "
+                  "WHERE ds.id = %d"),
+                 1),
+                (("SELECT s.name FROM Sample s JOIN s.datasets AS ds "
+                  "WHERE ds.id = %d"),
+                 "ab3465"),
+            ],
+            "testingest_sample_2": [
+                ("SELECT ds.description FROM Dataset ds WHERE ds.id = %d",
+                 "ab3465 at 5.1 K"),
+                ("SELECT ds.startDate FROM Dataset ds WHERE ds.id = %d",
+                 datetime.datetime(2020, 9, 30, 20, 29, 19, tzinfo=cest)),
+                ("SELECT ds.endDate FROM Dataset ds WHERE ds.id = %d",
+                 datetime.datetime(2020, 9, 30, 21, 23, 49, tzinfo=cest)),
+                (("SELECT COUNT(s) FROM Sample s JOIN s.datasets AS ds "
+                  "WHERE ds.id = %d"),
+                 1),
+                (("SELECT s.name FROM Sample s JOIN s.datasets AS ds "
+                  "WHERE ds.id = %d"),
+                 "ab3465"),
+            ],
+            "testingest_sample_3": [
+                ("SELECT ds.description FROM Dataset ds WHERE ds.id = %d",
+                 "ab3466 at 2.7 K"),
+                ("SELECT ds.startDate FROM Dataset ds WHERE ds.id = %d",
+                 datetime.datetime(2020, 9, 30, 21, 35, 16, tzinfo=cest)),
+                ("SELECT ds.endDate FROM Dataset ds WHERE ds.id = %d",
+                 datetime.datetime(2020, 9, 30, 23, 4, 27, tzinfo=cest)),
+                (("SELECT COUNT(s) FROM Sample s JOIN s.datasets AS ds "
+                  "WHERE ds.id = %d"),
+                 1),
+                (("SELECT s.name FROM Sample s JOIN s.datasets AS ds "
+                  "WHERE ds.id = %d"),
+                 "ab3466"),
+            ],
+            "testingest_sample_4": [
+                ("SELECT ds.description FROM Dataset ds WHERE ds.id = %d",
+                 "reference"),
+                ("SELECT ds.startDate FROM Dataset ds WHERE ds.id = %d",
+                 datetime.datetime(2020, 9, 30, 23, 4, 31, tzinfo=cest)),
+                ("SELECT ds.endDate FROM Dataset ds WHERE ds.id = %d",
+                 datetime.datetime(2020, 10, 1, 1, 26, 7, tzinfo=cest)),
+                (("SELECT COUNT(s) FROM Sample s JOIN s.datasets AS ds "
+                  "WHERE ds.id = %d"),
+                 0),
+            ],
+        },
+        marks = (
+            pytest.mark.xfail(reason="Issue #125"),
+        ),
+    ),
 ]
 @pytest.mark.parametrize("case", [
     pytest.param(c, id=c.metadata.name, marks=c.marks) for c in cases

--- a/tests/test_06_ingest.py
+++ b/tests/test_06_ingest.py
@@ -321,9 +321,7 @@ cases = [
                  0),
             ],
         },
-        marks = (
-            pytest.mark.xfail(reason="Issue #125"),
-        ),
+        marks = (),
     ),
 ]
 


### PR DESCRIPTION
Add version 1.1 of the ingest file format that features references to a `Sample` from a `Dataset`. Close #125.