### PR TITLE
icat.ingest.IngestReader: drop class attribute XSLT_name in favour of a new XSLT_Map

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -2,6 +2,29 @@ Changelog
 =========
 
 
+1.3.0 (not yet released)
+~~~~~~~~~~~~~~~~~~~~~~~~
+
+New features
+------------
+
++ `#143`_, `#144`_: Make it easier to configure XSLT files to use for
+  processing the input in custom versions of
+  :class:`icat.ingest.IngestReader`.
+
+Incompatible changes
+--------------------
+
++ `#144`_: Drop class attribute
+  :attr:`icat.ingest.IngestReader.XSLT_name` in favour of
+  :attr:`icat.ingest.IngestReader.XSLT_Map`.
+
+  Note that :mod:`icat.ingest` has been declared experimental for now.
+
+.. _#143: https://github.com/icatproject/python-icat/issues/143
+.. _#144: https://github.com/icatproject/python-icat/pull/144
+
+
 1.2.0 (2023-10-31)
 ~~~~~~~~~~~~~~~~~~
 

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -18,7 +18,9 @@ include etc/ingest.xslt
 include tests/conftest.py
 include tests/data/legacy-icatdump-*.xml
 include tests/data/legacy-icatdump-*.yaml
-include tests/data/metadata-5.0-badref.xml
+include tests/data/metadata-*.xml
+include tests/data/myingest.xsd
+include tests/data/myingest.xslt
 include tests/data/ref-icatdump-*.xml
 include tests/data/ref-icatdump-*.yaml
 include tests/data/summary*

--- a/doc/src/ingest.rst
+++ b/doc/src/ingest.rst
@@ -55,6 +55,10 @@ the ``Dataset``.
 .. versionchanged:: 1.2.0
    add version 1.1 of the ingest file format, including references to samples
 
+.. versionchanged:: 1.3.0
+   drop class attribute :attr:`~icat.ingest.IngestReader.XSLT_name` in
+   favour of :attr:`~icat.ingest.IngestReader.XSLT_Map`.
+
 .. autoclass:: icat.ingest.IngestReader
     :members:
     :show-inheritance:
@@ -114,8 +118,8 @@ Customizing the input format
 
 The ingest input file format may be customized by providing custom XSD
 and XSLT files.  The easiest way to do that is to subclass
-:class:`~icat.ingest.IngestReader`, you'd only need to override some
-class attributes as follows::
+:class:`~icat.ingest.IngestReader`.  In most cases, you'd only need to
+override some class attributes as follows::
 
   from pathlib import Path
   import icat.ingest
@@ -132,18 +136,27 @@ class attributes as follows::
       }
 
       # Override the XSLT file to use:
-      XSLT_name = "myingest.xslt"
+      XSLT_Map = {
+          'legacyingest': "legacy-ingest.xslt",
+          'myingest': "my-ingest.xslt",
+      }
 
-:attr:`~icat.ingest.IngestReader.XSD_Map` is a mapping with pairs of
-root element name and version attribute as keys and XSD file names as
-values.  The method :meth:`~icat.ingest.IngestReader.get_xsd` inspects
-the input file and selects the file name from
-:attr:`~icat.ingest.IngestReader.XSD_Map` accordingly.  (Note that
-there is no such mapping for the XSLT file, because its is assumed
-that it is fairly easy to formulate adaptations to the input version
-directly in XSLT, so one single XSLT file would be sufficient to cover
-all versions.)  In the above example, `MyFacilityIngestReader` would
-recognize input files like
+:attr:`~icat.ingest.IngestReader.XSD_Map` and
+:attr:`~icat.ingest.IngestReader.XSLT_Map` are mappings with
+properties of the root element of the input data as keys and file
+names as values.  The methods
+:meth:`~icat.ingest.IngestReader.get_xsd` and
+:meth:`~icat.ingest.IngestReader.get_xslt` respectively inspect the
+input file and use these mappings to select the XSD and XSLT file
+accordingly.  Note that :attr:`~icat.ingest.IngestReader.XSD_Map`
+takes tuples of root element name and version attribute as keys, while
+:attr:`~icat.ingest.IngestReader.XSLT_Map` uses the name of the root
+element name alone.  It is is assumed that it is fairly easy to
+formulate adaptations to the input version directly in XSLT, so one
+single XSLT file would be sufficient to cover all versions.
+
+In the above example, `MyFacilityIngestReader` would recognize input
+files like
 
 .. code-block:: xml
 

--- a/icat/ingest.py
+++ b/icat/ingest.py
@@ -127,9 +127,12 @@ class IngestReader(icat.dumpfile_xml.XMLDumpFileReader):
         :type ingest_data: :class:`lxml.etree._ElementTree`
         :return: path to the XSLT file.
         :rtype: :class:`~pathlib.Path`
+        :raise icat.exception.InvalidIngestFileError: if the root
+            element name could not be found in
+            :attr:`~icat.ingest.IngestReader.XSLT_Map`.
 
         .. versionchanged:: 1.3.0
-            Lookup the root element name in
+            lookup the root element name in
             :attr:`~icat.ingest.IngestReader.XSLT_Map` rather than
             using a static file name.
         """

--- a/icat/ingest.py
+++ b/icat/ingest.py
@@ -49,8 +49,14 @@ class IngestReader(icat.dumpfile_xml.XMLDumpFileReader):
     element name and version attribute, the values are the
     corresponding name of the XSD file.
     """
-    XSLT_name = "ingest.xslt"
-    """The name of the XSLT file to use.
+    XSLT_Map = {
+        'icatingest': "ingest.xslt",
+    }
+    """A mapping to select the XSLT file to use.  Keys are the root
+    element name, the values are the corresponding name of the XSLT
+    file.
+
+    .. versionadded:: 1.3.0
     """
 
     def __init__(self, client, metadata, investigation):
@@ -105,9 +111,11 @@ class IngestReader(icat.dumpfile_xml.XMLDumpFileReader):
     def get_xslt(self, ingest_data):
         """Get the XSLT file.
 
-        Take :attr:`~icat.ingest.IngestReader.XSLT_name` as a file
-        name relative to :attr:`~icat.ingest.IngestReader.SchemaDir`
-        and return this path.
+        Inspect the root element in the input data and lookup the
+        element name in :attr:`~icat.ingest.IngestReader.XSLT_Map`.
+        The value is taken as a file name relative to
+        :attr:`~icat.ingest.IngestReader.SchemaDir` and this path is
+        returned.
 
         Subclasses may override this method to customize the XSLT file
         to use.  These derived versions may inspect the input data to
@@ -119,8 +127,18 @@ class IngestReader(icat.dumpfile_xml.XMLDumpFileReader):
         :type ingest_data: :class:`lxml.etree._ElementTree`
         :return: path to the XSLT file.
         :rtype: :class:`~pathlib.Path`
+
+        .. versionchanged:: 1.3.0
+            Lookup the root element name in
+            :attr:`~icat.ingest.IngestReader.XSLT_Map` rather than
+            using a static file name.
         """
-        return self.SchemaDir / self.XSLT_name
+        root = ingest_data.getroot()
+        try:
+            xslt = self.XSLT_Map[root.tag]
+        except KeyError:
+            raise InvalidIngestFileError("unknown format")
+        return self.SchemaDir / xslt
 
     def getobjs(self):
         """Iterate over the objects in the ingest file.

--- a/tests/data/metadata-custom-icatingest.xml
+++ b/tests/data/metadata-custom-icatingest.xml
@@ -1,0 +1,15 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<icatingest version="1.0">
+  <head>
+    <date>2023-06-16T11:01:15+02:00</date>
+    <generator>metadata-writer 0.29</generator>
+  </head>
+  <data>
+    <dataset id="Dataset_1">
+      <name>testingest_custom_icatingest_1</name>
+      <description>Dy01Cp02 at 2.7 K</description>
+      <startDate>2022-02-03T15:40:12+01:00</startDate>
+      <endDate>2022-02-03T17:04:22+01:00</endDate>
+    </dataset>
+  </data>
+</icatingest>

--- a/tests/data/metadata-custom-myingest.xml
+++ b/tests/data/metadata-custom-myingest.xml
@@ -1,0 +1,15 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<myingest version="1.0">
+  <head>
+    <date>2023-06-16T11:01:15+02:00</date>
+    <generator>metadata-writer 0.29</generator>
+  </head>
+  <data>
+    <dataset id="Dataset_1">
+      <name>testingest_custom_myingest_1</name>
+      <description>Dy01Cp02 at 2.7 K</description>
+      <startDate>2022-02-03T15:40:12+01:00</startDate>
+      <endDate>2022-02-03T17:04:22+01:00</endDate>
+    </dataset>
+  </data>
+</myingest>

--- a/tests/data/myingest.xsd
+++ b/tests/data/myingest.xsd
@@ -1,0 +1,138 @@
+<?xml version="1.0" encoding="utf-8"?>
+
+<xsd:schema xmlns:xsd="http://www.w3.org/2001/XMLSchema">
+
+<xsd:annotation>
+  <xsd:documentation>
+    Schema definition for ingest files to ICAT.
+    Test schema for testing the use of a custom schema.
+    Version 1.0.
+  </xsd:documentation>
+</xsd:annotation>
+
+<xsd:element name="myingest" type="myingest"/>
+
+<xsd:complexType name="myingest">
+  <xsd:sequence>
+    <xsd:element name="head" type="head" minOccurs="0"/>
+    <xsd:element name="data" type="data"/>
+  </xsd:sequence>
+  <xsd:attribute name="version" type="version_10" use="required"/>
+</xsd:complexType>
+
+<xsd:complexType name="head">
+  <xsd:sequence>
+    <xsd:element name="date" type="xsd:dateTime"/>
+    <xsd:element name="generator" type="xsd:string"/>
+  </xsd:sequence>
+</xsd:complexType>
+
+<xsd:complexType name="data">
+  <xsd:sequence>
+    <xsd:element name="dataset" type="dataset"
+		 minOccurs="0" maxOccurs="unbounded"/>
+    <xsd:element name="datasetTechnique" type="datasetTechnique"
+		 minOccurs="0" maxOccurs="unbounded"/>
+    <xsd:element name="datasetInstrument" type="datasetInstrument"
+		 minOccurs="0" maxOccurs="unbounded"/>
+    <xsd:element name="datasetParameter" type="datasetParameter"
+		 minOccurs="0" maxOccurs="unbounded"/>
+  </xsd:sequence>
+</xsd:complexType>
+
+
+<xsd:complexType name="entityBase">
+  <xsd:attribute name="id" type="identifier"/>
+</xsd:complexType>
+
+<xsd:complexType name="entityReference">
+  <xsd:attribute name="ref" type="identifier" use="required"/>
+</xsd:complexType>
+
+
+<xsd:complexType name="dataset">
+  <xsd:complexContent>
+    <xsd:extension base="entityBase">
+      <xsd:sequence>
+	<xsd:element name="name" type="xsd:string"/>
+	<xsd:element name="description" type="xsd:string" minOccurs="0"/>
+	<xsd:element name="startDate" type="xsd:dateTime" minOccurs="0"/>
+	<xsd:element name="endDate" type="xsd:dateTime" minOccurs="0"/>
+	<xsd:element name="sample" type="nameRef" minOccurs="0"/>
+	<xsd:element name="datasetInstruments" type="datasetInstrument"
+		     minOccurs="0" maxOccurs="unbounded"/>
+	<xsd:element name="datasetTechniques" type="datasetTechnique"
+		     minOccurs="0" maxOccurs="unbounded"/>
+	<xsd:element name="parameters" type="datasetParameter"
+		     minOccurs="0" maxOccurs="unbounded"/>
+      </xsd:sequence>
+    </xsd:extension>
+  </xsd:complexContent>
+</xsd:complexType>
+
+<xsd:complexType name="datasetTechnique">
+  <xsd:complexContent>
+    <xsd:extension base="entityBase">
+      <xsd:sequence>
+	<xsd:element name="dataset" type="entityReference" minOccurs="0"/>
+	<xsd:element name="technique" type="nameRef"/>
+      </xsd:sequence>
+    </xsd:extension>
+  </xsd:complexContent>
+</xsd:complexType>
+
+<xsd:complexType name="datasetInstrument">
+  <xsd:complexContent>
+    <xsd:extension base="entityBase">
+      <xsd:sequence>
+	<xsd:element name="dataset" type="entityReference" minOccurs="0"/>
+	<xsd:element name="instrument" type="nameRef"/>
+      </xsd:sequence>
+    </xsd:extension>
+  </xsd:complexContent>
+</xsd:complexType>
+
+<xsd:complexType name="datasetParameter">
+  <xsd:complexContent>
+    <xsd:extension base="entityBase">
+      <xsd:sequence>
+	<xsd:element name="dateTimeValue" type="xsd:dateTime" minOccurs="0"/>
+	<xsd:element name="error" type="xsd:double" minOccurs="0"/>
+	<xsd:element name="numericValue" type="xsd:double" minOccurs="0"/>
+	<xsd:element name="rangeBottom" type="xsd:double" minOccurs="0"/>
+	<xsd:element name="rangeTop" type="xsd:double" minOccurs="0"/>
+	<xsd:element name="stringValue" type="xsd:string" minOccurs="0"/>
+	<xsd:element name="dataset" type="entityReference" minOccurs="0"/>
+	<xsd:element name="type" type="parameterTypeRef"/>
+      </xsd:sequence>
+    </xsd:extension>
+  </xsd:complexContent>
+</xsd:complexType>
+
+
+<xsd:complexType name="nameRef">
+  <xsd:attribute name="name" type="xsd:string"/>
+  <xsd:attribute name="pid" type="xsd:string"/>
+</xsd:complexType>
+
+<xsd:complexType name="parameterTypeRef">
+  <xsd:attribute name="name" type="xsd:string"/>
+  <xsd:attribute name="units" type="xsd:string"/>
+  <xsd:attribute name="pid" type="xsd:string"/>
+</xsd:complexType>
+
+
+<xsd:simpleType name="identifier">
+  <xsd:restriction base="xsd:string">
+    <xsd:pattern value="[A-Za-z][A-Za-z0-9_]*"/>
+  </xsd:restriction>
+</xsd:simpleType>
+
+<xsd:simpleType name="version_10">
+  <xsd:restriction base="xsd:string">
+    <xsd:enumeration value="1.0"/>
+  </xsd:restriction>
+</xsd:simpleType>
+
+
+</xsd:schema>

--- a/tests/data/myingest.xslt
+++ b/tests/data/myingest.xslt
@@ -1,0 +1,59 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<xsl:stylesheet version="1.0"
+		xmlns:xsl="http://www.w3.org/1999/XSL/Transform">
+
+    <xsl:output method="xml"/>
+
+    <xsl:template match="/myingest">
+	<icatdata>
+	    <xsl:apply-templates/>
+	</icatdata>
+    </xsl:template>
+
+    <xsl:template match="/myingest/head"/>
+
+    <xsl:template match="/myingest/data">
+	<data>
+	    <xsl:apply-templates/>
+	</data>
+    </xsl:template>
+
+    <xsl:template match="/myingest/data/dataset">
+	<dataset>
+	    <xsl:copy-of select="@id"/>
+	    <complete>false</complete>
+	    <xsl:apply-templates select="description"/>
+	    <xsl:copy-of select="endDate"/>
+	    <xsl:copy-of select="name"/>
+	    <xsl:copy-of select="startDate"/>
+	    <investigation ref="_Investigation"/>
+	    <xsl:apply-templates select="sample"/>
+	    <type name="raw"/>
+	    <xsl:copy-of select="datasetInstruments"/>
+	    <xsl:copy-of select="datasetTechniques"/>
+	    <parameters>
+		<stringValue>x-ray</stringValue>
+		<type name="Probe"/>
+	    </parameters>
+	    <xsl:copy-of select="parameters"/>
+	</dataset>
+    </xsl:template>
+
+    <xsl:template match="/myingest/data/dataset/description">
+	<xsl:copy>
+	    <xsl:value-of select="concat('My Ingest: ', .)"/>
+	</xsl:copy>
+    </xsl:template>
+
+    <xsl:template match="/myingest/data/dataset/sample">
+	<xsl:copy>
+	    <xsl:attribute name="investigation.ref">_Investigation</xsl:attribute>
+	    <xsl:copy-of select="@*"/>
+	</xsl:copy>
+    </xsl:template>
+
+    <xsl:template match="*">
+	<xsl:copy-of select="."/>
+    </xsl:template>
+
+</xsl:stylesheet>


### PR DESCRIPTION
As pointed out in #143, the current way of controlling the XSLT file to use for processing the input in class `icat.ingest.IngestReader` is inconvenient to customize the behavior in some cases.

This PR now drops the class attribute `XSLT_name` in favour of `XSLT_Map`. This new class attribute maps the name of the root element in the input to the file name of the XSLT file to use to process that data. This way, customized classes may add their own input format while still keeping the standard format providing by python-icat as an alternative. This is not only more convenient, but also more consistent with the way the name of XSD file is controlled.

Close #143.