### PR TITLE
Provide a meaningful error message if the IngestReader  input fails XSD validation

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -32,6 +32,10 @@ Incompatible changes
 Bug fixes and minor changes
 ---------------------------
 
++ `#151`_: Provide a more meaningful error message if the input to
+  :class:`icat.ingest.IngestReader` fails validation against the XML
+  Schema Definition.
+
 + `#141`_, `#142`_, `#150`_: Review documentation.
 
 + `#145`_: Review build tool chain.
@@ -46,6 +50,7 @@ Bug fixes and minor changes
 .. _#148: https://github.com/icatproject/python-icat/issues/148
 .. _#149: https://github.com/icatproject/python-icat/pull/149
 .. _#150: https://github.com/icatproject/python-icat/pull/150
+.. _#151: https://github.com/icatproject/python-icat/pull/151
 
 
 .. _changes-1_2_0:

--- a/src/icat/ingest.py
+++ b/src/icat/ingest.py
@@ -112,8 +112,10 @@ class IngestReader(XMLDumpFileReader):
             raise InvalidIngestFileError(e)
         with self.get_xsd(ingest_data).open("rb") as f:
             schema = etree.XMLSchema(etree.parse(f))
-        if not schema.validate(ingest_data):
-            raise InvalidIngestFileError("validation failed")
+        try:
+            schema.assertValid(ingest_data)
+        except etree.DocumentInvalid as exc:
+            raise InvalidIngestFileError("DocumentInvalid: %s" % exc)
         self.add_environment(client, ingest_data)
         with self.get_xslt(ingest_data).open("rb") as f:
             xslt = etree.XSLT(etree.parse(f))

--- a/tests/test_06_ingest.py
+++ b/tests/test_06_ingest.py
@@ -4,6 +4,7 @@
 from collections import namedtuple
 import datetime
 import io
+import logging
 import pytest
 pytest.importorskip("lxml")
 from lxml import etree
@@ -14,6 +15,7 @@ from icat.query import Query
 from conftest import (getConfig, gettestdata, icat_version,
                       get_icatdata_schema, testdatadir)
 
+logger = logging.getLogger(__name__)
 
 def get_test_investigation(client):
     query = Query(client, "Investigation", conditions={
@@ -560,9 +562,10 @@ def test_ingest_error_invalid(client, investigation, schemadir, case):
     datasets = []
     for name in case.data:
         datasets.append(client.new("Dataset", name=name))
-    with pytest.raises(icat.InvalidIngestFileError):
+    with pytest.raises(icat.InvalidIngestFileError) as exc:
         reader = IngestReader(client, case.metadata, investigation)
         reader.ingest(datasets, dry_run=True, update_ds=True)
+    logger.info("Raised %s: %s", exc.type.__name__, exc.value)
 
 searcherr_attr_metadata = NamedBytesIO("""<?xml version='1.0' encoding='UTF-8'?>
 <icatingest version="1.0">
@@ -621,9 +624,10 @@ def test_ingest_error_searcherr(client, investigation, schemadir, case):
     datasets = []
     for name in case.data:
         datasets.append(client.new("Dataset", name=name))
-    with pytest.raises(icat.SearchResultError):
+    with pytest.raises(icat.SearchResultError) as exc:
         reader = IngestReader(client, case.metadata, investigation)
         reader.ingest(datasets, dry_run=True, update_ds=True)
+    logger.info("Raised %s: %s", exc.type.__name__, exc.value)
 
 
 customcases = [

--- a/tests/test_06_ingest.py
+++ b/tests/test_06_ingest.py
@@ -357,7 +357,7 @@ def test_ingest_schema(client, investigation, schemadir, case):
     reader = IngestReader(client, case.metadata, investigation)
     with get_icatdata_schema().open("rb") as f:
         schema = etree.XMLSchema(etree.parse(f))
-    assert schema.validate(reader.infile)
+    schema.assertValid(reader.infile)
 
 @pytest.mark.parametrize("case", [
     pytest.param(c, id=c.metadata.name, marks=c.marks) for c in cases
@@ -735,7 +735,7 @@ def test_ingest_env(monkeypatch, client, investigation, schemadir, case):
     reader = IngestReader(client, case.metadata, investigation)
     with get_icatdata_schema().open("rb") as f:
         schema = etree.XMLSchema(etree.parse(f))
-    assert schema.validate(reader.infile)
+    schema.assertValid(reader.infile)
     version_elem = reader.infile.xpath("/icatdata/head/apiversion")
     assert version_elem
     assert version_elem[0].text == str(client.apiversion)


### PR DESCRIPTION
Call `XMLSchema().assertValid()` rather than `XMLSchema().validate()` which raises a more meaningful error message.  Pass that error message in the `InvalidIngestFileError` raised by `IngestReader`. As a result a much more meaningful error message is provided than a plain "Invalid ingest file: validation failed".