### PR TITLE
Fix a documentation error

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -2,6 +2,17 @@ Changelog
 =========
 
 
+dev (not yet released)
+~~~~~~~~~~~~~~~~~~~~~~
+
+Bug fixes and minor changes
+---------------------------
+
++ `#152`_: Fix a documentation error
+
+.. _#152: https://github.com/icatproject/python-icat/pull/152
+
+
 .. _changes-1_3_0:
 
 1.3.0 (2024-03-21)

--- a/src/icat/client.py
+++ b/src/icat/client.py
@@ -564,7 +564,7 @@ class Client(suds.client.Client):
                 # This version works!
                 query = Query(client, "Dataset", includes="1", order=["id"])
                 for ds in client.searchChunked(query):
-                    if not ds.complete:
+                    if ds.complete:
                         continue
                     ds.complete = True
                     ds.update()


### PR DESCRIPTION
Fix a logical error in a code example in the docstring of `Client.searchChunked()`.