### PR TITLE
Fix duplicate test name test_07_entity_validate

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -9,8 +9,10 @@ Bug fixes and minor changes
 ---------------------------
 
 + `#152`_: Fix a documentation error
++ `#154`_: Fix a duplicate test name
 
 .. _#152: https://github.com/icatproject/python-icat/pull/152
+.. _#154: https://github.com/icatproject/python-icat/pull/154
 
 
 .. _changes-1_3_0:

--- a/tests/test_07_entity_validate.py
+++ b/tests/test_07_entity_validate.py
@@ -100,7 +100,7 @@ def test_valid_numeric_value(client, dataset):
     param.create()
     assert param.id is not None
 
-def test_valid_string_permissible_value(client, dataset):
+def test_valid_string_simple_value(client, dataset):
     """Create a simple STRING parameter.
     """
     client.typemap['parameter'].validate = validate_param


### PR DESCRIPTION
In the test module `test_07_entity_validate` is a name collision with two different tests having the same name.  Fix that.