### PR TITLE
icat.ingest now considered stable

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -11,8 +11,14 @@ Bug fixes and minor changes
 + `#152`_: Fix a documentation error
 + `#154`_: Fix a duplicate test name
 
+Misc
+----
+
++ `#157`_: :mod:`icat.ingest` now considered stable.
+
 .. _#152: https://github.com/icatproject/python-icat/pull/152
 .. _#154: https://github.com/icatproject/python-icat/pull/154
+.. _#157: https://github.com/icatproject/python-icat/pull/157
 
 
 .. _changes-1_3_0:

--- a/doc/src/ingest.rst
+++ b/doc/src/ingest.rst
@@ -5,11 +5,6 @@
 
 .. versionadded:: 1.1.0
 
-.. note::
-   The status of this module in the current version is still
-   experimental.  There may be incompatible changes in the future
-   even in minor releases of python-icat.
-
 This module provides class :class:`icat.ingest.IngestReader` that
 reads :ref:`ICAT-ingest-files` to add them to ICAT.  It is designed
 for the use case of ingesting metadata for datasets created during

--- a/src/icat/ingest.py
+++ b/src/icat/ingest.py
@@ -1,10 +1,5 @@
 """Ingest metadata into ICAT.
 
-.. note::
-   The status of this module in the current version is still
-   experimental.  There may be incompatible changes in the future
-   even in minor releases of python-icat.
-
 .. versionadded:: 1.1.0
 """
 


### PR DESCRIPTION
Remove note on experimental status from `icat.ingest` module documentation.