### PR TITLE
Add class attributes to IngestReader to configure prescribed values

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -2,6 +2,22 @@ Changelog
 =========
 
 
+.. _changes-1_5_0:
+
+1.5.0 (not yet released)
+~~~~~~~~~~~~~~~~~~~~~~~~
+
+New features
+------------
+
++ `#160`_, `#161`_: Add class attributes to
+  :class:`icat.ingest.IngestReader` to make some prescribed values in
+  the transformation to ICAT data file format configurable.
+
+.. _#160: https://github.com/icatproject/python-icat/issues/160
+.. _#161: https://github.com/icatproject/python-icat/pull/161
+
+
 .. _changes-1_4_0:
 
 1.4.0 (2024-08-30)

--- a/doc/src/ingest.rst
+++ b/doc/src/ingest.rst
@@ -23,6 +23,14 @@ format of the input files may be customized to some extent by
 providing custom versions of XSD and XSLT files, see
 :ref:`ingest-customize` below.
 
+Some attributes and relations of the ``Dataset`` objects are
+prescribed during the transformation into ICAT data file format,
+namely the ``complete`` attribute and the name of the ``DatasetType``
+to relate them to.  The prescribed values are set in class attributes
+:attr:`~icat.ingest.IngestReader.Dataset_complete` and
+:attr:`~icat.ingest.IngestReader.DatasetType_name` respectively.  They
+may be customized by overriding these class attributes.
+
 The ``Dataset`` objects in the input will not be created by
 :class:`~icat.ingest.IngestReader`, because it is assumed that a
 separate workflow in the caller will copy the content of datafiles to

--- a/etc/ingest.xslt
+++ b/etc/ingest.xslt
@@ -23,14 +23,14 @@
     <xsl:template match="/icatingest/data/dataset">
 	<dataset>
 	    <xsl:copy-of select="@id"/>
-	    <complete>false</complete>
+	    <complete><xsl:copy-of select="/icatingest/_environment/@dataset_complete"/></complete>
 	    <xsl:copy-of select="description"/>
 	    <xsl:copy-of select="endDate"/>
 	    <xsl:copy-of select="name"/>
 	    <xsl:copy-of select="startDate"/>
 	    <investigation ref="_Investigation"/>
 	    <xsl:apply-templates select="sample"/>
-	    <type name="raw"/>
+	    <xsl:apply-templates select="type"/>
 	    <xsl:copy-of select="datasetInstruments"/>
 	    <xsl:copy-of select="datasetTechniques"/>
 	    <xsl:copy-of select="parameters"/>
@@ -41,6 +41,12 @@
 	<xsl:copy>
 	    <xsl:attribute name="investigation.ref">_Investigation</xsl:attribute>
 	    <xsl:copy-of select="@*"/>
+	</xsl:copy>
+    </xsl:template>
+
+    <xsl:template match="/icatingest/data/dataset/type">
+	<xsl:copy>
+	    <xsl:attribute name="name"><xsl:copy-of select="/icatingest/_environment/@datasettype_name"/></xsl:attribute>
 	</xsl:copy>
     </xsl:template>
 

--- a/etc/ingest.xslt
+++ b/etc/ingest.xslt
@@ -23,14 +23,22 @@
     <xsl:template match="/icatingest/data/dataset">
 	<dataset>
 	    <xsl:copy-of select="@id"/>
-	    <complete><xsl:copy-of select="/icatingest/_environment/@dataset_complete"/></complete>
+	    <xsl:element name="complete">
+		<xsl:value-of
+		    select="/icatingest/_environment/@dataset_complete"/>
+	    </xsl:element>
 	    <xsl:copy-of select="description"/>
 	    <xsl:copy-of select="endDate"/>
 	    <xsl:copy-of select="name"/>
 	    <xsl:copy-of select="startDate"/>
 	    <investigation ref="_Investigation"/>
 	    <xsl:apply-templates select="sample"/>
-	    <xsl:apply-templates select="type"/>
+	    <xsl:element name="type">
+		<xsl:attribute name="name">
+		    <xsl:value-of
+			select="/icatingest/_environment/@datasettype_name"/>
+		</xsl:attribute>
+	    </xsl:element>
 	    <xsl:copy-of select="datasetInstruments"/>
 	    <xsl:copy-of select="datasetTechniques"/>
 	    <xsl:copy-of select="parameters"/>
@@ -41,12 +49,6 @@
 	<xsl:copy>
 	    <xsl:attribute name="investigation.ref">_Investigation</xsl:attribute>
 	    <xsl:copy-of select="@*"/>
-	</xsl:copy>
-    </xsl:template>
-
-    <xsl:template match="/icatingest/data/dataset/type">
-	<xsl:copy>
-	    <xsl:attribute name="name"><xsl:copy-of select="/icatingest/_environment/@datasettype_name"/></xsl:attribute>
 	</xsl:copy>
     </xsl:template>
 

--- a/src/icat/ingest.py
+++ b/src/icat/ingest.py
@@ -94,6 +94,16 @@ class IngestReader(XMLDumpFileReader):
 
     .. versionadded:: 1.3.0
     """
+    Dataset_complete = "false"
+    """Value to prescribe in the `complete` attribute of datasets.
+
+    .. versionadded:: 1.5.0
+    """
+    DatasetType_name = "raw"
+    """Name of the `DatasetType` to relate datasets to.
+
+    .. versionadded:: 1.5.0
+    """
 
     def __init__(self, client, metadata, investigation):
         self.investigation = investigation
@@ -196,7 +206,12 @@ class IngestReader(XMLDumpFileReader):
 
         .. versionadded:: 1.3.0
         """
-        return dict(icat_version=str(client.apiversion))
+        env = dict(
+            icat_version=str(client.apiversion),
+            dataset_complete=self.Dataset_complete,
+            datasettype_name=self.DatasetType_name,
+        )
+        return env
 
     def add_environment(self, client, ingest_data):
         """Inject environment information into input data.


### PR DESCRIPTION
Add class attributes `Dataset_complete` and `DatasetType_name` to `IngestReader` to make the values of `complete` attributes of datasets and the name of the `type` they are related to respectively configurable. These values are (and should be) prescribed in the process of reading metadata from XML ingest files into ICAT, but they were hard coded in the provided XSLT file. Close #160.