### PR TITLE
Minor updates in the tool chain

### DIFF
--- a/doc/src/conf.py
+++ b/doc/src/conf.py
@@ -6,6 +6,7 @@
 # full list see the documentation:
 # http://www.sphinx-doc.org/en/master/config
 
+import os
 from pathlib import Path
 import sys
 
@@ -134,6 +135,15 @@ html_theme = 'sphinx_rtd_theme'
 # documentation.
 #
 # html_theme_options = {}
+
+# Define the canonical URL if you are using a custom domain on Read the Docs
+html_baseurl = os.environ.get("READTHEDOCS_CANONICAL_URL", "")
+
+# Tell Jinja2 templates the build is running on Read the Docs
+if os.environ.get("READTHEDOCS", "") == "True":
+    if "html_context" not in globals():
+        html_context = {}
+    html_context["READTHEDOCS"] = True
 
 # Add any paths that contain custom static files (such as style sheets) here,
 # relative to this directory. They are copied after the builtin static files,

--- a/setup.py
+++ b/setup.py
@@ -11,6 +11,7 @@ import setuptools
 from setuptools import setup
 import setuptools.command.build_py
 import distutils.command.sdist
+import distutils.dist
 from distutils import log
 from pathlib import Path
 import string
@@ -31,6 +32,15 @@ except (ImportError, LookupError):
         release = version = "UNKNOWN"
 
 docstring = __doc__
+
+
+# Enforcing of PEP 625 has been added in setuptools 69.3.0.  We don't
+# want this, we want to keep control on the name of the sdist
+# ourselves.  Disable it.
+def _fixed_get_fullname(self):
+    return "%s-%s" % (self.get_name(), self.get_version())
+
+distutils.dist.DistributionMetadata.get_fullname = _fixed_get_fullname
 
 
 class meta(setuptools.Command):


### PR DESCRIPTION
Add two minor updates to the tool chain to build the package and the documentation:

- Disable [PEP 625](https://peps.python.org/pep-0625/) enforcing added in [setuptools 69.3.0](https://setuptools.pypa.io/en/stable/history.html#v69-3-0)
- Update documentation build configuration to adapt to a [recent change in Read the Docs build](https://about.readthedocs.com/blog/2024/07/addons-by-default/)