### PR TITLE
More tests and documentation on class attributes in IngestReader to configure prescribed values

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -10,7 +10,7 @@ Changelog
 New features
 ------------
 
-+ `#160`_, `#161`_: Add class attributes to
++ `#160`_, `#161`_, `#163`_: Add class attributes to
   :class:`icat.ingest.IngestReader` to make some prescribed values in
   the transformation to ICAT data file format configurable.
 
@@ -22,6 +22,7 @@ Bug fixes and minor changes
 .. _#160: https://github.com/icatproject/python-icat/issues/160
 .. _#161: https://github.com/icatproject/python-icat/pull/161
 .. _#162: https://github.com/icatproject/python-icat/pull/162
+.. _#163: https://github.com/icatproject/python-icat/pull/163
 
 
 .. _changes-1_4_0:

--- a/src/icat/ingest.py
+++ b/src/icat/ingest.py
@@ -97,6 +97,11 @@ class IngestReader(XMLDumpFileReader):
     Dataset_complete = "false"
     """Value to prescribe in the `complete` attribute of datasets.
 
+    .. note::
+        The value for this class attribute is subject to change in
+        version 2.0.  You might want to override it in order to pin it
+        to a value that is suitable for you.
+
     .. versionadded:: 1.5.0
     """
     DatasetType_name = "raw"
@@ -197,6 +202,20 @@ class IngestReader(XMLDumpFileReader):
 
         Subclasses may override this method to control the attributes
         set in the environment.
+
+        .. note::
+            If you override this method, it is advisable to call the
+            inherited method from the parent class and augment the
+            result.  This avoids inadvertently dropping environment
+            settings added in future versions.  E.g. do something
+            like the following in your subclass:
+
+            .. code-block:: python
+
+                def get_environment(self, client):
+                    env = super().get_environment(client)
+                    env['mykey'] = 'value'
+                    return env
 
         :param client: the client object being used by this
             IngestReader.

--- a/tests/data/ingest-env.xslt
+++ b/tests/data/ingest-env.xslt
@@ -18,7 +18,9 @@
 	    <apiversion>
 		<xsl:copy-of select="string(/icatingest/_environment/@icat_version)"/>
 	    </apiversion>
-	    <generator>ingest-env.xslt</generator>
+	    <generator>
+		<xsl:copy-of select="string(/icatingest/_environment/@generator)"/>
+	    </generator>
 	</head>
     </xsl:template>
 

--- a/tests/test_06_ingest.py
+++ b/tests/test_06_ingest.py
@@ -104,6 +104,10 @@ cases = [
         metadata = gettestdata("metadata-4.4-inl.xml"),
         checks = {
             "testingest_inl_1": [
+                ("SELECT ds.complete FROM Dataset ds WHERE ds.id = %d",
+                 False),
+                ("SELECT ds.type.name FROM Dataset ds WHERE ds.id = %d",
+                 "raw"),
                 ("SELECT ds.description FROM Dataset ds WHERE ds.id = %d",
                  "Dy01Cp02 at 2.7 K"),
                 ("SELECT ds.startDate FROM Dataset ds WHERE ds.id = %d",
@@ -120,6 +124,10 @@ cases = [
                  2.74103),
             ],
             "testingest_inl_2": [
+                ("SELECT ds.complete FROM Dataset ds WHERE ds.id = %d",
+                 False),
+                ("SELECT ds.type.name FROM Dataset ds WHERE ds.id = %d",
+                 "raw"),
                 ("SELECT ds.description FROM Dataset ds WHERE ds.id = %d",
                  "Dy01Cp02 at 5.1 K"),
                 ("SELECT ds.startDate FROM Dataset ds WHERE ds.id = %d",
@@ -143,6 +151,10 @@ cases = [
         metadata = gettestdata("metadata-5.0-inl.xml"),
         checks = {
             "testingest_inl5_1": [
+                ("SELECT ds.complete FROM Dataset ds WHERE ds.id = %d",
+                 False),
+                ("SELECT ds.type.name FROM Dataset ds WHERE ds.id = %d",
+                 "raw"),
                 ("SELECT ds.description FROM Dataset ds WHERE ds.id = %d",
                  "Dy01Cp02 at 2.7 K"),
                 ("SELECT ds.startDate FROM Dataset ds WHERE ds.id = %d",
@@ -167,6 +179,10 @@ cases = [
                  2.74103),
             ],
             "testingest_inl5_2": [
+                ("SELECT ds.complete FROM Dataset ds WHERE ds.id = %d",
+                 False),
+                ("SELECT ds.type.name FROM Dataset ds WHERE ds.id = %d",
+                 "raw"),
                 ("SELECT ds.description FROM Dataset ds WHERE ds.id = %d",
                  "Dy01Cp02 at 5.1 K"),
                 ("SELECT ds.startDate FROM Dataset ds WHERE ds.id = %d",
@@ -201,6 +217,10 @@ cases = [
         metadata = gettestdata("metadata-4.4-sep.xml"),
         checks = {
             "testingest_sep_1": [
+                ("SELECT ds.complete FROM Dataset ds WHERE ds.id = %d",
+                 False),
+                ("SELECT ds.type.name FROM Dataset ds WHERE ds.id = %d",
+                 "raw"),
                 ("SELECT ds.description FROM Dataset ds WHERE ds.id = %d",
                  "Dy01Cp02 at 2.7 K"),
                 ("SELECT ds.startDate FROM Dataset ds WHERE ds.id = %d",
@@ -217,6 +237,10 @@ cases = [
                  2.74103),
             ],
             "testingest_sep_2": [
+                ("SELECT ds.complete FROM Dataset ds WHERE ds.id = %d",
+                 False),
+                ("SELECT ds.type.name FROM Dataset ds WHERE ds.id = %d",
+                 "raw"),
                 ("SELECT ds.description FROM Dataset ds WHERE ds.id = %d",
                  "Dy01Cp02 at 5.1 K"),
                 ("SELECT ds.startDate FROM Dataset ds WHERE ds.id = %d",
@@ -240,6 +264,10 @@ cases = [
         metadata = gettestdata("metadata-5.0-sep.xml"),
         checks = {
             "testingest_sep5_1": [
+                ("SELECT ds.complete FROM Dataset ds WHERE ds.id = %d",
+                 False),
+                ("SELECT ds.type.name FROM Dataset ds WHERE ds.id = %d",
+                 "raw"),
                 ("SELECT ds.description FROM Dataset ds WHERE ds.id = %d",
                  "Dy01Cp02 at 2.7 K"),
                 ("SELECT ds.startDate FROM Dataset ds WHERE ds.id = %d",
@@ -264,6 +292,10 @@ cases = [
                  2.74103),
             ],
             "testingest_sep5_2": [
+                ("SELECT ds.complete FROM Dataset ds WHERE ds.id = %d",
+                 False),
+                ("SELECT ds.type.name FROM Dataset ds WHERE ds.id = %d",
+                 "raw"),
                 ("SELECT ds.description FROM Dataset ds WHERE ds.id = %d",
                  "Dy01Cp02 at 5.1 K"),
                 ("SELECT ds.startDate FROM Dataset ds WHERE ds.id = %d",
@@ -299,6 +331,10 @@ cases = [
         metadata = gettestdata("metadata-sample.xml"),
         checks = {
             "testingest_sample_1": [
+                ("SELECT ds.complete FROM Dataset ds WHERE ds.id = %d",
+                 False),
+                ("SELECT ds.type.name FROM Dataset ds WHERE ds.id = %d",
+                 "raw"),
                 ("SELECT ds.description FROM Dataset ds WHERE ds.id = %d",
                  "ab3465 at 2.7 K"),
                 ("SELECT ds.startDate FROM Dataset ds WHERE ds.id = %d",
@@ -313,6 +349,10 @@ cases = [
                  "ab3465"),
             ],
             "testingest_sample_2": [
+                ("SELECT ds.complete FROM Dataset ds WHERE ds.id = %d",
+                 False),
+                ("SELECT ds.type.name FROM Dataset ds WHERE ds.id = %d",
+                 "raw"),
                 ("SELECT ds.description FROM Dataset ds WHERE ds.id = %d",
                  "ab3465 at 5.1 K"),
                 ("SELECT ds.startDate FROM Dataset ds WHERE ds.id = %d",
@@ -327,6 +367,10 @@ cases = [
                  "ab3465"),
             ],
             "testingest_sample_3": [
+                ("SELECT ds.complete FROM Dataset ds WHERE ds.id = %d",
+                 False),
+                ("SELECT ds.type.name FROM Dataset ds WHERE ds.id = %d",
+                 "raw"),
                 ("SELECT ds.description FROM Dataset ds WHERE ds.id = %d",
                  "ab3466 at 2.7 K"),
                 ("SELECT ds.startDate FROM Dataset ds WHERE ds.id = %d",
@@ -341,6 +385,10 @@ cases = [
                  "ab3466"),
             ],
             "testingest_sample_4": [
+                ("SELECT ds.complete FROM Dataset ds WHERE ds.id = %d",
+                 False),
+                ("SELECT ds.type.name FROM Dataset ds WHERE ds.id = %d",
+                 "raw"),
                 ("SELECT ds.description FROM Dataset ds WHERE ds.id = %d",
                  "reference"),
                 ("SELECT ds.startDate FROM Dataset ds WHERE ds.id = %d",


### PR DESCRIPTION
I merged #161 a little bit prematurely, a few more things should have been included:
- add tests to verify that the values of the new class attributes `Dataset_complete` and `DatasetType_name` are indeed properly set in the ingested data,
- add some more documentation on that new feature, including some caveats,
- while we are at it, extend the existing test for the `_environment` element to also add a custom attribute.