### PR TITLE
Add method Client.restoreData()

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -2,6 +2,20 @@ Changelog
 =========
 
 
+.. _changes-1_6_0:
+
+1.6.0 (not yet released)
+~~~~~~~~~~~~~~~~~~~~~~~~
+
+New features
+------------
+
++ `166`_: Add new custom IDS method
+  :meth:`icat.client.Client.restoreData`.
+
+.. _166: https://github.com/icatproject/python-icat/pull/166
+
+
 .. _changes-1_5_1:
 
 1.5.1 (2024-10-25)

--- a/doc/src/client.rst
+++ b/doc/src/client.rst
@@ -154,4 +154,6 @@ manages the interaction with an ICAT service as a client.
 
     .. automethod:: deleteData
 
+    .. automethod:: restoreData
+
 .. _ICAT SOAP Manual: https://repo.icatproject.org/site/icat/server/4.10.0/soap.html

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -48,8 +48,27 @@ logging.basicConfig(level=logging.INFO)
 logging.getLogger('suds.client').setLevel(logging.CRITICAL)
 logging.getLogger('suds').setLevel(logging.ERROR)
 
+_skip_slow = True
 testdir = Path(__file__).resolve().parent
 testdatadir = testdir / "data"
+
+def pytest_addoption(parser):
+    parser.addoption("--no-skip-slow", action="store_true", default=False,
+                     help="do not skip slow tests.")
+
+def pytest_configure(config):
+    global _skip_slow
+    _skip_slow = not config.getoption("--no-skip-slow")
+    config.addinivalue_line("markers", "slow: mark a test as slow, "
+                            "the test will be skipped unless --no-skip-slow "
+                            "is set on the command line")
+
+def pytest_runtest_setup(item):
+    """Skip slow tests by default.
+    """
+    marker = item.get_closest_marker("slow")
+    if marker is not None and _skip_slow:
+        pytest.skip("skip slow test")
 
 def _skip(reason):
     if Version(pytest.__version__) >= '3.3.0':

--- a/tests/test_06_ids.py
+++ b/tests/test_06_ids.py
@@ -23,7 +23,7 @@ class LoggingIDSClient(IDSClient):
     """
     def getStatus(self, selection):
         status = super().getStatus(selection)
-        logger.debug("getStatus(%s): %s", selection, status)
+        logger.debug("getStatus(%s): %s", selection, status, stacklevel=2)
         return status
 
 @pytest.fixture(scope="module")

--- a/tests/test_06_ids.py
+++ b/tests/test_06_ids.py
@@ -412,6 +412,30 @@ def test_restore(client, case):
     print("Status of dataset %s is now %s" % (case['dsname'], status))
 
 @pytest.mark.parametrize(("case"), markeddatasets)
+def test_restoreData(client, case):
+    """Test the high level call restoreData().
+
+    This is essentially a no-op as the dataset in question will
+    already be ONLINE.  It only tests that the call does not throw an
+    error.
+    """
+    dataset = getDataset(client, case)
+    client.restoreData([dataset])
+    status = client.ids.getStatus(DataSelection([dataset]))
+    assert status == "ONLINE"
+
+@pytest.mark.parametrize(("case"), markeddatasets)
+def test_restoreDataSelection(client, case):
+    """Test the high level call restoreData().
+
+    Same as last test, but now pass a DataSelection as argument.
+    """
+    selection = DataSelection([getDataset(client, case)])
+    client.restoreData(selection)
+    status = client.ids.getStatus(selection)
+    assert status == "ONLINE"
+
+@pytest.mark.parametrize(("case"), markeddatasets)
 def test_reset(client, case):
     """Call reset() on a dataset.
 


### PR DESCRIPTION
Add a IDS custom method `restoreData()` to class `Client`.  This method checks the status of the data in IDS, requests a restore if the data is not already online and waits for the restore to complete.

I found three independent implementations of that in my own code, so apparently this is needed as a helper in the library.

Draft status: should still add a test.